### PR TITLE
Request codeharbor by using codeharbor.openhpi.de subdomain

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,16 +118,16 @@ Rails.application.configure do
   # use relative URL path while compiling, maybe?
   config.assets.initialize_on_precompile = true
 
-  Rails.application.routes.default_url_options[:host] = 'https://tools.openhpi.de'
+  Rails.application.routes.default_url_options[:host] = 'https://codeharbor.openhpi.de'
 
   # Run on subfolder in production environment.
-  config.relative_url_root = '/codeharbor'
+  # config.relative_url_root = ''
 
   # Set up ActionMailer for subfolder
   config.action_mailer.default_url_options = {
-      :host => 'https://tools.openhpi.de',
+      :host => 'https://codeharbor.openhpi.de',
       :only_path => false,
-      :script_name => '/codeharbor'
+      :script_name => '/'
   }
 
 end


### PR DESCRIPTION
Apply changes to request codeharbor by using new subdomain "codeharbor.openhpi.de" instead of using tools.openhpi.de and "/codeharbor" path.