### PR TITLE
Fix icon location on frontpage

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -2,11 +2,6 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-#myCarousel {
-  position: absolute;
-  z-index: 1;
-}
-
 .background-transparent {
   width: 100%;
   padding: 2px;
@@ -38,12 +33,8 @@
 }
 
 .homepage {
-  margin-top: 450px;
+  margin-top: 10px;
   color: #444444;
-}
-
-.index-flash > #flash-message {
-
 }
 
 .copyright {


### PR DESCRIPTION
Fixes #71 
An absolute positioning of the carousel required the icons to have a high `margin-top`, which resulted in the observed errors.