### PR TITLE
Add BIRD XML sample endpoint

### DIFF
--- a/app/controllers/bridges/bird/tasks_controller.rb
+++ b/app/controllers/bridges/bird/tasks_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Bridges
+  module Bird
+    class TasksController < ActionController::API
+      def index
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| build_bird(xml) }
+        render xml: builder
+      end
+
+      private
+
+      def build_bird(xml)
+        xml.import(
+          xmlns: 'https://www.mathplan.de/moses/xsd/default',
+          'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance'
+        ) do
+          bird_academy(xml)
+          bird_courses(xml)
+        end
+      end
+
+      def bird_academy(xml)
+        xml.list(type: 'bird_academy') do
+          xml.bird_academy do
+            xml.id_ codeharbor_id
+            xml.name 'CodeHarbor: Your repository for auto-gradeable programming exercises'
+            xml.kurzname 'CodeHarbor'
+          end
+        end
+      end
+
+      def bird_courses(xml)
+        xml.list(type: 'bird_course') do
+          tasks.each.with_index do |task, i|
+            xml.bird_course do
+              xml.id_ task_url(id: "sample-#{i + 1}") # TODO: This needs to be replaced with the actual task id.
+              xml.name task.title
+              xml.academyId codeharbor_id
+              xml.lectureType 'Programming Exercise'
+            end
+          end
+        end
+      end
+
+      def codeharbor_id
+        root_url
+      end
+
+      def tasks
+        # TODO: Replace with DB query.
+        @tasks ||= [
+          Task.new(
+            title: 'Hello World in Java',
+            description: 'Write a simple program that prints "Hello World".',
+            internal_description: 'This is a simple exercise for your students to begin with Java.',
+            language: 'English'
+          ),
+          Task.new(
+            title: 'Hello World in Python',
+            description: 'Write a simple program that prints "Hello World".',
+            internal_description: 'This is a simple exercise for your students to begin with Python.',
+            language: 'English'
+          )
+        ]
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,9 @@ Rails.application.routes.draw do
     scope 'lom', module: :lom, as: 'lom' do
       resources :tasks, only: %i[show]
     end
+    scope 'bird', module: :bird, as: 'bird' do
+      resources :tasks, only: %i[index]
+    end
   end
 
   resources :ping, only: :index, defaults: {format: :json}


### PR DESCRIPTION
This CL adds a BIRD XML endpoint for a sample response of task metadata, similar to #553. This time without the validation, the XSD should not be added to the public repo. But I did that locally.

The endpoint can be requested under:
`/bridges/bird/tasks`

As already discussed, the XML schema is very limited for our use case. Attached you can find the sample response.

[bird_example.xml.zip](https://github.com/openHPI/codeharbor/files/7709998/bird_example.xml.zip)
