### PR TITLE
Fix name collision test

### DIFF
--- a/app/models/exercise_file.rb
+++ b/app/models/exercise_file.rb
@@ -14,8 +14,6 @@ class ExerciseFile < ApplicationRecord
 
   before_save :parse_text_data
 
-  accepts_nested_attributes_for :exercise_test
-
   ROLES = %w[main_file reference_implementation regular_file teacher_defined_test].freeze
   TEST_ROLE = %w[teacher_defined_test].freeze
 

--- a/app/models/exercise_file.rb
+++ b/app/models/exercise_file.rb
@@ -2,7 +2,7 @@
 
 class ExerciseFile < ApplicationRecord
   belongs_to :exercise, optional: true
-  belongs_to :test, optional: true, inverse_of: :exercise_file
+  belongs_to :exercise_test, optional: true, inverse_of: :exercise_file, foreign_key: 'test_id', class_name: 'Test'
   belongs_to :file_type
   has_attached_file :attachment, styles: ->(a) { ['image/jpeg', 'image/png', 'image/giv'].include?(a.content_type) ? {large: '900x'} : {} }
   do_not_validate_attachment_file_type :attachment
@@ -10,11 +10,11 @@ class ExerciseFile < ApplicationRecord
   validates :hidden, inclusion: [true, false]
   validates :read_only, inclusion: [true, false]
   validates :exercise, presence: true, unless: -> { purpose == 'test' }
-  validates :test, presence: true, if: -> { purpose == 'test' }
+  validates :exercise_test, presence: true, if: -> { purpose == 'test' }
 
   before_save :parse_text_data
 
-  accepts_nested_attributes_for :test
+  accepts_nested_attributes_for :exercise_test
 
   ROLES = %w[main_file reference_implementation regular_file teacher_defined_test].freeze
   TEST_ROLE = %w[teacher_defined_test].freeze
@@ -45,7 +45,7 @@ class ExerciseFile < ApplicationRecord
     exercise_file_duplicate = dup
     exercise_file_duplicate.attachment = attachment
     exercise_file_duplicate.exercise = exercise unless exercise.nil?
-    exercise_file_duplicate.test = test unless test.nil?
+    exercise_file_duplicate.exercise_test = test unless test.nil?
     exercise_file_duplicate
   end
 

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -3,7 +3,7 @@
 class Test < ApplicationRecord
   belongs_to :testing_framework, optional: true
   belongs_to :exercise
-  has_one :exercise_file, inverse_of: :test, dependent: :destroy
+  has_one :exercise_file, inverse_of: :exercise_test, dependent: :destroy, foreign_key: 'test_id'
   accepts_nested_attributes_for :exercise_file, allow_destroy: true
 
   validates :exercise_file, presence: true


### PR DESCRIPTION
As a result of #284 an `exercise_file` now has a `.test` method (instead of `.tests` before).
This causes weird issues with RailsAdmin (You can't view `exercise_files`) because `test` is a reserved word and gets called wrongly there. 
This renames the relation to `exercise_test` to fix that issue