### PR TITLE
add presence validation for name in account link

### DIFF
--- a/app/models/account_link.rb
+++ b/app/models/account_link.rb
@@ -4,6 +4,7 @@ class AccountLink < ApplicationRecord
   validates :check_uuid_url, presence: true
   validates :push_url, presence: true
   validates :api_key, presence: true
+  validates :name, presence: true
 
   belongs_to :user
 

--- a/spec/models/account_link_spec.rb
+++ b/spec/models/account_link_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe AccountLink, type: :model do
     it { is_expected.to validate_presence_of(:check_uuid_url) }
     it { is_expected.to validate_presence_of(:push_url) }
     it { is_expected.to validate_presence_of(:api_key) }
+    it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to belong_to(:user) }
   end
 


### PR DESCRIPTION
Please check whether there are invalid `AccountLinks` after deploy and supply them with a name.