### PR TITLE
Fix css of related exercise in exercise index

### DIFF
--- a/app/assets/javascripts/exercises.coffee
+++ b/app/assets/javascripts/exercises.coffee
@@ -77,10 +77,7 @@ toggleHideShowMore = (element) ->
 
 initCollapsable = (collapsables, max_height) ->
   collapsables.each ->
-    if $(this).prop('scrollHeight') > $(this).prop('clientHeight')
-      # $(this).css 'height', 'unset'
-      # $(this).css 'max-height', max_height
-    else
+    if $(this).prop('scrollHeight') <= $(this).prop('clientHeight')
       $(this).siblings('.more-btn-wrapper').hide()
     addAnimatedSliding()
 

--- a/app/assets/javascripts/exercises.coffee
+++ b/app/assets/javascripts/exercises.coffee
@@ -77,7 +77,10 @@ toggleHideShowMore = (element) ->
 
 initCollapsable = (collapsables, max_height) ->
   collapsables.each ->
-    if $(this).prop('scrollHeight') <= $(this).prop('clientHeight')
+    if $(this).prop('scrollHeight') > $(this).prop('clientHeight')
+      $(this).css 'height', 'unset'
+      $(this).css 'max-height', max_height
+    else
       $(this).siblings('.more-btn-wrapper').hide()
     addAnimatedSliding()
 

--- a/app/assets/javascripts/exercises.coffee
+++ b/app/assets/javascripts/exercises.coffee
@@ -291,7 +291,6 @@ ready =->
             anchor.scrollIntoView(false)
         complete: ->
           $icon.hide()
-          initCollapsable($('.small-description'), '58px')
       })
     else
       $caret.removeClass('fa-caret-up').addClass('fa-caret-down')

--- a/app/assets/javascripts/exercises.coffee
+++ b/app/assets/javascripts/exercises.coffee
@@ -78,8 +78,8 @@ toggleHideShowMore = (element) ->
 initCollapsable = (collapsables, max_height) ->
   collapsables.each ->
     if $(this).prop('scrollHeight') > $(this).prop('clientHeight')
-      $(this).css 'height', 'unset'
-      $(this).css 'max-height', max_height
+      # $(this).css 'height', 'unset'
+      # $(this).css 'max-height', max_height
     else
       $(this).siblings('.more-btn-wrapper').hide()
     addAnimatedSliding()

--- a/app/assets/stylesheets/exercises.scss
+++ b/app/assets/stylesheets/exercises.scss
@@ -27,6 +27,19 @@ $exercise-color: #006600;
   margin-left: 2px;
 }
 
+.small_label {
+  padding: 0.5em 1.5em;
+  font-size: 80%;
+  display: inline;
+  font-weight: bold;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  border-radius: 0.25em;
+  margin-left: 2px;
+}
+
 .exercise_label:first-child {
   margin-left: 0;
 }
@@ -547,9 +560,8 @@ input[type="radio"]:checked+label {
   }
 
   .content {
-    height: 200px;
     margin: 0 40px;
-    display: block;
+    display: flex;
     position: relative;
 
     .panel.displayed {
@@ -558,18 +570,22 @@ input[type="radio"]:checked+label {
       margin: 1%;
 
       .small-exercise-content {
-        display: inline-block;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
         width: 100%;
-        height: 90px;
+        max-height: 219px;
 
         .small-description {
           width: 100%;
-          height: 76px;
           padding-bottom: 5px;
-          border-bottom: 1px lightgrey solid;
-          display: block;
           word-wrap: break-word;
           overflow: hidden;
+          margin-bottom: 3px;
+        }
+
+        .small-exercise-footer {
+          border-top: 1px lightgrey solid;
         }
       }
     }
@@ -669,6 +685,11 @@ input[type="radio"]:checked+label {
 
 .more-btn-wrapper[style*='display: none'] ~ .labels {
   margin-top: 5px;
+}
+
+.labels {
+  line-height: 24px;
+  overflow-wrap: break-word;
 }
 
 .exercise-panel {

--- a/app/views/exercises/_related_exercises.html.slim
+++ b/app/views/exercises/_related_exercises.html.slim
@@ -14,24 +14,26 @@
               = t('exercises.defaults.no_description')
           - else
             = exercise.descriptions.first.text
-        .more-btn-wrapper
-          = link_to t('exercises.all.open_exercise'), exercise, class: 'open-link'
+        .small-exercise-footer
+          .more-btn-wrapper
+            = link_to t('exercises.all.open_exercise'), exercise, class: 'open-link'
 
-        span.star-rating
-          small.number-rating
-            = exercise.avg_rating.round(1)
-          - [*1..5].each do |i|
-            - if exercise.rating_star(exercise.avg_rating.round(1)) >= i
-              span.fa.fa-star data-rating=i
-            - elsif (exercise.rating_star(exercise.avg_rating.round(1)) + 0.5) >= i
-              span.fa.fa-star-half-o data-rating=i
-            - else
-              span.fa.fa-star-o data-rating=i
-          small
-            = ' ('
-            = exercise.ratings.count
-            = 'x)'
+          span.star-rating
+            small.number-rating
+              = exercise.avg_rating.round(1)
+            - [*1..5].each do |i|
+              - if exercise.rating_star(exercise.avg_rating.round(1)) >= i
+                span.fa.fa-star data-rating=i
+              - elsif (exercise.rating_star(exercise.avg_rating.round(1)) + 0.5) >= i
+                span.fa.fa-star-half-o data-rating=i
+              - else
+                span.fa.fa-star-o data-rating=i
+            small
+              = ' ('
+              = exercise.ratings.count
+              = 'x)'
 
-        - exercise.labels.each do |label|
-          .small-label style=("background-color: #{'#' + label.color.to_s}; color: white;")
-            = label.name
+          .labels
+            - exercise.labels.each do |label|
+              .small_label style=("background-color: #{'#' + label.color.to_s}; color: white;")
+                = label.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -552,7 +552,7 @@ en:
       delete: "Delete"
       show_more: "Show more"
       show_less: "Show less"
-      open_exercise: "Open exercise"
+      open_exercise: "Open exercise to show more"
       reset: "Reset"
 
     search:


### PR DESCRIPTION
Fix styling of related exercise in exercise-index. It was especially buggy with many tags (5 is max).

Before:
![Screenshot from 2020-03-28 09-53-35](https://user-images.githubusercontent.com/24592181/77819312-3f92fb00-70da-11ea-9213-7606c4a6cf6e.png)

After:
![Screenshot from 2020-03-28 09-54-06](https://user-images.githubusercontent.com/24592181/77819315-4de11700-70da-11ea-8116-eb6e8660edb7.png)
