### PR TITLE
Handle html descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'config'
 gem 'faraday'
 gem 'font-awesome-rails', '>= 4.7.0.5'
 gem 'jquery-ui-rails', '>= 6.0.1'
+gem 'kramdown', '~> 2.3'
 gem 'less-rails', '>= 3.0.0' # Sprockets (what Rails 3.1 uses for its asset pipeline) supports LESS
 gem 'nested_form_fields', '>= 0.8.2'
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    kramdown (2.3.0)
+      rexml
     less (2.6.0)
       commonjs (~> 0.2.7)
     less-rails (4.0.0)
@@ -488,6 +490,7 @@ DEPENDENCIES
   jbuilder (~> 2.10)
   jquery-rails (>= 4.3.5)
   jquery-ui-rails (>= 6.0.1)
+  kramdown (~> 2.3)
   less-rails (>= 3.0.0)
   mnemosyne-ruby
   nested_form_fields (>= 0.8.2)

--- a/app/services/proforma_service/convert_exercise_to_task.rb
+++ b/app/services/proforma_service/convert_exercise_to_task.rb
@@ -16,7 +16,7 @@ module ProformaService
       Proforma::Task.new(
         {
           title: @exercise.title,
-          description: primary_description.text,
+          description: Kramdown::Document.new(primary_description.text).to_html,
           internal_description: @exercise.instruction,
           proglang: proglang,
           files: task_files,

--- a/app/services/proforma_service/convert_exercise_to_task.rb
+++ b/app/services/proforma_service/convert_exercise_to_task.rb
@@ -2,8 +2,9 @@
 
 module ProformaService
   class ConvertExerciseToTask < ServiceBase
-    def initialize(exercise: nil)
+    def initialize(exercise: nil, options: {})
       @exercise = exercise
+      @options = options
     end
 
     def execute
@@ -16,7 +17,7 @@ module ProformaService
       Proforma::Task.new(
         {
           title: @exercise.title,
-          description: Kramdown::Document.new(primary_description.text).to_html.strip,
+          description: description,
           internal_description: @exercise.instruction,
           proglang: proglang,
           files: task_files,
@@ -27,6 +28,12 @@ module ProformaService
           model_solutions: model_solutions
         }.compact
       )
+    end
+
+    def description
+      return primary_description.text if @options[:description_format] == 'md'
+
+      Kramdown::Document.new(primary_description.text).to_html.strip
     end
 
     def parent_uuid

--- a/app/services/proforma_service/convert_exercise_to_task.rb
+++ b/app/services/proforma_service/convert_exercise_to_task.rb
@@ -16,7 +16,7 @@ module ProformaService
       Proforma::Task.new(
         {
           title: @exercise.title,
-          description: Kramdown::Document.new(primary_description.text).to_html,
+          description: Kramdown::Document.new(primary_description.text).to_html.strip,
           internal_description: @exercise.instruction,
           proglang: proglang,
           files: task_files,

--- a/app/services/proforma_service/convert_task_to_exercise.rb
+++ b/app/services/proforma_service/convert_task_to_exercise.rb
@@ -33,8 +33,12 @@ module ProformaService
     def new_descriptions
       descriptions = @exercise.descriptions.presence || [Description.new(primary: true)]
       primary = descriptions.select(&:primary?).first
-      primary.assign_attributes(text: @task.description, language: @task.language)
+      primary.assign_attributes(text: transform_description(@task.description), language: @task.language)
       descriptions
+    end
+
+    def transform_description(description)
+      Kramdown::Document.new(description, html_to_native: true).to_kramdown
     end
 
     def task_files

--- a/app/services/proforma_service/convert_task_to_exercise.rb
+++ b/app/services/proforma_service/convert_task_to_exercise.rb
@@ -38,7 +38,7 @@ module ProformaService
     end
 
     def transform_description(description)
-      Kramdown::Document.new(description || '', html_to_native: true).to_kramdown
+      Kramdown::Document.new(description || '', html_to_native: true).to_kramdown.strip
     end
 
     def task_files

--- a/app/services/proforma_service/convert_task_to_exercise.rb
+++ b/app/services/proforma_service/convert_task_to_exercise.rb
@@ -38,7 +38,7 @@ module ProformaService
     end
 
     def transform_description(description)
-      Kramdown::Document.new(description, html_to_native: true).to_kramdown
+      Kramdown::Document.new(description || '', html_to_native: true).to_kramdown
     end
 
     def task_files

--- a/app/services/proforma_service/export_task.rb
+++ b/app/services/proforma_service/export_task.rb
@@ -2,12 +2,13 @@
 
 module ProformaService
   class ExportTask < ServiceBase
-    def initialize(exercise: nil)
+    def initialize(exercise: nil, options: {})
       @exercise = exercise
+      @options = options
     end
 
     def execute
-      @task = ConvertExerciseToTask.call(exercise: @exercise)
+      @task = ConvertExerciseToTask.call(exercise: @exercise, options: @options)
       exporter = Proforma::Exporter.new(@task)
       exporter.perform
     end

--- a/app/services/proforma_service/handle_export_confirm.rb
+++ b/app/services/proforma_service/handle_export_confirm.rb
@@ -17,7 +17,7 @@ module ProformaService
       end
 
       account_link = AccountLink.find(@account_link_id)
-      zip_stream = ProformaService::ExportTask.call(exercise: @exercise)
+      zip_stream = ProformaService::ExportTask.call(exercise: @exercise, options: {description_format: 'md'})
       error = ExerciseService::PushExternal.call(zip: zip_stream, account_link: account_link)
 
       [@exercise, error]

--- a/spec/services/proforma_service/convert_exercise_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_exercise_to_task_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
       let(:description) { '# H1 header' }
 
       it 'creates a task with description and language from primary description' do
-        expect(task).to have_attributes(description: "<h1 id=\"h1-header\">H1 header</h1>")
+        expect(task).to have_attributes(description: '<h1 id="h1-header">H1 header</h1>')
       end
     end
 
@@ -233,7 +233,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
 
       it 'creates a task with description and language from primary description' do
         expect(task).to have_attributes(
-          description: "<p>primary desc</p>",
+          description: '<p>primary desc</p>',
           language: 'en'
         )
       end

--- a/spec/services/proforma_service/convert_exercise_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_exercise_to_task_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
     it 'creates a task with all basic attributes' do
       expect(task).to have_attributes(
         title: exercise.title,
-        description: Kramdown::Document.new(exercise.descriptions.select(&:primary?).first.text).to_html,
+        description: Kramdown::Document.new(exercise.descriptions.select(&:primary?).first.text).to_html.strip,
         internal_description: exercise.instruction,
         proglang: {
           name: exercise.execution_environment.language,
@@ -217,7 +217,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
       let(:description) { '# H1 header' }
 
       it 'creates a task with description and language from primary description' do
-        expect(task).to have_attributes(description: "<h1 id=\"h1-header\">H1 header</h1>\n")
+        expect(task).to have_attributes(description: "<h1 id=\"h1-header\">H1 header</h1>")
       end
     end
 
@@ -233,7 +233,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
 
       it 'creates a task with description and language from primary description' do
         expect(task).to have_attributes(
-          description: "<p>primary desc</p>\n",
+          description: "<p>primary desc</p>",
           language: 'en'
         )
       end

--- a/spec/services/proforma_service/convert_exercise_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_exercise_to_task_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
     it 'creates a task with all basic attributes' do
       expect(task).to have_attributes(
         title: exercise.title,
-        description: exercise.descriptions.select(&:primary?).first.text,
+        description: Kramdown::Document.new(exercise.descriptions.select(&:primary?).first.text).to_html,
         internal_description: exercise.instruction,
         proglang: {
           name: exercise.execution_environment.language,
@@ -212,6 +212,15 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
       end
     end
 
+    context 'when exercise has description formatted in markdown' do
+      let(:exercise) { create(:exercise, descriptions: [build(:description, :primary, text: description, language: 'de')]) }
+      let(:description) { '# H1 header' }
+
+      it 'creates a task with description and language from primary description' do
+        expect(task).to have_attributes(description: "<h1 id=\"h1-header\">H1 header</h1>\n")
+      end
+    end
+
     context 'when exercise has multiple descriptions' do
       let(:exercise) do
         create(:exercise,
@@ -224,7 +233,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
 
       it 'creates a task with description and language from primary description' do
         expect(task).to have_attributes(
-          description: 'primary desc',
+          description: "<p>primary desc</p>\n",
           language: 'en'
         )
       end

--- a/spec/services/proforma_service/convert_exercise_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_exercise_to_task_spec.rb
@@ -41,8 +41,15 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
 
     context 'with options' do
       let(:convert_to_task) { described_class.new(exercise: exercise, options: options) }
-      let(:options) {{}} # TODO descriptions
+      let(:options) { {} } # TODO: descriptions
 
+      context 'when options contain description_format md' do
+        let(:options) { {description_format: 'md'} }
+
+        it 'creates a task with all basic attributes' do
+          expect(task).to have_attributes(description: exercise.descriptions.select(&:primary?).first.text)
+        end
+      end
     end
 
     context 'when exercise has a mainfile' do

--- a/spec/services/proforma_service/convert_exercise_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_exercise_to_task_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
       )
     end
 
+    context 'with options' do
+      let(:convert_to_task) { described_class.new(exercise: exercise, options: options) }
+      let(:options) {{}} # TODO descriptions
+
+    end
+
     context 'when exercise has a mainfile' do
       let(:files) { [file] }
       let(:file) { build(:codeharbor_main_file) }

--- a/spec/services/proforma_service/convert_task_to_exercise_spec.rb
+++ b/spec/services/proforma_service/convert_task_to_exercise_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ProformaService::ConvertTaskToExercise do
     it 'creates an exercise with the correct attributes' do
       expect(convert_to_exercise_service).to have_attributes(
         title: 'title',
-        descriptions: have(1).item.and(include(have_attributes(text: "description",
+        descriptions: have(1).item.and(include(have_attributes(text: 'description',
                                                                primary: true,
                                                                language: 'language'))),
         instruction: 'internal_description',
@@ -452,7 +452,9 @@ RSpec.describe ProformaService::ConvertTaskToExercise do
         expect(exercise.reload).to have_attributes(
           id: exercise.id,
           title: task.title,
-          descriptions: include(have_attributes(primary: true, text: Kramdown::Document.new(task.description, html_to_native: true).to_kramdown.strip)),
+          descriptions: include(
+            have_attributes(primary: true, text: Kramdown::Document.new(task.description, html_to_native: true).to_kramdown.strip)
+          ),
           instruction: task.internal_description,
           execution_environment: have_attributes(language: task.proglang[:name], version: task.proglang[:version]),
           uuid: exercise.uuid,

--- a/spec/services/proforma_service/convert_task_to_exercise_spec.rb
+++ b/spec/services/proforma_service/convert_task_to_exercise_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ProformaService::ConvertTaskToExercise do
     it 'creates an exercise with the correct attributes' do
       expect(convert_to_exercise_service).to have_attributes(
         title: 'title',
-        descriptions: have(1).item.and(include(have_attributes(text: "description\n\n",
+        descriptions: have(1).item.and(include(have_attributes(text: "description",
                                                                primary: true,
                                                                language: 'language'))),
         instruction: 'internal_description',
@@ -72,7 +72,7 @@ RSpec.describe ProformaService::ConvertTaskToExercise do
 
       it 'creates an exercise with a correct description' do
         expect(convert_to_exercise_service).to have_attributes(
-          descriptions: include(have_attributes(text: "description\n\n"))
+          descriptions: include(have_attributes(text: 'description'))
         )
       end
 
@@ -81,7 +81,7 @@ RSpec.describe ProformaService::ConvertTaskToExercise do
 
         it 'creates an exercise with a correct description' do
           expect(convert_to_exercise_service).to have_attributes(
-            descriptions: include(have_attributes(text: "descrüption\n\n"))
+            descriptions: include(have_attributes(text: 'descrüption'))
           )
         end
       end
@@ -452,7 +452,7 @@ RSpec.describe ProformaService::ConvertTaskToExercise do
         expect(exercise.reload).to have_attributes(
           id: exercise.id,
           title: task.title,
-          descriptions: include(have_attributes(primary: true, text: Kramdown::Document.new(task.description, html_to_native: true).to_kramdown)),
+          descriptions: include(have_attributes(primary: true, text: Kramdown::Document.new(task.description, html_to_native: true).to_kramdown.strip)),
           instruction: task.internal_description,
           execution_environment: have_attributes(language: task.proglang[:name], version: task.proglang[:version]),
           uuid: exercise.uuid,

--- a/spec/services/proforma_service/export_task_spec.rb
+++ b/spec/services/proforma_service/export_task_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ProformaService::ExportTask do
       expect(xml.xpath('/task/title').text).to eql exercise.title
     end
 
-    it 'adds description node with correct content to task node' do
+    it 'adds description node with correct content (html) to task node' do
       expect(xml.xpath('/task/description').text).to eql Kramdown::Document.new(
         exercise.descriptions.select(&:primary).first.text
       ).to_html.strip
@@ -65,6 +65,19 @@ RSpec.describe ProformaService::ExportTask do
 
     it 'adds uuid attribute to task node' do
       expect(xml.xpath('/task').attribute('uuid').value).to eql exercise.uuid
+    end
+
+    context 'with options' do
+      let(:export_service) { described_class.new(exercise: exercise, options: options) }
+      let(:options) { {} }
+
+      context 'when options contain description_format md' do
+        let(:options) { {description_format: 'md'} }
+
+        it 'adds description node with correct content to task node' do
+          expect(xml.xpath('/task/description').text).to eql exercise.descriptions.select(&:primary).first.text
+        end
+      end
     end
 
     context 'when exercise is minimal' do

--- a/spec/services/proforma_service/export_task_spec.rb
+++ b/spec/services/proforma_service/export_task_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe ProformaService::ExportTask do
     end
 
     it 'adds description node with correct content to task node' do
-      expect(xml.xpath('/task/description').text).to eql Kramdown::Document.new(exercise.descriptions.select(&:primary).first.text).to_html.strip
+      expect(xml.xpath('/task/description').text).to eql Kramdown::Document.new(
+        exercise.descriptions.select(&:primary).first.text
+      ).to_html.strip
     end
 
     it 'adds proglang node with correct content to task node' do

--- a/spec/services/proforma_service/export_task_spec.rb
+++ b/spec/services/proforma_service/export_task_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ProformaService::ExportTask do
     end
 
     it 'adds description node with correct content to task node' do
-      expect(xml.xpath('/task/description').text).to eql exercise.descriptions.select(&:primary).first.text
+      expect(xml.xpath('/task/description').text).to eql Kramdown::Document.new(exercise.descriptions.select(&:primary).first.text).to_html
     end
 
     it 'adds proglang node with correct content to task node' do
@@ -217,7 +217,7 @@ RSpec.describe ProformaService::ExportTask do
       end
 
       it 'adds description node with correct content to task node' do
-        expect(xml.xpath('/task/description').text).to eql exercise.descriptions.select(&:primary).first.text
+        expect(xml.xpath('/task/description').text).to include exercise.descriptions.select(&:primary).first.text
       end
     end
   end

--- a/spec/services/proforma_service/export_task_spec.rb
+++ b/spec/services/proforma_service/export_task_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ProformaService::ExportTask do
     end
 
     it 'adds description node with correct content to task node' do
-      expect(xml.xpath('/task/description').text).to eql Kramdown::Document.new(exercise.descriptions.select(&:primary).first.text).to_html
+      expect(xml.xpath('/task/description').text).to eql Kramdown::Document.new(exercise.descriptions.select(&:primary).first.text).to_html.strip
     end
 
     it 'adds proglang node with correct content to task node' do

--- a/spec/services/proforma_service/handle_export_confirm_spec.rb
+++ b/spec/services/proforma_service/handle_export_confirm_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ProformaService::HandleExportConfirm do
 
     it 'calls ExportTask-service with correct arguments' do
       handle_export_confirm
-      expect(ProformaService::ExportTask).to have_received(:call).with(exercise: exercise)
+      expect(ProformaService::ExportTask).to have_received(:call).with(exercise: exercise, options: {description_format: 'md'})
     end
 
     it 'calls PushExternal-service with correct arguments' do
@@ -80,12 +80,12 @@ RSpec.describe ProformaService::HandleExportConfirm do
 
       it 'does not call ExportTask-service with old exercise' do
         handle_export_confirm
-        expect(ProformaService::ExportTask).to have_received(:call).with(exercise: not_have_attributes(uuid: exercise.uuid))
+        expect(ProformaService::ExportTask).to have_received(:call).with(exercise: not_have_attributes(uuid: exercise.uuid), options: {description_format: 'md'})
       end
 
       it 'only calls ExportTask-service after uuid has been set' do
         handle_export_confirm
-        expect(ProformaService::ExportTask).to have_received(:call).with(exercise: not_have_attributes(uuid: nil))
+        expect(ProformaService::ExportTask).to have_received(:call).with(exercise: not_have_attributes(uuid: nil), options: {description_format: 'md'})
       end
 
       # it 'calls PushExternal-service with correct arguments' do

--- a/spec/services/proforma_service/handle_export_confirm_spec.rb
+++ b/spec/services/proforma_service/handle_export_confirm_spec.rb
@@ -80,12 +80,16 @@ RSpec.describe ProformaService::HandleExportConfirm do
 
       it 'does not call ExportTask-service with old exercise' do
         handle_export_confirm
-        expect(ProformaService::ExportTask).to have_received(:call).with(exercise: not_have_attributes(uuid: exercise.uuid), options: {description_format: 'md'})
+        expect(ProformaService::ExportTask).to have_received(:call).with(
+          exercise: not_have_attributes(uuid: exercise.uuid), options: {description_format: 'md'}
+        )
       end
 
       it 'only calls ExportTask-service after uuid has been set' do
         handle_export_confirm
-        expect(ProformaService::ExportTask).to have_received(:call).with(exercise: not_have_attributes(uuid: nil), options: {description_format: 'md'})
+        expect(ProformaService::ExportTask).to have_received(:call).with(
+          exercise: not_have_attributes(uuid: nil), options: {description_format: 'md'}
+        )
       end
 
       # it 'calls PushExternal-service with correct arguments' do

--- a/spec/support/expectations/equal_exercise.rb
+++ b/spec/support/expectations/equal_exercise.rb
@@ -14,7 +14,6 @@ RSpec::Matchers.define :be_an_equal_exercise_as do |exercise|
     return false unless object.class == other.class
     return attributes_equal?(object, other) if object.is_a?(ApplicationRecord)
     return array_equal?(object, other) if object.is_a?(Array) || object.is_a?(ActiveRecord::Associations::CollectionProxy)
-    # return object.strip == other.strip if object.is_a?(String)
 
     object == other
   end

--- a/spec/support/expectations/equal_exercise.rb
+++ b/spec/support/expectations/equal_exercise.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define :be_an_equal_exercise_as do |exercise|
     return false unless object.class == other.class
     return attributes_equal?(object, other) if object.is_a?(ApplicationRecord)
     return array_equal?(object, other) if object.is_a?(Array) || object.is_a?(ActiveRecord::Associations::CollectionProxy)
-    return object.strip == other.strip if object.is_a?(String)
+    # return object.strip == other.strip if object.is_a?(String)
 
     object == other
   end

--- a/spec/support/expectations/equal_exercise.rb
+++ b/spec/support/expectations/equal_exercise.rb
@@ -14,6 +14,7 @@ RSpec::Matchers.define :be_an_equal_exercise_as do |exercise|
     return false unless object.class == other.class
     return attributes_equal?(object, other) if object.is_a?(ApplicationRecord)
     return array_equal?(object, other) if object.is_a?(Array) || object.is_a?(ActiveRecord::Associations::CollectionProxy)
+    return object.strip == other.strip if object.is_a?(String)
 
     object == other
   end


### PR DESCRIPTION
Convert HTML descriptions in imported tasks to MD, also handles converting of HTML-Entities.
Convert descriptions to HTML on export.