### PR TITLE
LOM Sample Endpoint

### DIFF
--- a/app/controllers/bridges/lom/tasks_controller.rb
+++ b/app/controllers/bridges/lom/tasks_controller.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+module Bridges
+  module Lom
+    # rubocop:disable Metrics/ClassLength
+    class TasksController < ActionController::API
+      OML_SCHEMA_PATH = Rails.root.join('vendor/assets/schemas/lom_1484.12.3-2020/lom.xsd')
+
+      def show
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| sample_oml(xml) }
+
+        if params[:validate].present?
+          schema = Nokogiri::XML::Schema(File.read(OML_SCHEMA_PATH))
+          errors = schema.validate(builder.doc)
+
+          return render plain: errors.map(&:message).join("\n") if errors.any?
+        end
+
+        render xml: builder
+      end
+
+      private
+
+      def sample_oml(xml)
+        xml.lom(xmlns: 'http://ltsc.ieee.org/xsd/LOM') do
+          oml_general(xml)
+          oml_lifecycle(xml)
+          oml_meta_metadata(xml)
+          oml_technical(xml)
+          oml_educational(xml)
+          oml_rights(xml)
+          # Other top-level elements: relation, annotation, and classification.
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/BlockLength
+      # rubocop:disable Metrics/MethodLength
+      def oml_general(xml)
+        xml.general do
+          xml.identifier do
+            xml.catalog 'UUID'
+            xml.entry task.uuid
+          end
+          xml.title do
+            xml.string task.title, language: task_lang
+          end
+          xml.language task_lang
+          xml.description do
+            xml.string task.description, language: task_lang
+          end
+          if task.programming_language&.language.present?
+            xml.keyword do
+              xml.string "programming language: #{task.programming_language.language}", language: 'en'
+            end
+            if task.programming_language&.version.present?
+              xml.keyword do
+                xml.string "programming language version: #{task.programming_language.version}", language: 'en'
+              end
+            end
+          end
+          xml.structure do
+            xml.value 'atomic'
+          end
+          xml.aggregationLevel do
+            xml.value 1
+          end
+        end
+      end
+      # rubocop:enable all
+
+      def oml_lifecycle(xml)
+        xml.lifeCycle do
+          xml.version do
+            xml.string task_version, language: 'en'
+          end
+          xml.status do
+            xml.value 'final'
+          end
+          xml.contribute do
+            xml.role do
+              xml.value 'author'
+            end
+            xml.entity task_author_vcard
+            xml.date do
+              # TODO: We omit the time part, since the regex provided by the xsd schema seems to be broken regarding
+              # the time zone part. Try a validated request, e.g., with '1997-07-16T19:20:30+01:00'. It fails, but
+              # it is an example from the IEEE Standard document.
+              xml.dateTime task.updated_at.to_date.iso8601
+            end
+          end
+        end
+      end
+
+      def oml_meta_metadata(xml)
+        xml.metaMetadata do
+          xml.metadataSchema 'ProFormA MD 1.0'
+        end
+      end
+
+      def oml_technical(xml)
+        xml.technical do
+          xml.format 'text/xml'
+          xml.location task_url(id: 'sample')
+          xml.location download_task_url(id: 'sample')
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/BlockLength
+      # rubocop:disable Metrics/MethodLength
+      def oml_educational(xml)
+        xml.educational do
+          xml.interactivityType do
+            xml.value 'active'
+          end
+          xml.learningResourceType do
+            xml.value 'exercise'
+          end
+          xml.interactivityLevel do
+            xml.value 'high'
+          end
+          xml.semanticDensity do
+            xml.value 'high'
+          end
+          xml.intendedEndUserRole do
+            xml.value 'learner'
+          end
+          xml.context_ do
+            xml.value 'school'
+          end
+          xml.context_ do
+            xml.value 'higher education'
+          end
+          xml.context_ do
+            xml.value 'training'
+          end
+          xml.typicalAgeRange do
+            xml.string '13-'
+          end
+          xml.description do
+            xml.string task.internal_description, language: task_lang
+          end
+          xml.language task_lang
+        end
+      end
+      # rubocop:enable all
+
+      def oml_rights(xml)
+        xml.rights do
+          xml.cost do
+            xml.value 'no'
+          end
+          xml.copyrightAndOtherRestrictions do
+            xml.value 'yes'
+          end
+          xml.description do
+            xml.string 'GNU General Public License (GPLv3): https://www.gnu.org/licenses/gpl-3.0.en.html', language: 'en'
+          end
+        end
+      end
+
+      def task
+        @task ||= Task.new(
+          title: 'Hello World',
+          description: 'Write a simple program that prints "Hello World".',
+          internal_description: 'This is a simple exercise for your students to begin with Java.',
+          uuid: 'f15cb7a3-87eb-4c4c-a998-c33e25d44cdc',
+          language: 'English',
+          programming_language: pl,
+          user: user,
+          updated_at: Time.zone.now
+        )
+      end
+
+      def task_lang
+        # TODO: Ensure `task.language` returns 2 letter code from ISO 639:1988.
+        'en'
+      end
+
+      def task_version
+        # TODO: Traverse all parent tasks to obtain correct version. This only checks the first parent.
+        task.parent_uuid.present? ? 2 : 1
+      end
+
+      def task_author_vcard
+        <<~VCARD
+          BEGIN:VCARD
+          FN:#{task.user.first_name} #{task.user.last_name}
+          END:VCARD
+        VCARD
+      end
+
+      def pl
+        @pl ||= ProgrammingLanguage.new(language: 'Java', version: '17')
+      end
+
+      def user
+        @user ||= User.new(
+          first_name: 'John',
+          last_name: 'Doe',
+          email: 'john.doe@openhpi.de'
+        )
+      end
+    end
+    # rubocop:enasle all
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,12 @@ Rails.application.routes.draw do
     end
   end
 
+  scope 'bridges', module: :bridges, as: 'bridges' do
+    scope 'lom', module: :lom, as: 'lom' do
+      resources :tasks, only: %i[show]
+    end
+  end
+
   resources :ping, only: :index, defaults: {format: :json}
 
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'

--- a/vendor/assets/schemas/lom_1484.12.3-2020/common/anyElement.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/common/anyElement.xsd
@@ -1,0 +1,27 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides an element group declaration used for
+         custom metadata elements.
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:group name="customElements">
+      <xs:choice>
+         <xs:any namespace="##other" processContents="lax"/>
+      </xs:choice>
+   </xs:group>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/common/dataTypes.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/common/dataTypes.xsd
@@ -1,0 +1,138 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:ag="http://ltsc.ieee.org/xsd/LOM/unique"
+           xmlns:ex="http://ltsc.ieee.org/xsd/LOM/extend"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides global type declarations for LOM datatypes.
+      </xs:documentation>
+      <xs:documentation>
+        ****************************************************************************
+        **                           CHANGE HISTORY                               **
+        ****************************************************************************
+        ** 11/14/2003:  1)Updated xs:pattern for the DurationString.  The pattern **
+        **                did not permit zero values for each of the date and     **
+        **                time components.                                        **
+        **                                                                        **
+        ** 03/15/2004:  1)Changed the restriction type for LanguageIdNone from    **
+        **                xs:string to xs:token                                   **
+        ****************************************************************************
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique" />
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend" />
+
+   <!-- Data type declarations -->
+
+   <!-- CharacterString -->
+   <xs:simpleType name="CharacterString">
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+
+   <!-- LanguageId -->
+   <xs:simpleType name="LanguageIdOrNone">
+      <xs:union memberTypes="LanguageId LanguageIdNone"/>
+   </xs:simpleType>
+
+   <xs:simpleType name="LanguageId">
+      <xs:restriction base="xs:language"/>
+   </xs:simpleType>
+
+   <xs:simpleType name="LanguageIdNone">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="none"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- VCard -->
+   <xs:simpleType name="VCard">
+      <xs:restriction base="CharacterString"/>
+   </xs:simpleType>
+
+   <!-- MimeType -->
+   <xs:simpleType name="MimeType">
+      <xs:restriction base="CharacterString"/>
+   </xs:simpleType>
+
+   <!-- Size -->
+   <xs:simpleType name="Size">
+      <xs:restriction base="xs:nonNegativeInteger"/>
+   </xs:simpleType>
+
+   <!-- LangString -->
+   <xs:complexType name="LangString">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="string" type="langString"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="langString">
+      <xs:simpleContent>
+         <xs:extension base="CharacterString">
+            <xs:attribute name="language" type="LanguageId"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- DateTime -->
+   <xs:complexType name="DateTime">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="dateTime" type="DateTimeValue"/>
+         <xs:element name="description" type="description"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="DateTimeValue">
+      <xs:simpleContent>
+         <xs:extension base="DateTimeString">
+           <xs:attributeGroup ref="ag:DateTimeValue"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- Regular expresion from Christian Klaue -->
+   <xs:simpleType name="DateTimeString">
+      <xs:restriction base="CharacterString">
+         <xs:pattern value="([0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3})(\-(0[1-9]|1[0-2])(\-(0[1-9]|[1-2][0-9]|3[0-1])(T([0-1][0-9]|2[0-3])(:[0-5][0-9](:[0-5][0-9](\.[0-9]{1,}(Z|((\+|\-)([0-1][0-9]|2[0-3]):[0-5][0-9]))?)?)?)?)?)?)?"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- Duration -->
+   <xs:complexType name="Duration">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="duration" type="DurationValue"/>
+         <xs:element name="description" type="description"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="DurationValue">
+      <xs:simpleContent>
+         <xs:extension base="DurationString">
+            <xs:attributeGroup ref="ag:DurationValue"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- Regular expresion from Christian Klaue -->
+   <xs:simpleType name="DurationString">
+      <xs:restriction base="CharacterString">
+         <xs:pattern value="P([0-9]{1,}Y){0,1}([0-9]{1,}M){0,1}([0-9]{1,}D){0,1}(T([0-9]{1,}H){0,1}([0-9]{1,}M){0,1}([0-9]{1,}(\.[0-9]{1,}){0,1}S){0,1}){0,1}"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/common/elementNames.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/common/elementNames.xsd
@@ -1,0 +1,767 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides element name declarations for metadata elements.
+
+         This component schema checks for the uniqueness of elements declared to be unique
+         within their parent by the presence of the uniqueElementName attribute,
+         and is common to all uniqueness profiles.
+      </xs:documentation>
+   </xs:annotation>
+
+   <!-- Element declarations -->
+
+   <!-- Duplicate declarations are included as comments. -->
+
+   <!-- 1 General -->
+   <xs:group name="general">
+      <xs:sequence>
+         <xs:element name="general" type="general">
+            <xs:unique name="generalUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.1 Identifier -->
+   <xs:group name="identifier">
+      <xs:sequence>
+         <xs:element name="identifier" type="identifier">
+            <xs:unique name="identifierUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.1.1 Catalog -->
+   <xs:group name="catalog">
+      <xs:sequence>
+         <xs:element name="catalog" type="catalog"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.1.2 Entry -->
+   <xs:group name="entry">
+      <xs:sequence>
+         <xs:element name="entry" type="entry"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.2 Title -->
+   <xs:group name="title">
+      <xs:sequence>
+         <xs:element name="title" type="title"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.3 Language -->
+   <xs:group name="languageIdOrNone">
+      <xs:sequence>
+         <xs:element name="language" type="LanguageIdOrNone"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.4 Description -->
+   <xs:group name="descriptionUnbounded">
+      <xs:sequence>
+         <xs:element name="description" type="LangString"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.5 Keyword -->
+   <xs:group name="keyword">
+      <xs:sequence>
+         <xs:element name="keyword" type="keyword"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.6 Coverage -->
+   <xs:group name="coverage">
+      <xs:sequence>
+         <xs:element name="coverage" type="coverage"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.7 Structure -->
+   <xs:group name="structure">
+      <xs:sequence>
+         <xs:element name="structure" type="structure">
+            <xs:unique name="structureUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 1.8 Aggregation Level -->
+   <xs:group name="aggregationLevel">
+      <xs:sequence>
+         <xs:element name="aggregationLevel" type="aggregationLevel">
+            <xs:unique name="aggregationLevelUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 2 Life Cycle -->
+   <xs:group name="lifeCycle">
+      <xs:sequence>
+         <xs:element name="lifeCycle" type="lifeCycle">
+            <xs:unique name="lifeCycleUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 2.1 Version -->
+   <xs:group name="version">
+      <xs:sequence>
+         <xs:element name="version" type="version"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 2.2 Status -->
+   <xs:group name="status">
+      <xs:sequence>
+         <xs:element name="status" type="status">
+            <xs:unique name="statusUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 2.3 Contribute -->
+   <xs:group name="contribute">
+      <xs:sequence>
+         <xs:element name="contribute" type="contribute">
+            <xs:unique name="contributeUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 2.3.1 Role -->
+   <xs:group name="role">
+      <xs:sequence>
+         <xs:element name="role" type="role">
+            <xs:unique name="roleUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 2.3.2 Entity -->
+   <xs:group name="entityUnbounded">
+      <xs:sequence>
+         <xs:element name="entity" type="VCard"/>
+      </xs:sequence>
+   </xs:group>
+
+  <!-- 2.3.3 Date -->
+  <xs:group name="date">
+     <xs:sequence>
+        <xs:element name="date" type="date">
+           <xs:unique name="dateUnique">
+              <xs:selector xpath="*"/>
+              <xs:field xpath="@uniqueElementName"/>
+           </xs:unique>
+        </xs:element>
+     </xs:sequence>
+   </xs:group>
+
+   <!-- 3 Meta-Metadata -->
+   <xs:group name="metaMetadata">
+      <xs:sequence>
+         <xs:element name="metaMetadata" type="metaMetadata">
+            <xs:unique name="metaMetadataUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 3.1 Identifier
+   <xs:group name="identifier">
+      <xs:sequence>
+         <xs:element name="identifier" type="identifier">
+            <xs:unique name="identifierUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 3.1.1 Catalog
+   <xs:group name="catalog">
+      <xs:sequence>
+         <xs:element name="catalog" type="catalog"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 3.1.2 Entry
+   <xs:group name="entry">
+      <xs:sequence>
+         <xs:element name="entry" type="entry"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 3.2 Contribute -->
+   <xs:group name="contributeMeta">
+      <xs:sequence>
+         <xs:element name="contribute" type="contributeMeta">
+            <xs:unique name="contributeMetaUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 3.2.1 Role -->
+   <xs:group name="roleMeta">
+      <xs:sequence>
+         <xs:element name="role" type="roleMeta">
+            <xs:unique name="roleMetaUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 3.2.2 Entity
+   <xs:group name="entityUnbounded">
+      <xs:sequence>
+         <xs:element name="entity" type="VCard"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 3.2.3 Date
+   <xs:group name="date">
+      <xs:sequence>
+         <xs:element name="date" type="date">
+            <xs:unique name="dateUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 3.3 Metadata Schema -->
+   <xs:group name="metadataSchema">
+      <xs:sequence>
+         <xs:element name="metadataSchema" type="metadataSchema"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 3.4 Language -->
+   <xs:group name="language">
+      <xs:sequence>
+         <xs:element name="language" type="language"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4 Technical -->
+   <xs:group name="technical">
+      <xs:sequence>
+         <xs:element name="technical" type="technical">
+            <xs:unique name="technicalUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.1 Format -->
+  <xs:group name="format">
+      <xs:sequence>
+         <xs:element name="format" type="format"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.2 Size -->
+   <xs:group name="size">
+      <xs:sequence>
+         <xs:element name="size" type="size"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.3 Location -->
+   <xs:group name="location">
+      <xs:sequence>
+         <xs:element name="location" type="location"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.4 Requirement -->
+   <xs:group name="requirement">
+      <xs:sequence>
+         <xs:element name="requirement" type="requirement"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.4.1 OrComposite -->
+   <xs:group name="orComposite">
+      <xs:sequence>
+         <xs:element name="orComposite" type="orComposite">
+            <xs:unique name="orCompositeUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.4.1.1 Type -->
+   <xs:group name="type">
+      <xs:sequence>
+         <xs:element name="type" type="type">
+            <xs:unique name="typeUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.4.1.2 Name -->
+   <xs:group name="name">
+      <xs:sequence>
+         <xs:element name="name" type="name">
+            <xs:unique name="nameUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.4.1.3 Minimum Version -->
+   <xs:group name="minimumVersion">
+      <xs:sequence>
+         <xs:element name="minimumVersion" type="minimumVersion"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.4.1.4 Maximum Version -->
+   <xs:group name="maximumVersion">
+      <xs:sequence>
+         <xs:element name="maximumVersion" type="maximumVersion"/>
+      </xs:sequence>
+    </xs:group>
+
+   <!-- 4.5 Installation Remarks -->
+   <xs:group name="installationRemarks">
+      <xs:sequence>
+         <xs:element name="installationRemarks" type="installationRemarks"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.6 Other Platform Requirements -->
+   <xs:group name="otherPlatformRequirements">
+      <xs:sequence>
+         <xs:element name="otherPlatformRequirements" type="otherPlatformRequirements"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 4.7 Duration -->
+   <xs:group name="duration">
+      <xs:sequence>
+         <xs:element name="duration" type="duration">
+            <xs:unique name="durationUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5 Educational -->
+   <xs:group name="educational">
+      <xs:sequence>
+         <xs:element name="educational" type="educational">
+            <xs:unique name="educationalUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.1 Interactivity Type -->
+   <xs:group name="interactivityType">
+      <xs:sequence>
+         <xs:element name="interactivityType" type="interactivityType">
+            <xs:unique name="interactivityTypeUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.2 Learning Resource Type -->
+   <xs:group name="learningResourceType">
+      <xs:sequence>
+         <xs:element name="learningResourceType" type="learningResourceType">
+            <xs:unique name="learningResourceTypeUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.3 Interactivity Level -->
+   <xs:group name="interactivityLevel">
+      <xs:sequence>
+         <xs:element name="interactivityLevel" type="interactivityLevel">
+            <xs:unique name="interactivityLevelUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.4 Semantic Density -->
+   <xs:group name="semanticDensity">
+      <xs:sequence>
+         <xs:element name="semanticDensity" type="semanticDensity">
+            <xs:unique name="semanticDensityUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.5 Intended End User Role -->
+   <xs:group name="intendedEndUserRole">
+      <xs:sequence>
+         <xs:element name="intendedEndUserRole" type="intendedEndUserRole">
+            <xs:unique name="intendedEndUserRoleUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.6 Context -->
+   <xs:group name="context">
+      <xs:sequence>
+         <xs:element name="context" type="context">
+            <xs:unique name="contextUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.7 Typical Age Range -->
+   <xs:group name="typicalAgeRange">
+      <xs:sequence>
+         <xs:element name="typicalAgeRange" type="typicalAgeRange"/>
+      </xs:sequence>
+   </xs:group>
+  
+   <!-- 5.8 Difficulty -->
+   <xs:group name="difficulty">
+      <xs:sequence>
+         <xs:element name="difficulty" type="difficulty">
+            <xs:unique name="difficultyUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.9 Typical Learning Time -->
+   <xs:group name="typicalLearningTime">
+      <xs:sequence>
+         <xs:element name="typicalLearningTime" type="typicalLearningTime">
+            <xs:unique name="typicalLearningTimeUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 5.10 Description
+   <xs:group name="descriptionUnbounded">
+      <xs:sequence>
+         <xs:element name="description" type="LangString"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 5.11 Language -->
+   <xs:group name="languageId">
+      <xs:sequence>
+         <xs:element name="language" type="LanguageId"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 6 Rights -->
+   <xs:group name="rights">
+      <xs:sequence>
+         <xs:element name="rights" type="rights">
+            <xs:unique name="rightsUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 6.1 Cost -->
+   <xs:group name="cost">
+      <xs:sequence>
+         <xs:element name="cost" type="cost">
+            <xs:unique name="costUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 6.2 Copyright and Other Restrictions -->
+   <xs:group name="copyrightAndOtherRestrictions">
+      <xs:sequence>
+         <xs:element name="copyrightAndOtherRestrictions" type="copyrightAndOtherRestrictions">
+            <xs:unique name="copyrightAndOtherRestrictionsUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 6.3 Description -->
+   <xs:group name="description">
+      <xs:sequence>
+         <xs:element name="description" type="description"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 7 Relation -->
+   <xs:group name="relation">
+      <xs:sequence>
+         <xs:element name="relation" type="relation">
+            <xs:unique name="relationUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 7.1 Kind -->
+   <xs:group name="kind">
+      <xs:sequence>
+         <xs:element name="kind" type="kind">
+            <xs:unique name="kindUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 7.2 Resource -->
+   <xs:group name="resource">
+      <xs:sequence>
+         <xs:element name="resource" type="resource"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 7.2.1 Identifier
+   <xs:group name="identifier">
+      <xs:sequence>
+         <xs:element name="identifier" type="identifier">
+            <xs:unique name="identifierUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 7.2.1.1 Catalog
+   <xs:group name="catalog">
+      <xs:sequence>
+         <xs:element name="catalog" type="catalog"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 7.2.1.2 Entry
+   <xs:group name="entry">
+      <xs:sequence>
+         <xs:element name="entry" type="entry"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 7.2.2 Description
+   <xs:group name="description">
+      <xs:sequence>
+         <xs:element name="description" type="description"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 8 Annotation -->
+   <xs:group name="annotation">
+      <xs:sequence>
+         <xs:element name="annotation" type="annotation">
+            <xs:unique name="annotationUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 8.1 Entity -->
+   <xs:group name="entity">
+      <xs:sequence>
+         <xs:element name="entity" type="entity"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 8.2 Date
+   <xs:group name="date">
+      <xs:sequence>
+         <xs:element name="date" type="date">
+            <xs:unique name="dateUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 8.3 Description
+   <xs:group name="description">
+      <xs:sequence>
+         <xs:element name="description" type="description"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 9 Classification -->
+   <xs:group name="classification">
+      <xs:sequence>
+         <xs:element name="classification" type="classification">
+            <xs:unique name="classificationUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 9.1 Purpose -->
+   <xs:group name="purpose">
+      <xs:sequence>
+         <xs:element name="purpose" type="purpose">
+            <xs:unique name="purposeUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 9.2 Taxon Path -->
+   <xs:group name="taxonPath">
+      <xs:sequence>
+         <xs:element name="taxonPath" type="taxonPath">
+            <xs:unique name="taxonPathUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 9.2.1 Source -->
+   <xs:group name="source">
+      <xs:sequence>
+         <xs:element name="source" type="source"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 9.2.2 Taxon -->
+   <xs:group name="taxon">
+      <xs:sequence>
+         <xs:element name="taxon" type="taxon">
+            <xs:unique name="taxonUnique">
+               <xs:selector xpath="*"/>
+               <xs:field xpath="@uniqueElementName"/>
+            </xs:unique>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 9.2.2.1 Id -->
+   <xs:group name="id">
+      <xs:sequence>
+         <xs:element name="id" type="id"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 9.2.2.2 Entry -->
+   <xs:group name="entryTaxon">
+      <xs:sequence>
+         <xs:element name="entry" type="entryTaxon"/>
+      </xs:sequence>
+   </xs:group>
+
+   <!-- 9.3 Description
+   <xs:group name="description">
+      <xs:sequence>
+         <xs:element name="description" type="description"/>
+      </xs:sequence>
+   </xs:group> -->
+
+   <!-- 9.4 Keyword
+   <xs:group name="keyword">
+      <xs:sequence>
+         <xs:element name="keyword" type="keyword"/>
+      </xs:sequence>
+   </xs:group> -->
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/common/elementTypes.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/common/elementTypes.xsd
@@ -1,0 +1,786 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:ag="http://ltsc.ieee.org/xsd/LOM/unique"
+           xmlns:ex="http://ltsc.ieee.org/xsd/LOM/extend"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+  <xs:annotation>
+    <xs:documentation>
+       This work is licensed under the Creative Commons Attribution-ShareAlike
+       License.  To view a copy of this license, see the file license.txt,
+       visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+       Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+    </xs:documentation>
+
+    <xs:documentation>
+       This component schema provides global type declarations for metadata elements.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique"/>
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend"/>
+
+  <!-- Element type declarations -->
+
+  <!-- Learning Object Metadata -->
+  <xs:complexType name="lom">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="general"/>
+      <xs:group ref="lifeCycle"/>
+      <xs:group ref="metaMetadata"/>
+      <xs:group ref="technical"/>
+      <xs:group ref="educational"/>
+      <xs:group ref="rights"/>
+      <xs:group ref="relation"/>
+      <xs:group ref="annotation"/>
+      <xs:group ref="classification"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:lom"/>
+  </xs:complexType>
+
+  <!-- 1 General -->
+  <xs:complexType name="general">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="identifier"/>
+      <xs:group ref="title"/>
+      <xs:group ref="languageIdOrNone"/>
+      <xs:group ref="descriptionUnbounded"/>
+      <xs:group ref="keyword"/>
+      <xs:group ref="coverage"/>
+      <xs:group ref="structure"/>
+      <xs:group ref="aggregationLevel"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:general"/>
+  </xs:complexType>
+
+  <!-- 1.1 Identifier -->
+  <xs:complexType name="identifier">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="catalog"/>
+      <xs:group ref="entry"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:identifier"/>
+  </xs:complexType>
+
+  <!-- 1.1.1 Catalog -->
+  <xs:complexType name="catalog">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:catalog"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 1.1.2 Entry -->
+  <xs:complexType name="entry">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:entry"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 1.2 Title -->
+  <xs:complexType name="title">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:title"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 1.3 Language
+  <xs:complexType name="language">
+    <xs:simpleContent>
+      <xs:extension base="LanguageIdOrNone">
+        <xs:attributeGroup ref="ag:language"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 1.4 Description
+  <xs:complexType name="description">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:description"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+  <!-- 1.5 Keyword -->
+  <xs:complexType name="keyword">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:keyword"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 1.6 Coverage -->
+  <xs:complexType name="coverage">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:coverage"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 1.7 Structure -->
+  <xs:complexType name="structure">
+    <xs:complexContent>
+      <xs:extension base="structureVocab">
+        <xs:attributeGroup ref="ag:structure"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 1.8 Aggregation Level -->
+  <xs:complexType name="aggregationLevel">
+    <xs:complexContent>
+      <xs:extension base="aggregationLevelVocab">
+        <xs:attributeGroup ref="ag:aggregationLevel"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 2 Life Cycle -->
+  <xs:complexType name="lifeCycle">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="version"/>
+      <xs:group ref="status"/>
+      <xs:group ref="contribute"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:lifeCycle"/>
+  </xs:complexType>
+
+  <!-- 2.1 Version -->
+  <xs:complexType name="version">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:version"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 2.2 Status -->
+  <xs:complexType name="status">
+    <xs:complexContent>
+      <xs:extension base="statusVocab">
+        <xs:attributeGroup ref="ag:status"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 2.3 Contribute -->
+  <xs:complexType name="contribute">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="role"/>
+      <xs:group ref="entityUnbounded"/>
+      <xs:group ref="date"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:contribute"/>
+  </xs:complexType>
+
+  <!-- 2.3.1 Role -->
+  <xs:complexType name="role">
+    <xs:complexContent>
+      <xs:extension base="roleVocab">
+        <xs:attributeGroup ref="ag:role"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 2.3.2 Entity
+  <xs:complexType name="entity">
+    <xs:simpleContent>
+      <xs:extension base="VCard">
+        <xs:attributeGroup ref="ag:entity"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 2.3.3 Date -->
+  <xs:complexType name="date">
+    <xs:complexContent>
+      <xs:extension base="DateTime">
+        <xs:attributeGroup ref="ag:date"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 3 Meta-Metadata -->
+  <xs:complexType name="metaMetadata">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="identifier"/>
+      <xs:group ref="contributeMeta"/>
+      <xs:group ref="metadataSchema"/>
+      <xs:group ref="language"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:metaMetadata"/>
+  </xs:complexType>
+
+  <!-- 3.1 Identifier
+  <xs:complexType name="identifier">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="catalog"/>
+      <xs:group ref="entry"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:identifier"/>
+  </xs:complexType> -->
+
+  <!-- 3.1.1 Catalog
+  <xs:complexType name="catalog">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:catalog"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 3.1.2 Entry
+  <xs:complexType name="entry">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:entry"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 3.2 Contribute -->
+  <xs:complexType name="contributeMeta">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="roleMeta"/>
+      <xs:group ref="entityUnbounded"/>
+      <xs:group ref="date"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:contribute"/>
+  </xs:complexType>
+
+  <!-- 3.2.1 Role -->
+  <xs:complexType name="roleMeta">
+    <xs:complexContent>
+      <xs:extension base="roleMetaVocab">
+        <xs:attributeGroup ref="ag:role"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 3.2.2 Entity
+  <xs:complexType name="entity">
+    <xs:simpleContent>
+      <xs:extension base="VCard">
+        <xs:attributeGroup ref="ag:entity"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 3.2.3 Date
+  <xs:complexType name="date">
+    <xs:complexContent>
+      <xs:extension base="DateTime">
+        <xs:attributeGroup ref="ag:date"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+  <!-- 3.3 Metadata Schema -->
+  <xs:complexType name="metadataSchema">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:metadataSchema"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 3.4 Language -->
+  <xs:complexType name="language">
+    <xs:simpleContent>
+      <xs:extension base="LanguageId">
+        <xs:attributeGroup ref="ag:language"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 4 Technical -->
+  <xs:complexType name="technical">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="format"/>
+      <xs:group ref="size"/>
+      <xs:group ref="location"/>
+      <xs:group ref="requirement"/>
+      <xs:group ref="installationRemarks"/>
+      <xs:group ref="otherPlatformRequirements"/>
+      <xs:group ref="duration"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:technical"/>
+  </xs:complexType>
+
+  <!-- 4.1 Format -->
+  <xs:complexType name="format">
+    <xs:simpleContent>
+      <xs:extension base="MimeType">
+        <xs:attributeGroup ref="ag:format"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 4.2 Size -->
+  <xs:complexType name="size">
+    <xs:simpleContent>
+      <xs:extension base="Size">
+        <xs:attributeGroup ref="ag:size"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 4.3 Location -->
+  <xs:complexType name="location">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:location"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 4.4 Requirement -->
+  <xs:complexType name="requirement">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="orComposite"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:requirement"/>
+  </xs:complexType>
+
+  <!-- 4.4.1 OrComposite -->
+  <xs:complexType name="orComposite">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="type"/>
+      <xs:group ref="name"/>
+      <xs:group ref="minimumVersion"/>
+      <xs:group ref="maximumVersion"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:orComposite"/>
+  </xs:complexType>
+
+  <!-- 4.4.1.1 Type -->
+  <xs:complexType name="type">
+    <xs:complexContent>
+      <xs:extension base="typeVocab">
+        <xs:attributeGroup ref="ag:type"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 4.4.1.2 Name -->
+  <xs:complexType name="name">
+    <xs:complexContent>
+      <xs:extension base="nameVocab">
+        <xs:attributeGroup ref="ag:name"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 4.4.1.3 Minimum Version -->
+  <xs:complexType name="minimumVersion">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:minimumVersion"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 4.4.1.4 Maximum Version -->
+  <xs:complexType name="maximumVersion">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:maximumVersion"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 4.5 Installation Remarks -->
+  <xs:complexType name="installationRemarks">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:installationRemarks"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 4.6 Other Platform Requirements -->
+  <xs:complexType name="otherPlatformRequirements">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:otherPlatformRequirements"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 4.7 Duration -->
+  <xs:complexType name="duration">
+    <xs:complexContent>
+      <xs:extension base="Duration">
+        <xs:attributeGroup ref="ag:duration"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5 Educational -->
+  <xs:complexType name="educational">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="interactivityType"/>
+      <xs:group ref="learningResourceType"/>
+      <xs:group ref="interactivityLevel"/>
+      <xs:group ref="semanticDensity"/>
+      <xs:group ref="intendedEndUserRole"/>
+      <xs:group ref="context"/>
+      <xs:group ref="typicalAgeRange"/>
+      <xs:group ref="difficulty"/>
+      <xs:group ref="typicalLearningTime"/>
+      <xs:group ref="descriptionUnbounded"/>
+      <xs:group ref="languageId"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:educational"/>
+  </xs:complexType>
+
+  <!-- 5.1 Interactivity Type -->
+  <xs:complexType name="interactivityType">
+    <xs:complexContent>
+      <xs:extension base="interactivityTypeVocab">
+        <xs:attributeGroup ref="ag:interactivityType"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.2 Learning Resource Type -->
+  <xs:complexType name="learningResourceType">
+    <xs:complexContent>
+      <xs:extension base="learningResourceTypeVocab">
+        <xs:attributeGroup ref="ag:learningResourceType"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.3 Interactivity Level -->
+  <xs:complexType name="interactivityLevel">
+    <xs:complexContent>
+      <xs:extension base="interactivityLevelVocab">
+        <xs:attributeGroup ref="ag:interactivityLevel"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.4 Semantic Density -->
+  <xs:complexType name="semanticDensity">
+    <xs:complexContent>
+      <xs:extension base="semanticDensityVocab">
+        <xs:attributeGroup ref="ag:semanticDensity"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.5 Intended End User Role -->
+  <xs:complexType name="intendedEndUserRole">
+    <xs:complexContent>
+      <xs:extension base="intendedEndUserRoleVocab">
+        <xs:attributeGroup ref="ag:intendedEndUserRole"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.6 Context -->
+  <xs:complexType name="context">
+    <xs:complexContent>
+      <xs:extension base="contextVocab">
+        <xs:attributeGroup ref="ag:context"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.7 Typical Age Range -->
+  <xs:complexType name="typicalAgeRange">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:typicalAgeRange"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.8 Difficulty -->
+  <xs:complexType name="difficulty">
+    <xs:complexContent>
+      <xs:extension base="difficultyVocab">
+        <xs:attributeGroup ref="ag:difficulty"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.9 Typical Learning Time -->
+  <xs:complexType name="typicalLearningTime">
+    <xs:complexContent>
+      <xs:extension base="Duration">
+        <xs:attributeGroup ref="ag:typicalLearningTime"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 5.10 Description
+  <xs:complexType name="description">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:description"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+  <!-- 5.11 Language
+  <xs:complexType name="language">
+    <xs:simpleContent>
+      <xs:extension base="LanguageId">
+        <xs:attributeGroup ref="ag:language"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 6 Rights -->
+  <xs:complexType name="rights">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="cost"/>
+      <xs:group ref="copyrightAndOtherRestrictions"/>
+      <xs:group ref="description"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:rights"/>
+  </xs:complexType>
+
+  <!-- 6.1 Cost -->
+  <xs:complexType name="cost">
+    <xs:complexContent>
+      <xs:extension base="costVocab">
+        <xs:attributeGroup ref="ag:cost"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 6.2 Copyright and Other Restrictions -->
+  <xs:complexType name="copyrightAndOtherRestrictions">
+    <xs:complexContent>
+      <xs:extension base="copyrightAndOtherRestrictionsVocab">
+        <xs:attributeGroup ref="ag:copyrightAndOtherRestrictions"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 6.3 Description -->
+  <xs:complexType name="description">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:description"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 7 Relation -->
+  <xs:complexType name="relation">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="kind"/>
+      <xs:group ref="resource"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:relation"/>
+  </xs:complexType>
+
+  <!-- 7.1 Kind -->
+  <xs:complexType name="kind">
+    <xs:complexContent>
+      <xs:extension base="kindVocab">
+        <xs:attributeGroup ref="ag:kind"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 7.2 Resource -->
+  <xs:complexType name="resource">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="identifier"/>
+      <xs:group ref="description"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:resource"/>
+  </xs:complexType>
+
+  <!-- 7.2.1 Identifier
+  <xs:complexType name="identifier">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="catalog"/>
+      <xs:group ref="entry"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:identifier"/>
+  </xs:complexType> -->
+
+  <!-- 7.2.1.1 Catalog
+  <xs:complexType name="catalog">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:catalog"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 7.2.1.2 Entry
+  <xs:complexType name="entry">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:entry"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType> -->
+
+  <!-- 7.2.2 Description
+  <xs:complexType name="description">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:description"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+  <!-- 8 Annotation -->
+  <xs:complexType name="annotation">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="entity"/>
+      <xs:group ref="date"/>
+      <xs:group ref="description"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:annotation"/>
+  </xs:complexType>
+
+  <!-- 8.1 Entity -->
+  <xs:complexType name="entity">
+    <xs:simpleContent>
+      <xs:extension base="VCard">
+        <xs:attributeGroup ref="ag:entity"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 8.2 Date
+  <xs:complexType name="date">
+    <xs:complexContent>
+      <xs:extension base="DateTime">
+        <xs:attributeGroup ref="ag:date"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+  <!-- 8.3 Description
+  <xs:complexType name="description">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:description"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+  <!-- 9 Classification -->
+  <xs:complexType name="classification">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="purpose"/>
+      <xs:group ref="taxonPath"/>
+      <xs:group ref="description"/>
+      <xs:group ref="keyword"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:classification"/>
+  </xs:complexType>
+
+  <!-- 9.1 Purpose -->
+  <xs:complexType name="purpose">
+    <xs:complexContent>
+      <xs:extension base="purposeVocab">
+        <xs:attributeGroup ref="ag:purpose"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 9.2 Taxon Path -->
+  <xs:complexType name="taxonPath">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="source"/>
+      <xs:group ref="taxon"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:taxonPath"/>
+  </xs:complexType>
+
+  <!-- 9.2.1 Source -->
+  <xs:complexType name="source">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:source"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 9.2.2 Taxon -->
+  <xs:complexType name="taxon">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="id"/>
+      <xs:group ref="entryTaxon"/>
+      <xs:group ref="ex:customElements"/>
+    </xs:choice>
+    <xs:attributeGroup ref="ag:taxon"/>
+  </xs:complexType>
+
+  <!-- 9.2.2.1 Id -->
+  <xs:complexType name="id">
+    <xs:simpleContent>
+      <xs:extension base="CharacterString">
+        <xs:attributeGroup ref="ag:id"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- 9.2.2.2 Entry -->
+  <xs:complexType name="entryTaxon">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:entry"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- 9.3 Description
+  <xs:complexType name="description">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:description"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+  <!-- 9.4 Keyword
+  <xs:complexType name="keyword">
+    <xs:complexContent>
+      <xs:extension base="LangString">
+        <xs:attributeGroup ref="ag:keyword"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType> -->
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/common/rootElement.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/common/rootElement.xsd
@@ -1,0 +1,31 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides the element name declaration for the
+         root element for all LOM instances.
+      </xs:documentation>
+   </xs:annotation>
+
+   <!-- Element declarations -->
+
+   <!-- Learning Object Metadata -->
+   <xs:element name="lom" type="lom">
+      <xs:unique name="lomUnique">
+         <xs:selector xpath="*"/>
+         <xs:field xpath="@uniqueElementName"/>
+      </xs:unique>
+   </xs:element>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/common/vocabTypes.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/common/vocabTypes.xsd
@@ -1,0 +1,345 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:ag="http://ltsc.ieee.org/xsd/LOM/unique"
+           xmlns:ex="http://ltsc.ieee.org/xsd/LOM/extend"
+           xmlns:voc="http://ltsc.ieee.org/xsd/LOM/vocab"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides global type declarations for those metadata
+         elements whose values are taken from a vocabulary datatype.
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique"/>
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend"/>
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"/>
+
+   <!-- Vocabulary type declarations -->
+
+   <!-- Source -->
+   <xs:complexType name="sourceValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:source">
+            <xs:attributeGroup ref="ag:source"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 1.7 Structure -->
+   <xs:complexType name="structureVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="structureValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+  
+   <xs:complexType name="structureValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:structure">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 1.8 Aggregation Level -->
+   <xs:complexType name="aggregationLevelVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="aggregationLevelValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+  
+   <xs:complexType name="aggregationLevelValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:aggregationLevel">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 2.2 Status -->
+   <xs:complexType name="statusVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="statusValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="statusValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:status">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 2.3.1 Role -->
+   <xs:complexType name="roleVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="roleValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="roleValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:role">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 3.2.1 Role -->
+   <xs:complexType name="roleMetaVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="roleMetaValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+ 
+   <xs:complexType name="roleMetaValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:roleMeta">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 4.4.1.1 Type -->
+   <xs:complexType name="typeVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="typeValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="typeValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:type">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 4.4.1.2 Name -->
+   <xs:complexType name="nameVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="nameValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="nameValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:name">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 5.1 Interactivity Type -->
+   <xs:complexType name="interactivityTypeVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="interactivityTypeValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="interactivityTypeValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:interactivityType">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 5.2 Learning Resource Type -->
+   <xs:complexType name="learningResourceTypeVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="learningResourceTypeValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="learningResourceTypeValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:learningResourceType">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 5.3 Interactivity Level -->
+   <xs:complexType name="interactivityLevelVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="interactivityLevelValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="interactivityLevelValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:interactivityLevel">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 5.4 Semantic Density -->
+   <xs:complexType name="semanticDensityVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="semanticDensityValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="semanticDensityValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:semanticDensity">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 5.5 Intended End User Role -->
+   <xs:complexType name="intendedEndUserRoleVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="intendedEndUserRoleValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="intendedEndUserRoleValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:intendedEndUserRole">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 5.6 Context -->
+   <xs:complexType name="contextVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="contextValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="contextValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:context">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 5.8 Difficulty -->
+   <xs:complexType name="difficultyVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="difficultyValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="difficultyValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:difficulty">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 6.1 Cost -->
+   <xs:complexType name="costVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="costValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="costValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:cost">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 6.2 Copyright and Other Restrictions -->
+   <xs:complexType name="copyrightAndOtherRestrictionsVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="copyrightAndOtherRestrictionsValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="copyrightAndOtherRestrictionsValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:copyrightAndOtherRestrictions">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 7.1 Kind -->
+   <xs:complexType name="kindVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="kindValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="kindValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:kind">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <!-- 9.1 Purpose -->
+   <xs:complexType name="purposeVocab">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element name="source" type="sourceValue"/>
+         <xs:element name="value" type="purposeValue"/>
+         <xs:group ref="ex:customElements"/>
+      </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="purposeValue">
+      <xs:simpleContent>
+         <xs:extension base="voc:purpose">
+            <xs:attributeGroup ref="ag:value"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/common/vocabValues.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/common/vocabValues.xsd
@@ -1,0 +1,257 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides global type declarations for the standard
+         enumerated types for those metadata elements whose values are taken from
+         a vocabulary datatype.
+      </xs:documentation>
+      <xs:documentation>
+        ****************************************************************************
+        **                           CHANGE HISTORY                               **
+        ****************************************************************************
+        ** 09/22/2003:  - Updated comment describing this file to state that this **
+        **                file is the LOM V1.0 Base Schema vocabulary source and  **
+        **                value declarations.                                     ** 
+        ****************************************************************************
+      </xs:documentation>
+   </xs:annotation>
+
+   <!-- LOM V1.0 Base Schema vocabulary source and value declarations -->
+
+   <!-- Source -->
+   <xs:simpleType name="sourceValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="LOMv1.0"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 1.7 Structure -->
+   <xs:simpleType name="structureValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="atomic"/>
+         <xs:enumeration value="collection"/>
+         <xs:enumeration value="networked"/>
+         <xs:enumeration value="hierarchical"/>
+         <xs:enumeration value="linear"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 1.8 Aggregation Level -->
+   <xs:simpleType name="aggregationLevelValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="1"/>
+         <xs:enumeration value="2"/>
+         <xs:enumeration value="3"/>
+         <xs:enumeration value="4"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 2.2 Status -->
+   <xs:simpleType name="statusValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="draft"/>
+         <xs:enumeration value="final"/>
+         <xs:enumeration value="revised"/>
+         <xs:enumeration value="unavailable"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 2.3.1 Role -->
+   <xs:simpleType name="roleValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="author"/>
+         <xs:enumeration value="publisher"/>
+         <xs:enumeration value="unknown"/>
+         <xs:enumeration value="initiator"/>
+         <xs:enumeration value="terminator"/>
+         <xs:enumeration value="validator"/>
+         <xs:enumeration value="editor"/>
+         <xs:enumeration value="graphical designer"/>
+         <xs:enumeration value="technical implementer"/>
+         <xs:enumeration value="content provider"/>
+         <xs:enumeration value="technical validator"/>
+         <xs:enumeration value="educational validator"/>
+         <xs:enumeration value="script writer"/>
+         <xs:enumeration value="instructional designer"/>
+         <xs:enumeration value="subject matter expert"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 3.2.1 Role -->
+   <xs:simpleType name="roleMetaValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="creator"/>
+         <xs:enumeration value="validator"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 4.4.1.1 Type -->
+   <xs:simpleType name="typeValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="operating system"/>
+         <xs:enumeration value="browser"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 4.4.1.2 Name -->
+   <xs:simpleType name="nameValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="pc-dos"/>
+         <xs:enumeration value="ms-windows"/>
+         <xs:enumeration value="macos"/>
+         <xs:enumeration value="unix"/>
+         <xs:enumeration value="multi-os"/>
+         <xs:enumeration value="none"/>
+         <xs:enumeration value="any"/>
+         <xs:enumeration value="netscape communicator"/>
+         <xs:enumeration value="ms-internet explorer"/>
+         <xs:enumeration value="opera"/>
+         <xs:enumeration value="amaya"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 5.1 Interactivity Type -->
+   <xs:simpleType name="interactivityTypeValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="active"/>
+         <xs:enumeration value="expositive"/>
+         <xs:enumeration value="mixed"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 5.2 Learning Resource Type -->
+   <xs:simpleType name="learningResourceTypeValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="exercise"/>
+         <xs:enumeration value="simulation"/>
+         <xs:enumeration value="questionnaire"/>
+         <xs:enumeration value="diagram"/>
+         <xs:enumeration value="figure"/>
+         <xs:enumeration value="graph"/>
+         <xs:enumeration value="index"/>
+         <xs:enumeration value="slide"/>
+         <xs:enumeration value="table"/>
+         <xs:enumeration value="narrative text"/>
+         <xs:enumeration value="exam"/>
+         <xs:enumeration value="experiment"/>
+         <xs:enumeration value="problem statement"/>
+         <xs:enumeration value="self assessment"/>
+         <xs:enumeration value="lecture"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 5.3 Interactivity Level -->
+   <xs:simpleType name="interactivityLevelValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="very low"/>
+         <xs:enumeration value="low"/>
+         <xs:enumeration value="medium"/>
+         <xs:enumeration value="high"/>
+         <xs:enumeration value="very high"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 5.4 Semantic Density -->
+   <xs:simpleType name="semanticDensityValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="very low"/>
+         <xs:enumeration value="low"/>
+         <xs:enumeration value="medium"/>
+         <xs:enumeration value="high"/>
+         <xs:enumeration value="very high"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 5.5 Intended End User Role -->
+   <xs:simpleType name="intendedEndUserRoleValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="teacher"/>
+         <xs:enumeration value="author"/>
+         <xs:enumeration value="learner"/>
+         <xs:enumeration value="manager"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 5.6 Context -->
+   <xs:simpleType name="contextValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="school"/>
+         <xs:enumeration value="higher education"/>
+         <xs:enumeration value="training"/>
+         <xs:enumeration value="other"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 5.8 Difficulty -->
+   <xs:simpleType name="difficultyValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="very easy"/>
+         <xs:enumeration value="easy"/>
+         <xs:enumeration value="medium"/>
+         <xs:enumeration value="difficult"/>
+         <xs:enumeration value="very difficult"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 6.1 Cost -->
+   <xs:simpleType name="costValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="yes"/>
+         <xs:enumeration value="no"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 6.2 Copyright and Other Restrictions -->
+   <xs:simpleType name="copyrightAndOtherRestrictionsValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="yes"/>
+         <xs:enumeration value="no"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 7.1 Kind -->
+   <xs:simpleType name="kindValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="ispartof"/>
+         <xs:enumeration value="haspart"/>
+         <xs:enumeration value="isversionof"/>
+         <xs:enumeration value="hasversion"/>
+         <xs:enumeration value="isformatof"/>
+         <xs:enumeration value="hasformat"/>
+         <xs:enumeration value="references"/>
+         <xs:enumeration value="isreferencedby"/>
+         <xs:enumeration value="isbasedon"/>
+         <xs:enumeration value="isbasisfor"/>
+         <xs:enumeration value="requires"/>
+         <xs:enumeration value="isrequiredby"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <!-- 9.1 Purpose -->
+   <xs:simpleType name="purposeValues">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="discipline"/>
+         <xs:enumeration value="idea"/>
+         <xs:enumeration value="prerequisite"/>
+         <xs:enumeration value="educational objective"/>
+         <xs:enumeration value="accessibility restrictions"/>
+         <xs:enumeration value="educational level"/>
+         <xs:enumeration value="skill level"/>
+         <xs:enumeration value="security level"/>
+         <xs:enumeration value="competency"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/extend/custom.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/extend/custom.xsd
@@ -1,0 +1,41 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM/extend"
+           xmlns="http://ltsc.ieee.org/xsd/LOM/extend"
+           xmlns:lom="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+  <xs:annotation>
+    <xs:documentation>
+       This work is licensed under the Creative Commons Attribution-ShareAlike
+       License.  To view a copy of this license, see the file license.txt,
+       visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+       Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+    </xs:documentation>
+
+    <xs:documentation>
+       This component schema defines the content model group customElements
+       to support validation of custom metadata elements. This component XSD 
+       should be used if extensions are to be supported in LOM instances.
+    </xs:documentation>
+    <xs:documentation>
+        *****************************************************************************
+        **                           CHANGE HISTORY                                **
+        *****************************************************************************
+        ** 03/15/2004:  1)Updated annoation describing purpose and design of the   **
+        **                XSD.                                                     **
+        *****************************************************************************
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM"/>
+
+  <!-- Model group declarations -->
+
+  <xs:group name="customElements">
+    <xs:choice>
+      <xs:group ref="lom:customElements"/>
+    </xs:choice>
+  </xs:group>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/extend/strict.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/extend/strict.xsd
@@ -1,0 +1,36 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM/extend"
+           xmlns="http://ltsc.ieee.org/xsd/LOM/extend"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+  <xs:annotation>
+    <xs:documentation>
+       This work is licensed under the Creative Commons Attribution-ShareAlike
+       License.  To view a copy of this license, see the file license.txt,
+       visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+       Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+    </xs:documentation>
+
+    <xs:documentation>
+       This component schema defines the content model group customElements
+       to support strict validation of standard metadata elements.  This component 
+       XSD should be used if extensions are not to be supported in LOM instances. 
+    </xs:documentation>
+    <xs:documentation>
+        *****************************************************************************
+        **                           CHANGE HISTORY                                **
+        *****************************************************************************
+        ** 03/15/2004:  1)Updated annoation describing purpose and design of the   **
+        **                XSD.                                                     **
+        *****************************************************************************
+    </xs:documentation>
+  </xs:annotation>
+
+  <!-- Model group declarations -->
+
+  <xs:group name="customElements">
+    <xs:choice/>
+  </xs:group>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/lom.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/lom.xsd
@@ -1,0 +1,102 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+      <xs:documentation>
+         This file represents a composite schema for validating
+         LOM V1.0 instances.  This file is built by default to represent a 
+         composite schema for validation of the following:          
+
+         1) The use of LOM Base Schema vocabulary source/value pairs only
+         2) Uniqueness constraints defined by 1484.12.1-2002
+         3) No existenace of any defined extensions
+
+         Alternative composite schemas can be assembled by selecting
+         from the various alternative component schema listed below.
+      </xs:documentation>
+      <xs:documentation>
+        *****************************************************************************
+        **                           CHANGE HISTORY                                **
+        *****************************************************************************
+        ** 11/14/2003:  1)Updated comment describing vocab/strict.xsd.  Indicated  **
+        **                that the strict.xsd is used to validate vocabularies     **
+        **                defined in the LOM V1.0 Base Schema.                     **
+        **              2)Moved included schema elementNames.xsd just before       **
+        **                elementTypes.xsd.                                        **
+        **              3)Moved the element declaration for the top-level lom      **
+        **                metadata element to a separate file (rootElement.xsd)    **
+        **                and included this file just after elementTypes.xsd.      **
+        **              4)Moved the XML Schema import statements before the XML    **
+        **                Schema include statements.                               **
+        **              5)Moved the element group declaration named                **
+        **                lom:customElements to a separate file (anyElement.xsd)   **
+        **                and included this new file just before the XML Schema    **
+        **                import statments.                                        **
+        **                                                                         **
+        ** 03/15/2004:  1)Switched which vocabulary vaidation approach is the      **
+        **                default to be used by this template from vocab/loose.xsd **
+        **                to vocab/strict.xsd.  Base on ballot resolution comment  **
+        **                addressed on 03/15/2004                                  **
+        **              2)Switched the extension validation approach to use        **
+        **                extend/strict.xsd.  The XSD now is reprsentative of      **
+        **                a schema that can be used to validate strictly           **
+        **                conforming LOM XML Instances.                            **
+        *****************************************************************************
+      </xs:documentation>
+   </xs:annotation>
+
+   <!-- Learning Object Metadata -->
+
+   <xs:include schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/common/anyElement.xsd"/>
+
+   <!-- Element uniqueness:  use one of the following                   -->
+   <!-- Use unique/loose.xsd to relax element uniqueness constraints    -->
+   <!-- Use unique/strict.xsd to enforce element uniqueness constraints -->
+
+   <!-- <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique"
+              schemaLocation="unique/loose.xsd"/> -->
+
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique"
+              schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/unique/strict.xsd"/>
+
+   <!-- Vocabulary checking:  use one of the following                             -->
+   <!-- Use vocab/loose.xsd to relax vocabulary enumeration constraints            -->
+   <!-- Use vocab/strict.xsd to enforce the LOM V1.0 Base Schema vocabulary values -->
+   <!-- Use vocab/custom.xsd to enforce custom vocabulary values                   -->
+
+   <!--<xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+              schemaLocation="vocab/loose.xsd"/> -->
+
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+              schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/vocab/strict.xsd"/>
+
+   <!-- <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+              schemaLocation="vocab/custom.xsd"/> -->
+
+   <!-- Custom elements:  use one of the following                     -->
+   <!-- Use extend/strict.xsd to enforce strictly conforming elements  -->
+   <!-- Use extend/custom.xsd to allow custom metadata elements        -->
+
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend"
+             schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/extend/strict.xsd"/>
+
+   <!--<xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend"
+              schemaLocation="extend/custom.xsd"/> -->
+
+   <xs:include schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/common/dataTypes.xsd"/>
+   <xs:include schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/common/elementNames.xsd"/>
+   <xs:include schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/common/elementTypes.xsd"/>
+   <xs:include schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/common/rootElement.xsd"/>
+   <xs:include schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/common/vocabValues.xsd"/>
+   <xs:include schemaLocation="vendor/assets/schemas/lom_1484.12.3-2020/common/vocabTypes.xsd"/>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/lomCustom.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/lomCustom.xsd
@@ -1,0 +1,62 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+      <xs:documentation>
+         This file represents a composite schema for validation of the following:
+         1) The use of custom vocabulary source/value pairs and LOM Base Schema vocabulary source/value pairs
+         2) Uniqueness constraints defined by 1484.12.1-2002
+         3) The use of custom extensions to the LOM Base Schema
+      </xs:documentation>
+      <xs:documentation>
+        ****************************************************************************
+        **                           CHANGE HISTORY                               **
+        ****************************************************************************
+        ** 11/14/2003:  1)Updated comment describing vocab/strict.xsd.  Indicated **
+        **                that the strict.xsd is used to validate vocabularies    **
+        **                defined in the LOM V1.0 Base Schema.                    **
+        **              2)Moved included schema elementNames.xsd just before      **
+        **                elementTypes.xsd.                                       **
+        **              3)Moved the element declaration for the top-level lom     **
+        **                metadata element to a separate file (rootElement.xsd)   **
+        **                and included this file just after elementTypes.xsd.     **
+        **              4)Moved the XML Schema import statements before the XML   **
+        **                Schema include statements.                              **
+        **              5)Moved the element group declaration named               **
+        **                lom:customElements to a separate file (anyElement.xsd)  **
+        **                and included this new file just before the XML Schema   **
+        **                import statments.                                       **
+        ****************************************************************************
+      </xs:documentation>
+   </xs:annotation>
+
+  <!-- Learning Object Metadata -->
+
+  <xs:include schemaLocation="common/anyElement.xsd"/>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique"
+             schemaLocation="unique/strict.xsd"/>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+             schemaLocation="vocab/custom.xsd"/>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend"
+             schemaLocation="extend/custom.xsd"/>
+
+  <xs:include schemaLocation="common/dataTypes.xsd"/>
+  <xs:include schemaLocation="common/elementNames.xsd"/>
+  <xs:include schemaLocation="common/elementTypes.xsd"/>
+  <xs:include schemaLocation="common/rootElement.xsd"/>
+  <xs:include schemaLocation="common/vocabValues.xsd"/>
+  <xs:include schemaLocation="common/vocabTypes.xsd"/>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/lomLoose.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/lomLoose.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ltsc.ieee.org/xsd/LOM" xmlns:ag="http://ltsc.ieee.org/xsd/LOM/unique" xmlns:voc="http://ltsc.ieee.org/xsd/LOM/vocab" xmlns:ex="http://ltsc.ieee.org/xsd/LOM/extend" targetNamespace="http://ltsc.ieee.org/xsd/LOM" elementFormDefault="qualified" version="IEEE LTSC LOM XML 1.0">
+    <xs:annotation>
+        <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/2.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+        <xs:documentation>
+         This file represents a composite schema for validating
+         LOM XML Instances.  This file is built by default to represent a
+         composite schema for validation of the following:
+
+         1) The use of LOMv1.0 base schema (i.e., 1484.12.1-2002) vocabulary
+            source/value pairs only
+         2) Uniqueness constraints defined by LOMv1.0 base schema
+         3) No existenace of any defined extensions:
+            LOMv1.0 base schema XML element extension,
+            LOMv1.0 base schema XML attribute extension and
+            LOMv1.0 base schema vocabulary data type extension
+
+         Alternative composite schemas can be assembled by selecting
+         from the various alternative component schema listed below.
+      </xs:documentation>
+      <xs:documentation>
+         This file has been modified by the Knowledge Media Institute of the 
+         University Koblenz-Landau (http://iwm.uni-koblenz.de). It contains the
+         following changes:
+         1) Instead of "unique/strict.xsd" the schema "unique/loose.xsd" is imported 
+            because this reflects what is said in 1484.12.3-2005, page 35 (section C.1.3)
+         2) In all component XSDs the schemaLocation attribute was amended to the 
+            xs:import and xs:include statements. This enables the usage of the schemas
+            with tools which don't deal well with missing schemaLocation informations.
+            
+         This file is available at "http://iwm.uni-koblenz.de/xsd/IEEE-LOM/loose"
+      </xs:documentation>
+    </xs:annotation>
+    <!-- Learning Object Metadata -->
+    <xs:include schemaLocation="common/anyElement.xsd" />
+    <!-- LOM data element uniqueness constraints:  use one of the following         -->
+    <!-- Use unique/loose.xsd to relax element uniqueness constraints               -->
+    <!-- Use unique/strict.xsd to enforce element uniqueness constraints            -->
+    <!-- <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique"
+              schemaLocation="unique/loose.xsd"/> -->
+    <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique" schemaLocation="unique/loose.xsd" />
+
+    <!-- Vocabulary value validation:  use one of the following                     -->
+    <!-- Use vocab/loose.xsd to relax vocabulary value constraints                  -->
+    <!-- Use vocab/strict.xsd to enforce the LOMv1.0 base schema vocabulary values  -->
+    <!-- Use vocab/custom.xsd to enforce custom vocabulary values                   -->
+    <!--<xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+              schemaLocation="vocab/loose.xsd"/> -->
+    <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab" schemaLocation="vocab/loose.xsd" />
+
+    <!-- <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+              schemaLocation="vocab/custom.xsd"/> -->
+    <!-- Extension elements/attributes support:  use one of the following           -->
+    <!-- Use extend/strict.xsd to enforce no element/attribute extension            -->
+    <!-- Use extend/custom.xsd to allow element/attribute extension                 -->
+    <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend" schemaLocation="extend/custom.xsd" />
+
+    <!--<xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend"
+              schemaLocation="extend/custom.xsd"/> -->
+    <xs:include schemaLocation="common/dataTypes.xsd" />
+    <xs:include schemaLocation="common/elementNames.xsd" />
+    <xs:include schemaLocation="common/elementTypes.xsd" />
+    <xs:include schemaLocation="common/rootElement.xsd" />
+    <xs:include schemaLocation="common/vocabValues.xsd" />
+    <xs:include schemaLocation="common/vocabTypes.xsd" />
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/lomStrict.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/lomStrict.xsd
@@ -1,0 +1,62 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM"
+           xmlns="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+      <xs:documentation>
+         This file represents a composite schema for validation of the following:
+         1) The use of LOM Base Schema vocabulary source/value pairs only
+         2) Uniqueness constraints defined by 1484.12.1-2002
+         3) No existenace of any defined extensions
+      </xs:documentation>
+      <xs:documentation>
+        ****************************************************************************
+        **                           CHANGE HISTORY                               **
+        ****************************************************************************
+        ** 09/22/2003:  - Updated comment describing vocab/strict.xsd.  Indicated **
+        **                that the strict.xsd is used to validate vocabularies    **
+        **                defined in the LOM V1.0 Base Schema.                    **
+        **              - Moved included schema elementNames.xsd just before      **
+        **                elementTypes.xsd.                                       **
+        **              - Moved the element declaration for the top-level lom     **
+        **                metadata element to a separate file (rootElement.xsd)   **
+        **                and included this file just after elementTypes.xsd.     **
+        **              - Moved the XML Schema import statements before the XML   **
+        **                Schema include statements.                              **
+        **              - Moved the element group declaration named               **
+        **                lom:customElements to a separate file (anyElement.xsd)  **
+        **                and included this new file just before the XML Schema   **
+        **                import statments.                                       **
+        ****************************************************************************
+      </xs:documentation>
+   </xs:annotation>
+
+  <!-- Learning Object Metadata -->
+
+  <xs:include schemaLocation="common/anyElement.xsd"/>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/unique"
+             schemaLocation="unique/strict.xsd"/>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+             schemaLocation="vocab/strict.xsd"/>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/extend"
+             schemaLocation="extend/strict.xsd"/>
+
+  <xs:include schemaLocation="common/dataTypes.xsd"/>
+  <xs:include schemaLocation="common/elementNames.xsd"/>
+  <xs:include schemaLocation="common/elementTypes.xsd"/>
+  <xs:include schemaLocation="common/rootElement.xsd"/>
+  <xs:include schemaLocation="common/vocabValues.xsd"/>
+  <xs:include schemaLocation="common/vocabTypes.xsd"/>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/unique/loose.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/unique/loose.xsd
@@ -1,0 +1,285 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM/unique"
+           xmlns="http://ltsc.ieee.org/xsd/LOM/unique"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+  <xs:annotation>
+    <xs:documentation>
+       This work is licensed under the Creative Commons Attribution-ShareAlike
+       License.  To view a copy of this license, see the file license.txt,
+       visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+       Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+    </xs:documentation>
+
+    <xs:documentation>
+       This component schema provides attribute group declarations for metadata
+       elements to support loose validation of element uniqueness constraints.
+
+       NOTE: The absence of the enforcement of the uniqueness constraints does not 
+       relieve a particular LOM instance from satisfying the uniqueness constraints 
+       described in the LOMv1.0 base schema. Applications that require the use of 
+       the unique/loose.xsd component XSD have to enforce those uniqueness constraints 
+       by other means.
+    </xs:documentation> 
+    <xs:documentation>
+      *****************************************************************************
+      **                           CHANGE HISTORY                                **
+      *****************************************************************************
+      ** 03/15/2004:  1)Updated annoation describing purpose and design of the   **
+      **                XSD.                                                     **
+      *****************************************************************************
+    </xs:documentation>
+  </xs:annotation>
+
+  <!-- Attribute group declarations -->
+
+  <!-- Duplicate declarations are included as comments. -->
+
+  <!-- Learning Object Metadata -->
+  <xs:attributeGroup name="lom"/>
+
+  <!-- DateTime -->
+  <xs:attributeGroup name="DateTimeValue"/>
+
+  <!-- Duration -->
+  <xs:attributeGroup name="DurationValue"/>
+
+  <!-- Source -->
+  <xs:attributeGroup name="source"/>
+
+  <!-- Value -->
+  <xs:attributeGroup name="value"/>
+
+  <!-- 1 General -->
+  <xs:attributeGroup name="general"/>
+
+  <!-- 1.1 Identifier -->
+  <xs:attributeGroup name="identifier"/>
+
+  <!-- 1.1.1 Catalog -->
+  <xs:attributeGroup name="catalog"/>
+
+  <!-- 1.1.2 Entry -->
+  <xs:attributeGroup name="entry"/>
+
+  <!-- 1.2 Title -->
+  <xs:attributeGroup name="title"/>
+
+  <!-- 1.3 Language -->
+  <xs:attributeGroup name="language"/>
+
+  <!-- 1.4 Description -->
+  <xs:attributeGroup name="description"/>
+
+  <!-- 1.5 Keyword -->
+  <xs:attributeGroup name="keyword"/>
+
+  <!-- 1.6 Coverage -->
+  <xs:attributeGroup name="coverage"/>
+
+  <!-- 1.7 Structure -->
+  <xs:attributeGroup name="structure"/>
+
+  <!-- 1.8 Aggregation Level -->
+  <xs:attributeGroup name="aggregationLevel"/>
+
+  <!-- 2 Life Cycle -->
+  <xs:attributeGroup name="lifeCycle"/>
+
+  <!-- 2.1 Version -->
+  <xs:attributeGroup name="version"/>
+
+  <!-- 2.2 Status -->
+  <xs:attributeGroup name="status"/>
+
+  <!-- 2.3 Contribute -->
+  <xs:attributeGroup name="contribute"/>
+
+  <!-- 2.3.1 Role -->
+  <xs:attributeGroup name="role"/>
+
+  <!-- 2.3.2 Entity -->
+  <xs:attributeGroup name="entity"/>
+
+  <!-- 2.3.3 Date -->
+  <xs:attributeGroup name="date"/>
+
+  <!-- 3 Meta-Metadata -->
+  <xs:attributeGroup name="metaMetadata"/>
+
+  <!-- 3.1 Identifier
+  <xs:attributeGroup name="identifier"/> -->
+
+  <!-- 3.1.1 Catalog
+  <xs:attributeGroup name="catalog"/> -->
+
+  <!-- 3.1.2 Entry
+  <xs:attributeGroup name="entry"/> -->
+
+  <!-- 3.2 Contribute
+  <xs:attributeGroup name="contribute"/> -->
+
+  <!-- 3.2.1 Role
+  <xs:attributeGroup name="role"/> -->
+
+  <!-- 3.2.2 Entity
+  <xs:attributeGroup name="entity"/> -->
+
+  <!-- 3.2.3 Date
+  <xs:attributeGroup name="date"/> -->
+
+  <!-- 3.3 Metadata Schema -->
+  <xs:attributeGroup name="metadataSchema"/>
+
+  <!-- 3.4 Language
+  <xs:attributeGroup name="language"/> -->
+
+  <!-- 4 Technical -->
+  <xs:attributeGroup name="technical"/>
+
+  <!-- 4.1 Format -->
+  <xs:attributeGroup name="format"/>
+
+  <!-- 4.2 Size -->
+  <xs:attributeGroup name="size"/>
+
+  <!-- 4.3 Location -->
+  <xs:attributeGroup name="location"/>
+
+  <!-- 4.4 Requirement -->
+  <xs:attributeGroup name="requirement"/>
+
+  <!-- 4.4.1 OrComposite -->
+  <xs:attributeGroup name="orComposite"/>
+
+  <!-- 4.4.1.1 Type -->
+  <xs:attributeGroup name="type"/>
+
+  <!-- 4.4.1.2 Name -->
+  <xs:attributeGroup name="name"/>
+
+  <!-- 4.4.1.3 Minimum Version -->
+  <xs:attributeGroup name="minimumVersion"/>
+
+  <!-- 4.4.1.4 Maximum Version -->
+  <xs:attributeGroup name="maximumVersion"/>
+
+  <!-- 4.5 Installation Remarks -->
+  <xs:attributeGroup name="installationRemarks"/>
+
+  <!-- 4.6 Other Platform Requirements -->
+  <xs:attributeGroup name="otherPlatformRequirements"/>
+
+  <!-- 4.7 Duration -->
+  <xs:attributeGroup name="duration"/>
+
+  <!-- 5 Educational -->
+  <xs:attributeGroup name="educational"/>
+
+  <!-- 5.1 Interactivity Type -->
+  <xs:attributeGroup name="interactivityType"/>
+
+  <!-- 5.2 Learning Resource Type -->
+  <xs:attributeGroup name="learningResourceType"/>
+
+  <!-- 5.3 Interactivity Level -->
+  <xs:attributeGroup name="interactivityLevel"/>
+
+  <!-- 5.4 Semantic Density -->
+  <xs:attributeGroup name="semanticDensity"/>
+
+  <!-- 5.5 Intended End User Role -->
+  <xs:attributeGroup name="intendedEndUserRole"/>
+
+  <!-- 5.6 Context -->
+  <xs:attributeGroup name="context"/>
+
+  <!-- 5.7 Typical Age Range -->
+  <xs:attributeGroup name="typicalAgeRange"/>
+
+  <!-- 5.8 Difficulty -->
+  <xs:attributeGroup name="difficulty"/>
+
+  <!-- 5.9 Typical Learning Time -->
+  <xs:attributeGroup name="typicalLearningTime"/>
+
+  <!-- 5.10 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 5.11 Language
+  <xs:attributeGroup name="language"/> -->
+
+  <!-- 6 Rights -->
+  <xs:attributeGroup name="rights"/>
+
+  <!-- 6.1 Cost -->
+  <xs:attributeGroup name="cost"/>
+
+  <!-- 6.2 Copyright and Other Restrictions -->
+  <xs:attributeGroup name="copyrightAndOtherRestrictions"/>
+
+  <!-- 6.3 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 7 Relation -->
+  <xs:attributeGroup name="relation"/>
+
+  <!-- 7.1 Kind -->
+  <xs:attributeGroup name="kind"/>
+
+  <!-- 7.2 Resource -->
+  <xs:attributeGroup name="resource"/>
+
+  <!-- 7.2.1 Identifier
+  <xs:attributeGroup name="identifier"/> -->
+
+  <!-- 7.2.1.1 Catalog
+  <xs:attributeGroup name="catalog"/> -->
+
+  <!-- 7.2.1.2 Entry
+  <xs:attributeGroup name="entry"/> -->
+
+  <!-- 7.2.2 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 8 Annotation -->
+  <xs:attributeGroup name="annotation"/>
+
+  <!-- 8.1 Entity
+  <xs:attributeGroup name="entity"/> -->
+
+  <!-- 8.2 Date
+  <xs:attributeGroup name="date"/> -->
+
+  <!-- 8.3 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 9 Classification -->
+  <xs:attributeGroup name="classification"/>
+
+  <!-- 9.1 Purpose -->
+  <xs:attributeGroup name="purpose"/>
+
+  <!-- 9.2 Taxon Path -->
+  <xs:attributeGroup name="taxonPath"/>
+
+  <!-- 9.2.1 Source
+  <xs:attributeGroup name="source"/> -->
+
+  <!-- 9.2.2 Taxon -->
+  <xs:attributeGroup name="taxon"/>
+
+  <!-- 9.2.2.1 Id -->
+  <xs:attributeGroup name="id"/>
+
+  <!-- 9.2.2.2 Entry
+  <xs:attributeGroup name="entry"/> -->
+
+  <!-- 9.3 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 9.4 Keyword
+  <xs:attributeGroup name="keyword"/> -->
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/unique/strict.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/unique/strict.xsd
@@ -1,0 +1,391 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM/unique"
+           xmlns="http://ltsc.ieee.org/xsd/LOM/unique"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+  <xs:annotation>
+    <xs:documentation>
+       This work is licensed under the Creative Commons Attribution-ShareAlike
+       License.  To view a copy of this license, see the file license.txt,
+       visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+       Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+    </xs:documentation>
+
+    <xs:documentation>
+       This component schema provides attribute group declarations for metadata
+       elements to support strict validation of element uniqueness constraints,
+       by providing the attribute uniqueElementName for each metadata element
+       that should appear with multiplicity at most one.
+
+       NOTE: For most applications, enforcing the uniqueness constraints using the 
+       unique/strict.xsd component XSD is desirable, but adding such an artificial 
+       attribute is undesirable, although the addition of the artificial attribute 
+       is unlikely to cause problems.
+    </xs:documentation>
+    <xs:documentation>
+        *****************************************************************************
+        **                           CHANGE HISTORY                                **
+        *****************************************************************************
+        ** 03/15/2004:  1)Updated annoation describing purpose and design of the   **
+        **                XSD.                                                     **
+        *****************************************************************************
+      </xs:documentation>
+  </xs:annotation>
+
+  <!-- Attribute group declarations -->
+
+  <!-- Duplicate declarations are included as comments. -->
+
+  <!-- For duplicate element names with different local multiplicities,
+       the unique declaration is used.  The non-unique instances use
+       local element declarations.  (<language>, <description>, <entity>)
+    -->
+
+  <!-- Learning Object Metadata -->
+  <xs:attributeGroup name="lom"/>
+
+  <!-- DateTime -->
+  <xs:attributeGroup name="DateTimeValue">
+    <xs:attribute name="uniqueElementName" fixed="dateTime"/>
+  </xs:attributeGroup>
+
+  <!-- Duration -->
+  <xs:attributeGroup name="DurationValue">
+    <xs:attribute name="uniqueElementName" fixed="duration"/>
+  </xs:attributeGroup>
+
+  <!-- Source -->
+  <xs:attributeGroup name="source">
+    <xs:attribute name="uniqueElementName" fixed="source"/>
+  </xs:attributeGroup>
+
+  <!-- Value -->
+  <xs:attributeGroup name="value">
+    <xs:attribute name="uniqueElementName" fixed="value"/>
+  </xs:attributeGroup>
+
+  <!-- 1 General -->
+  <xs:attributeGroup name="general">
+    <xs:attribute name="uniqueElementName" fixed="general"/>
+  </xs:attributeGroup>
+
+  <!-- 1.1 Identifier -->
+  <xs:attributeGroup name="identifier"/>
+
+  <!-- 1.1.1 Catalog -->
+  <xs:attributeGroup name="catalog">
+    <xs:attribute name="uniqueElementName" fixed="catalog"/>
+  </xs:attributeGroup>
+
+  <!-- 1.1.2 Entry -->
+  <xs:attributeGroup name="entry">
+    <xs:attribute name="uniqueElementName" fixed="entry"/>
+  </xs:attributeGroup>
+
+  <!-- 1.2 Title -->
+  <xs:attributeGroup name="title">
+    <xs:attribute name="uniqueElementName" fixed="title"/>
+  </xs:attributeGroup>
+
+  <!-- 1.3 Language
+  <xs:attributeGroup name="language"/> -->
+
+  <!-- 1.4 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 1.5 Keyword -->
+  <xs:attributeGroup name="keyword"/>
+
+  <!-- 1.6 Coverage -->
+  <xs:attributeGroup name="coverage"/>
+
+  <!-- 1.7 Structure -->
+  <xs:attributeGroup name="structure">
+    <xs:attribute name="uniqueElementName" fixed="structure"/>
+  </xs:attributeGroup>
+
+  <!-- 1.8 Aggregation Level -->
+  <xs:attributeGroup name="aggregationLevel">
+    <xs:attribute name="uniqueElementName" fixed="aggregationLevel"/>
+  </xs:attributeGroup>
+
+  <!-- 2 Life Cycle -->
+  <xs:attributeGroup name="lifeCycle">
+    <xs:attribute name="uniqueElementName" fixed="lifeCycle"/>
+  </xs:attributeGroup>
+
+  <!-- 2.1 Version -->
+  <xs:attributeGroup name="version">
+    <xs:attribute name="uniqueElementName" fixed="version"/>
+  </xs:attributeGroup>
+
+  <!-- 2.2 Status -->
+  <xs:attributeGroup name="status">
+    <xs:attribute name="uniqueElementName" fixed="status"/>
+  </xs:attributeGroup>
+
+  <!-- 2.3 Contribute -->
+  <xs:attributeGroup name="contribute"/>
+
+  <!-- 2.3.1 Role -->
+  <xs:attributeGroup name="role">
+    <xs:attribute name="uniqueElementName" fixed="role"/>
+  </xs:attributeGroup>
+
+  <!-- 2.3.2 Entity
+  <xs:attributeGroup name="entity"/> -->
+
+  <!-- 2.3.3 Date -->
+  <xs:attributeGroup name="date">
+    <xs:attribute name="uniqueElementName" fixed="date"/>
+  </xs:attributeGroup>
+
+  <!-- 3 Meta-Metadata -->
+  <xs:attributeGroup name="metaMetadata">
+    <xs:attribute name="uniqueElementName" fixed="metaMetadata"/>
+  </xs:attributeGroup>
+
+  <!-- 3.1 Identifier
+  <xs:attributeGroup name="identifier"/> -->
+
+  <!-- 3.1.1 Catalog
+  <xs:attributeGroup name="catalog">
+    <xs:attribute name="uniqueElementName" fixed="catalog"/>
+  </xs:attributeGroup> -->
+
+  <!-- 3.1.2 Entry
+  <xs:attributeGroup name="entry">
+    <xs:attribute name="uniqueElementName" fixed="entry"/>
+  </xs:attributeGroup> -->
+
+  <!-- 3.2 Contribute
+  <xs:attributeGroup name="contribute"/> -->
+
+  <!-- 3.2.1 Role
+  <xs:attributeGroup name="role">
+    <xs:attribute name="uniqueElementName" fixed="role"/>
+  </xs:attributeGroup> -->
+
+  <!-- 3.2.2 Entity
+  <xs:attributeGroup name="entity"/> -->
+
+  <!-- 3.2.3 Date
+  <xs:attributeGroup name="date">
+    <xs:attribute name="uniqueElementName" fixed="date"/>
+  </xs:attributeGroup> -->
+
+  <!-- 3.3 Metadata Schema -->
+  <xs:attributeGroup name="metadataSchema"/>
+
+  <!-- 3.4 Language -->
+  <xs:attributeGroup name="language">
+    <xs:attribute name="uniqueElementName" fixed="language"/>
+  </xs:attributeGroup>
+
+  <!-- 4 Technical -->
+  <xs:attributeGroup name="technical">
+    <xs:attribute name="uniqueElementName" fixed="technical"/>
+  </xs:attributeGroup>
+
+  <!-- 4.1 Format -->
+  <xs:attributeGroup name="format"/>
+
+  <!-- 4.2 Size -->
+  <xs:attributeGroup name="size">
+    <xs:attribute name="uniqueElementName" fixed="size"/>
+  </xs:attributeGroup>
+
+  <!-- 4.3 Location -->
+  <xs:attributeGroup name="location"/>
+
+  <!-- 4.4 Requirement -->
+  <xs:attributeGroup name="requirement"/>
+
+  <!-- 4.4.1 OrComposite -->
+  <xs:attributeGroup name="orComposite"/>
+
+  <!-- 4.4.1.1 Type -->
+  <xs:attributeGroup name="type">
+    <xs:attribute name="uniqueElementName" fixed="type"/>
+  </xs:attributeGroup>
+
+  <!-- 4.4.1.2 Name -->
+  <xs:attributeGroup name="name">
+    <xs:attribute name="uniqueElementName" fixed="name"/>
+  </xs:attributeGroup>
+
+  <!-- 4.4.1.3 Minimum Version -->
+  <xs:attributeGroup name="minimumVersion">
+    <xs:attribute name="uniqueElementName" fixed="minimumVersion"/>
+  </xs:attributeGroup>
+
+  <!-- 4.4.1.4 Maximum Version -->
+  <xs:attributeGroup name="maximumVersion">
+    <xs:attribute name="uniqueElementName" fixed="maximumVersion"/>
+  </xs:attributeGroup>
+
+  <!-- 4.5 Installation Remarks -->
+  <xs:attributeGroup name="installationRemarks">
+    <xs:attribute name="uniqueElementName" fixed="installationRemarks"/>
+  </xs:attributeGroup>
+
+  <!-- 4.6 Other Platform Requirements -->
+  <xs:attributeGroup name="otherPlatformRequirements"/>
+
+  <!-- 4.7 Duration -->
+  <xs:attributeGroup name="duration">
+    <xs:attribute name="uniqueElementName" fixed="duration"/>
+  </xs:attributeGroup>
+
+  <!-- 5 Educational -->
+  <xs:attributeGroup name="educational"/>
+
+  <!-- 5.1 Interactivity Type -->
+  <xs:attributeGroup name="interactivityType">
+    <xs:attribute name="uniqueElementName" fixed="interactivityType"/>
+  </xs:attributeGroup>
+
+  <!-- 5.2 Learning Resource Type -->
+  <xs:attributeGroup name="learningResourceType"/>
+
+  <!-- 5.3 Interactivity Level -->
+  <xs:attributeGroup name="interactivityLevel">
+    <xs:attribute name="uniqueElementName" fixed="interactivityLevel"/>
+  </xs:attributeGroup>
+
+  <!-- 5.4 Semantic Density -->
+  <xs:attributeGroup name="semanticDensity">
+    <xs:attribute name="uniqueElementName" fixed="semanticDensity"/>
+  </xs:attributeGroup>
+
+  <!-- 5.5 Intended End User Role -->
+  <xs:attributeGroup name="intendedEndUserRole"/>
+
+  <!-- 5.6 Context -->
+  <xs:attributeGroup name="context"/>
+
+  <!-- 5.7 Typical Age Range -->
+  <xs:attributeGroup name="typicalAgeRange"/>
+
+  <!-- 5.8 Difficulty -->
+  <xs:attributeGroup name="difficulty">
+    <xs:attribute name="uniqueElementName" fixed="difficulty"/>
+  </xs:attributeGroup>
+
+  <!-- 5.9 Typical Learning Time -->
+  <xs:attributeGroup name="typicalLearningTime">
+    <xs:attribute name="uniqueElementName" fixed="typicalLearningTime"/>
+  </xs:attributeGroup>
+
+  <!-- 5.10 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 5.11 Language
+  <xs:attributeGroup name="language"/> -->
+
+  <!-- 6 Rights -->
+  <xs:attributeGroup name="rights">
+    <xs:attribute name="uniqueElementName" fixed="rights"/>
+  </xs:attributeGroup>
+
+  <!-- 6.1 Cost -->
+  <xs:attributeGroup name="cost">
+    <xs:attribute name="uniqueElementName" fixed="cost"/>
+  </xs:attributeGroup>
+
+  <!-- 6.2 Copyright and Other Restrictions -->
+  <xs:attributeGroup name="copyrightAndOtherRestrictions">
+    <xs:attribute name="uniqueElementName" fixed="copyrightAndOtherRestrictions"/>
+  </xs:attributeGroup>
+
+  <!-- 6.3 Description -->
+  <xs:attributeGroup name="description">
+    <xs:attribute name="uniqueElementName" fixed="description"/>
+  </xs:attributeGroup>
+
+  <!-- 7 Relation -->
+  <xs:attributeGroup name="relation"/>
+
+  <!-- 7.1 Kind -->
+  <xs:attributeGroup name="kind">
+    <xs:attribute name="uniqueElementName" fixed="kind"/>
+  </xs:attributeGroup>
+
+  <!-- 7.2 Resource -->
+  <xs:attributeGroup name="resource">
+    <xs:attribute name="uniqueElementName" fixed="resource"/>
+  </xs:attributeGroup>
+
+  <!-- 7.2.1 Identifier
+  <xs:attributeGroup name="identifier"/> -->
+
+  <!-- 7.2.1.1 Catalog
+  <xs:attributeGroup name="catalog">
+    <xs:attribute name="uniqueElementName" fixed="catalog"/>
+  </xs:attributeGroup> -->
+
+  <!-- 7.2.1.2 Entry
+  <xs:attributeGroup name="entry">
+    <xs:attribute name="uniqueElementName" fixed="entry"/>
+  </xs:attributeGroup> -->
+
+  <!-- 7.2.2 Description
+  <xs:attributeGroup name="description"/> -->
+
+  <!-- 8 Annotation -->
+  <xs:attributeGroup name="annotation"/>
+
+  <!-- 8.1 Entity -->
+  <xs:attributeGroup name="entity">
+    <xs:attribute name="uniqueElementName" fixed="entity"/>
+  </xs:attributeGroup>
+
+  <!-- 8.2 Date
+  <xs:attributeGroup name="date">
+    <xs:attribute name="uniqueElementName" fixed="date"/>
+  </xs:attributeGroup> -->
+
+  <!-- 8.3 Description
+  <xs:attributeGroup name="description">
+    <xs:attribute name="uniqueElementName" fixed="description"/>
+  </xs:attributeGroup> -->
+
+  <!-- 9 Classification -->
+  <xs:attributeGroup name="classification"/>
+
+  <!-- 9.1 Purpose -->
+  <xs:attributeGroup name="purpose">
+    <xs:attribute name="uniqueElementName" fixed="purpose"/>
+  </xs:attributeGroup>
+
+  <!-- 9.2 Taxon Path -->
+  <xs:attributeGroup name="taxonPath"/>
+
+  <!-- 9.2.1 Source
+  <xs:attributeGroup name="source">
+    <xs:attribute name="uniqueElementName" fixed="source"/>
+  </xs:attributeGroup> -->
+
+  <!-- 9.2.2 Taxon -->
+  <xs:attributeGroup name="taxon"/>
+
+  <!-- 9.2.2.1 Id -->
+  <xs:attributeGroup name="id">
+    <xs:attribute name="uniqueElementName" fixed="id"/>
+  </xs:attributeGroup>
+
+  <!-- 9.2.2.2 Entry
+  <xs:attributeGroup name="entry">
+    <xs:attribute name="uniqueElementName" fixed="entry"/>
+  </xs:attributeGroup> -->
+
+  <!-- 9.3 Description
+  <xs:attributeGroup name="description">
+    <xs:attribute name="uniqueElementName" fixed="description"/>
+  </xs:attributeGroup> -->
+
+  <!-- 9.4 Keyword
+  <xs:attributeGroup name="keyword"/> -->
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/vocab/custom.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/vocab/custom.xsd
@@ -1,0 +1,139 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+           xmlns="http://ltsc.ieee.org/xsd/LOM/vocab"
+           xmlns:lom="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:lx="http://ltsc.ieee.org/xsd/LOM/custom"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides simple type declarations for metadata
+         elements whose values are taken from a vocabulary datatype.
+
+         This component schema supports strict validation of both standard and custom
+         vocabulary values by checking that both the source and value are taken
+         from either the IEEE standard token set or from a custom token set.  
+
+         Organizations are free to define their own namespace for the custom vocabulary
+         extensions.  For completeness this XSD is set up to use a namespace defined
+         as xmlns:ls="http://ltsc.ieee.org/xsd/LOM/custom"
+      </xs:documentation>
+      <xs:documentation>
+        *****************************************************************************
+        **                           CHANGE HISTORY                                **
+        *****************************************************************************
+        ** 03/15/2004:  1)Updated annoation describing purpose and design of the   **
+        **                XSD.                                                     **
+        *****************************************************************************
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM"/>
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM/custom"/>
+  
+   <!-- Vocabulary type declarations -->
+
+   <!-- Source -->
+   <xs:simpleType name="source">
+      <xs:union memberTypes="lom:sourceValues lx:sourceValues"/>
+   </xs:simpleType>
+
+   <!-- 1.7 Structure -->
+   <xs:simpleType name="structure">
+      <xs:union memberTypes="lom:structureValues lx:structureValues"/>
+   </xs:simpleType>
+
+   <!-- 1.8 Aggregation Level -->
+   <xs:simpleType name="aggregationLevel">
+      <xs:union memberTypes="lom:aggregationLevelValues lx:aggregationLevelValues"/>
+   </xs:simpleType>
+
+   <!-- 2.2 Status -->
+   <xs:simpleType name="status">
+      <xs:union memberTypes="lom:statusValues lx:statusValues"/>
+   </xs:simpleType>
+
+   <!-- 2.3.1 Role -->
+   <xs:simpleType name="role">
+      <xs:union memberTypes="lom:roleValues lx:roleValues"/>
+   </xs:simpleType>
+
+   <!-- 3.2.1 Role -->
+   <xs:simpleType name="roleMeta">
+      <xs:union memberTypes="lom:roleMetaValues lx:roleMetaValues"/>
+   </xs:simpleType>
+
+   <!-- 4.4.1.1 Type -->
+   <xs:simpleType name="type">
+      <xs:union memberTypes="lom:typeValues lx:typeValues"/>
+   </xs:simpleType>
+
+   <!-- 4.4.1.2 Name -->
+   <xs:simpleType name="name">
+      <xs:union memberTypes="lom:nameValues lx:nameValues"/>
+   </xs:simpleType>
+
+   <!-- 5.1 Interactivity Type -->
+   <xs:simpleType name="interactivityType">
+      <xs:union memberTypes="lom:interactivityTypeValues lx:interactivityTypeValues"/>
+   </xs:simpleType>
+
+   <!-- 5.2 Learning Resource Type -->
+   <xs:simpleType name="learningResourceType">
+      <xs:union memberTypes="lom:learningResourceTypeValues lx:learningResourceTypeValues"/>
+   </xs:simpleType>
+
+   <!-- 5.3 Interactivity Level -->
+   <xs:simpleType name="interactivityLevel">
+      <xs:union memberTypes="lom:interactivityLevelValues lx:interactivityLevelValues"/>
+   </xs:simpleType>
+
+   <!-- 5.4 Semantic Density -->
+   <xs:simpleType name="semanticDensity">
+      <xs:union memberTypes="lom:semanticDensityValues lx:semanticDensityValues"/>
+   </xs:simpleType>
+
+   <!-- 5.5 Intended End User Role -->
+   <xs:simpleType name="intendedEndUserRole">
+      <xs:union memberTypes="lom:intendedEndUserRoleValues lx:intendedEndUserRoleValues"/>
+   </xs:simpleType>
+
+   <!-- 5.6 Context -->
+   <xs:simpleType name="context">
+      <xs:union memberTypes="lom:contextValues lx:contextValues"/>
+   </xs:simpleType>
+
+   <!-- 5.8 Difficulty -->
+   <xs:simpleType name="difficulty">
+      <xs:union memberTypes="lom:difficultyValues lx:difficultyValues"/>
+   </xs:simpleType>
+
+   <!-- 6.1 Cost -->
+   <xs:simpleType name="cost">
+      <xs:union memberTypes="lom:costValues lx:costValues"/>
+   </xs:simpleType>
+
+   <!-- 6.2 Copyright and Other Restrictions -->
+   <xs:simpleType name="copyrightAndOtherRestrictions">
+      <xs:union memberTypes="lom:copyrightAndOtherRestrictionsValues lx:copyrightAndOtherRestrictionsValues"/>
+   </xs:simpleType>
+
+   <!-- 7.1 Kind -->
+   <xs:simpleType name="kind">
+      <xs:union memberTypes="lom:kindValues lx:kindValues"/>
+   </xs:simpleType>
+
+   <!-- 9.1 Purpose -->
+   <xs:simpleType name="purpose">
+      <xs:union memberTypes="lom:purposeValues lx:purposeValues"/>
+   </xs:simpleType>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/vocab/loose.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/vocab/loose.xsd
@@ -1,0 +1,137 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+           xmlns="http://ltsc.ieee.org/xsd/LOM/vocab"
+           xmlns:lom="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+  <xs:annotation>
+    <xs:documentation>
+       This work is licensed under the Creative Commons Attribution-ShareAlike
+       License.  To view a copy of this license, see the file license.txt,
+       visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+       Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+    </xs:documentation>
+
+    <xs:documentation>
+       This component schema provides simple type declarations for metadata
+       elements that are defined to be of the Vocabulary datatype.
+
+       This component schema supports loose validation of vocabulary value constraints
+       by allowing both the source and value to be arbitrary strings. 
+
+       NOTE-The absence of the enforcement of vocabulary values does not relieve a 
+       particular LOM instance from satisfying vocabulary requirements defined in the
+       LOMv1.0 base schema. Applications that require the use of vocab/loose.xsd 
+       component XSD should enforce those vocabulary requirements by other means.
+    </xs:documentation>
+    <xs:documentation>
+        *****************************************************************************
+        **                           CHANGE HISTORY                                **
+        *****************************************************************************
+        ** 03/15/2004:  1)Updated annoation describing purpose and design of the   **
+        **                XSD.                                                     **
+        *****************************************************************************
+      </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://ltsc.ieee.org/xsd/LOM"/>
+
+  <!-- Vocabulary type declarations -->
+
+  <!-- Source -->
+  <xs:simpleType name="source">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 1.7 Structure -->
+  <xs:simpleType name="structure">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 1.8 Aggregation Level -->
+  <xs:simpleType name="aggregationLevel">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 2.2 Status -->
+  <xs:simpleType name="status">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 2.3.1 Role -->
+  <xs:simpleType name="role">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 3.2.1 Role -->
+  <xs:simpleType name="roleMeta">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 4.4.1.1 Type -->
+  <xs:simpleType name="type">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 4.4.1.2 Name -->
+  <xs:simpleType name="name">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 5.1 Interactivity Type -->
+  <xs:simpleType name="interactivityType">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 5.2 Learning Resource Type -->
+  <xs:simpleType name="learningResourceType">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 5.3 Interactivity Level -->
+  <xs:simpleType name="interactivityLevel">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 5.4 Semantic Density -->
+  <xs:simpleType name="semanticDensity">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 5.5 Intended End User Role -->
+  <xs:simpleType name="intendedEndUserRole">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 5.6 Context -->
+  <xs:simpleType name="context">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 5.8 Difficulty -->
+  <xs:simpleType name="difficulty">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 6.1 Cost -->
+  <xs:simpleType name="cost">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 6.2 Copyright and Other Restrictions -->
+  <xs:simpleType name="copyrightAndOtherRestrictions">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 7.1 Kind -->
+  <xs:simpleType name="kind">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+  <!-- 9.1 Purpose -->
+  <xs:simpleType name="purpose">
+    <xs:restriction base="lom:CharacterString"/>
+  </xs:simpleType>
+
+</xs:schema>

--- a/vendor/assets/schemas/lom_1484.12.3-2020/vocab/strict.xsd
+++ b/vendor/assets/schemas/lom_1484.12.3-2020/vocab/strict.xsd
@@ -1,0 +1,132 @@
+<xs:schema targetNamespace="http://ltsc.ieee.org/xsd/LOM/vocab"
+           xmlns="http://ltsc.ieee.org/xsd/LOM/vocab"
+           xmlns:lom="http://ltsc.ieee.org/xsd/LOM"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           version="IEEE LTSC LOM XML 1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         This work is licensed under the Creative Commons Attribution-ShareAlike
+         License.  To view a copy of this license, see the file license.txt,
+         visit http://creativecommons.org/licenses/by-sa/1.0 or send a letter to
+         Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+      </xs:documentation>
+
+      <xs:documentation>
+         This component schema provides simple type declarations for metadata
+         elements whose values are taken from the IEEE standard vocabulary token set.
+
+         This component schema supports strict validation of vocabulary values by
+         checking that both the source and value are from the IEEE standard token set.
+      </xs:documentation>
+      <xs:documentation>
+        *****************************************************************************
+        **                           CHANGE HISTORY                                **
+        *****************************************************************************
+        ** 03/15/2004:  1)Updated annoation describing purpose and design of the   **
+        **                XSD.                                                     **
+        *****************************************************************************
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://ltsc.ieee.org/xsd/LOM"/>
+
+   <!-- Vocabulary type declarations -->
+
+   <!-- Source -->
+   <xs:simpleType name="source">
+      <xs:union memberTypes="lom:sourceValues"/>
+   </xs:simpleType>
+
+   <!-- 1.7 Structure -->
+   <xs:simpleType name="structure">
+      <xs:union memberTypes="lom:structureValues"/>
+   </xs:simpleType>
+
+   <!-- 1.8 Aggregation Level -->
+   <xs:simpleType name="aggregationLevel">
+      <xs:union memberTypes="lom:aggregationLevelValues"/>
+   </xs:simpleType>
+
+   <!-- 2.2 Status -->
+   <xs:simpleType name="status">
+      <xs:union memberTypes="lom:statusValues"/>
+   </xs:simpleType>
+
+   <!-- 2.3.1 Role -->
+   <xs:simpleType name="role">
+      <xs:union memberTypes="lom:roleValues"/>
+   </xs:simpleType>
+
+   <!-- 3.2.1 Role -->
+   <xs:simpleType name="roleMeta">
+      <xs:union memberTypes="lom:roleMetaValues"/>
+   </xs:simpleType>
+
+   <!-- 4.4.1.1 Type -->
+   <xs:simpleType name="type">
+      <xs:union memberTypes="lom:typeValues"/>
+   </xs:simpleType>
+
+   <!-- 4.4.1.2 Name -->
+   <xs:simpleType name="name">
+      <xs:union memberTypes="lom:nameValues"/>
+   </xs:simpleType>
+
+   <!-- 5.1 Interactivity Type -->
+   <xs:simpleType name="interactivityType">
+      <xs:union memberTypes="lom:interactivityTypeValues"/>
+   </xs:simpleType>
+ 
+   <!-- 5.2 Learning Resource Type -->
+   <xs:simpleType name="learningResourceType">
+      <xs:union memberTypes="lom:learningResourceTypeValues"/>
+   </xs:simpleType>
+ 
+   <!-- 5.3 Interactivity Level -->
+   <xs:simpleType name="interactivityLevel">
+      <xs:union memberTypes="lom:interactivityLevelValues"/>
+   </xs:simpleType>
+
+   <!-- 5.4 Semantic Density -->
+   <xs:simpleType name="semanticDensity">
+      <xs:union memberTypes="lom:semanticDensityValues"/>
+   </xs:simpleType>
+
+   <!-- 5.5 Intended End User Role -->
+   <xs:simpleType name="intendedEndUserRole">
+      <xs:union memberTypes="lom:intendedEndUserRoleValues"/>
+   </xs:simpleType>
+
+   <!-- 5.6 Context -->
+   <xs:simpleType name="context">
+      <xs:union memberTypes="lom:contextValues"/>
+   </xs:simpleType>
+
+   <!-- 5.8 Difficulty -->
+   <xs:simpleType name="difficulty">
+      <xs:union memberTypes="lom:difficultyValues"/>
+   </xs:simpleType>
+
+   <!-- 6.1 Cost -->
+   <xs:simpleType name="cost">
+      <xs:union memberTypes="lom:costValues"/>
+   </xs:simpleType>
+
+   <!-- 6.2 Copyright and Other Restrictions -->
+   <xs:simpleType name="copyrightAndOtherRestrictions">
+      <xs:union memberTypes="lom:copyrightAndOtherRestrictionsValues"/>
+   </xs:simpleType>
+
+   <!-- 7.1 Kind -->
+   <xs:simpleType name="kind">
+      <xs:union memberTypes="lom:kindValues"/>
+   </xs:simpleType>
+
+   <!-- 9.1 Purpose -->
+   <xs:simpleType name="purpose">
+      <xs:union memberTypes="lom:purposeValues"/>
+   </xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
This CL adds a [LOM](https://en.wikipedia.org/wiki/Learning_object_metadata) ([IEEE 1484.12.3-2020](https://standards.ieee.org/standard/1484_12_3-2020.html) compatible) endpoint for a sample response of task metadata. Therefore, we introduce a bridges API namespace similar to the ones used in the Xikolo project.

The endpoint can be requested under:  
`/bridges/lom/tasks/sample`

Also, we provide the ability to validate the response with an additional parameter:
`/bridges/lom/tasks/sample?validate=true`

This uses the provided XSD schema files for LOM and responds the error messages. This was quite handy for debugging and can be used for tests in case we will build a real feature for this in the future.