### PR TITLE
Fix deprecation warnings

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -229,7 +229,8 @@ class TasksController < ApplicationController
   end
 
   def render_export_actions(task:, exported:, error: nil, task_found: nil, update_right: nil)
-    render_to_string(partial: 'export_actions.html.slim',
+    render_to_string(partial: 'export_actions',
+                     formats: [:'html.slim'],
                      locals: {task: task, exported: exported, error: error, task_found: task_found,
                               update_right: update_right})
   end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe TasksController, type: :controller do
 
     subject(:post_request) { post :import_start, params: {zip_file: zip_file}, format: :js, xhr: true }
 
-    let(:zip_file) { fixture_file_upload('files/proforma_import/testfile.zip', 'application/zip') }
+    let(:zip_file) { fixture_file_upload('proforma_import/testfile.zip', 'application/zip') }
 
     before { allow(ProformaService::CacheImportFile).to receive(:call).and_call_original }
 
@@ -295,7 +295,7 @@ RSpec.describe TasksController, type: :controller do
     end
 
     context 'when file contains three tasks' do
-      let(:zip_file) { fixture_file_upload('files/proforma_import/testfile_multi.zip', 'application/zip') }
+      let(:zip_file) { fixture_file_upload('proforma_import/testfile_multi.zip', 'application/zip') }
 
       it 'renders import view for three tasks' do
         post_request
@@ -330,7 +330,7 @@ RSpec.describe TasksController, type: :controller do
            params: {import_id: import_data[1][:import_id], subfile_id: import_data[0], import_type: 'export'}, xhr: true
     end
 
-    let(:zip_file) { fixture_file_upload('files/proforma_import/testfile_multi.zip', 'application/zip') }
+    let(:zip_file) { fixture_file_upload('proforma_import/testfile_multi.zip', 'application/zip') }
     let(:data) { ProformaService::CacheImportFile.call(user: user, zip_file: zip_file) }
     let(:import_data) { data.first }
 


### PR DESCRIPTION
There were a few deprecation warnings:
- `DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: tasks/_export_actions.html.slim`
- ``Please modify the call from
`fixture_file_upload("files/proforma_import/testfile.zip")` to `fixture_file_upload("proforma_import/testfile.zip")`.
``