### PR TITLE
Fix unused xml_id for files

### DIFF
--- a/app/assets/stylesheets/exercises.scss
+++ b/app/assets/stylesheets/exercises.scss
@@ -44,7 +44,7 @@ $exercise-color: #006600;
   margin-left: 0;
 }
 
-.files, .nested_fields {
+.files, .tests, .model_solutions, .nested_fields {
   .exercise-show.show-table {
     margin-bottom: 12px;
   }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -191,7 +191,7 @@ class TasksController < ApplicationController
   end
 
   def file_params
-    %i[id content attachment path name internal_description mime_type use_attached_file used_by_grader visible usage_by_lms _destroy]
+    %i[id content attachment path name internal_description mime_type use_attached_file used_by_grader visible usage_by_lms xml_id _destroy]
   end
 
   def test_params

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -83,6 +83,10 @@ class Task < ApplicationRecord
     (average_rating * 2).round / 2.0
   end
 
+  def all_files
+    (files + tests.map(&:files) + model_solutions.map(&:files)).flatten
+  end
+
   private
 
   def duplicate_tests

--- a/app/models/task_file.rb
+++ b/app/models/task_file.rb
@@ -6,6 +6,8 @@ class TaskFile < ApplicationRecord
   has_one_attached :attachment
   validates :name, presence: true
   validates :attachment, presence: true, if: -> { use_attached_file == 'true' }, on: :force_validations
+  validates :xml_id, presence: true
+  validates :xml_id, uniqueness: {scope: [:fileable_id, :fileable_type]}
 
   attr_accessor :use_attached_file, :file_marked_for_deletion
 

--- a/app/models/task_file.rb
+++ b/app/models/task_file.rb
@@ -7,7 +7,7 @@ class TaskFile < ApplicationRecord
   validates :name, presence: true
   validates :attachment, presence: true, if: -> { use_attached_file == 'true' }, on: :force_validations
   validates :xml_id, presence: true
-  validates :xml_id, uniqueness: {scope: [:fileable_id, :fileable_type]}
+  validates :xml_id, uniqueness: {scope: %i[fileable_id fileable_type]}
 
   attr_accessor :use_attached_file, :file_marked_for_deletion
 

--- a/app/services/proforma_service/convert_task_to_proforma_task.rb
+++ b/app/services/proforma_service/convert_task_to_proforma_task.rb
@@ -70,7 +70,7 @@ module ProformaService
 
     def task_file(file)
       task_file = Proforma::TaskFile.new(
-        id: file.xml_id || file.id,
+        id: file.xml_id,
         filename: file.full_file_name,
         used_by_grader: file.used_by_grader || false,
         visible: file.visible,

--- a/app/services/proforma_service/convert_task_to_proforma_task.rb
+++ b/app/services/proforma_service/convert_task_to_proforma_task.rb
@@ -70,7 +70,7 @@ module ProformaService
 
     def task_file(file)
       task_file = Proforma::TaskFile.new(
-        id: file.id,
+        id: file.xml_id || file.id,
         filename: file.full_file_name,
         used_by_grader: file.used_by_grader || false,
         visible: file.visible,

--- a/app/views/tasks/_file_form.html.slim
+++ b/app/views/tasks/_file_form.html.slim
@@ -9,7 +9,7 @@
   = file.text_area :internal_description, class:'form-control'
 .field-element
   = file.label :xml_id, t('tasks.tests.xml_id'), class: 'form-label'
-  = file.text_field :xml_id, class: 'form-control', value: file.object.xml_id.presence || '__nested_field_for_replace_with_index__'
+  = file.text_field :xml_id, class: 'form-control', value: file.object.xml_id.presence || nested_form_placeholder
 
 .field-element
   = render 'file_config', file: file

--- a/app/views/tasks/_file_form.html.slim
+++ b/app/views/tasks/_file_form.html.slim
@@ -8,6 +8,10 @@
   = file.label :internal_description, t('tasks.files.internal_description'), class:'form-label'
   = file.text_area :internal_description, class:'form-control'
 .field-element
+  = file.label :xml_id, t('tasks.tests.xml_id'), class: 'form-label'
+  = file.text_field :xml_id, class: 'form-control', value: file.object.xml_id.presence || '__nested_field_for_replace_with_index__'
+
+.field-element
   = render 'file_config', file: file
 .field-element
   = render 'editor', f: f, file: file

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -85,7 +85,7 @@
         = t('tasks.files.label') + ' '
         span.fa.fa-caret-up
       .form-content
-        = render 'nested_file_form', f: f
+        = render 'nested_file_form', f: f, nested_form_placeholder: 'f-__nested_field_for_replace_with_index__'
         /.field-element
           = f.nested_fields_for :files, style: 'margin-left: 10px' do |file|
             .show-table.exercise-show

--- a/app/views/tasks/_model_solution_form.html.slim
+++ b/app/views/tasks/_model_solution_form.html.slim
@@ -9,7 +9,7 @@
   = model_solution.text_field :xml_id, class: 'form-control', value: model_solution.object.xml_id.presence || '__nested_field_for_replace_with_index__'
 .files-header
   = label_tag nil, t('tasks.files.label') + ':'
-= render 'nested_file_form', f: model_solution
+= render 'nested_file_form', f: model_solution, nested_form_placeholder: 'ms-__nested_field_for_replace_with_index__-__task_model_solutions___nested_field_for_replace_with_index___files_index__'
 
 / .show-table.exercise-show
   = test.nested_fields_for :files, style: 'margin-left: 10px' do |file|

--- a/app/views/tasks/_nested_file_form.html.slim
+++ b/app/views/tasks/_nested_file_form.html.slim
@@ -17,7 +17,7 @@
             i.fa.fa-remove style=("color: #800000")
             = ' ' + t('tasks.form.files.remove')
       .file-container style="margin-left: 10px; #{display_container}"
-        = render 'file_form', f: f, file: file
+        = render 'file_form', f: f, file: file, nested_form_placeholder: nested_form_placeholder
   = f.add_nested_fields_link :files, ' ', class:'btn btn-main', id: 'addFileButton' do
     i.fa.fa-plus style=("color: #008000")
     = ' ' + t('tasks.form.files.add')

--- a/app/views/tasks/_test_form.html.slim
+++ b/app/views/tasks/_test_form.html.slim
@@ -22,7 +22,7 @@
   / = test.fields_for :file do |file|
 .files-header
   = label_tag nil, t('tasks.files.label') + ':'
-= render 'nested_file_form', f: test
+= render 'nested_file_form', f: test, nested_form_placeholder: 't-__nested_field_for_replace_with_index__-__task_tests___nested_field_for_replace_with_index___files_index__'
 
 / .show-table.exercise-show
   = test.nested_fields_for :files, style: 'margin-left: 10px' do |file|

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -216,13 +216,12 @@ legend.toggle-next
             | :
           .row-value
             = file.internal_description
-        - if @task.meta_data.present? && file.xml_id.present?
-          .row
-            .row-label
-              = t('tasks.files.xml_id')
-              | :
-            .row-value
-              = file.xml_id
+        .row
+          .row-label
+            = t('tasks.files.xml_id')
+            | :
+          .row-value
+            = file.xml_id
 
         - if !file.attachment.present?
           .row
@@ -363,7 +362,12 @@ legend.toggle-next
                     | :
                   .row-value
                     = file.internal_description
-
+                .row
+                  .row-label
+                    = t('tasks.files.xml_id')
+                    | :
+                  .row-value
+                    = file.xml_id
                 - if !file.attachment.present?
                   .row
                     .editor.readonly data-file-name="#{file.name}"
@@ -461,7 +465,12 @@ legend.toggle-next
                     | :
                   .row-value
                     = file.internal_description
-
+                .row
+                  .row-label
+                    = t('tasks.files.xml_id')
+                    | :
+                  .row-value
+                    = file.xml_id
                 - if !file.attachment.present?
                   .row
                     .editor.readonly data-file-name="#{file.name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1126,6 +1126,9 @@ en:
     edit:
       toggle_file: "Toggle file upload/editor"
       upload_a_new_file: "Upload a new file"
+  task_files:
+    xml_id_not_unique: id is not unique
+    fileable_not_set: "is not set"
 
 
 

--- a/db/migrate/20230110212941_populate_task_file_xml_ids.rb
+++ b/db/migrate/20230110212941_populate_task_file_xml_ids.rb
@@ -1,0 +1,9 @@
+class PopulateTaskFileXmlIds < ActiveRecord::Migration[6.1]
+  def up
+    Task.all.each do |task|
+      task.all_files.each_with_index do |file, index|
+        file.update_attribute(:xml_id, index)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_09_202113) do
+ActiveRecord::Schema.define(version: 2023_01_10_212941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -89,6 +89,7 @@ TaskFile.create!(
   visible: 'yes',
   usage_by_lms: 'edit',
   fileable: task1,
+  xml_id: '0',
   content: <<~JAVA)
     public class HelloWorld {
       public static void main (String[] args) {
@@ -113,6 +114,7 @@ TaskFile.create!(
   visible: 'no',
   usage_by_lms: 'display',
   fileable: task1_test1,
+  xml_id: '1',
   content: <<~JAVA)
     import org.junit.jupiter.api.*;
     import java.io.*;
@@ -162,6 +164,7 @@ TaskFile.create!(
   visible: 'delayed',
   usage_by_lms: 'display',
   fileable: task1_solution1,
+  xml_id: '2',
   content: <<~JAVA)
     public class HelloWorld {
       public static void main (String[] args) {

--- a/spec/factories/task_files.rb
+++ b/spec/factories/task_files.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :task_file do
     name { 'name' }
+    sequence(:xml_id, &:to_s)
 
     trait :with_task do
       fileable { build(:task) }

--- a/spec/models/task_file_spec.rb
+++ b/spec/models/task_file_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe TaskFile do
   describe '#valid?' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to belong_to(:fileable) }
+    it { is_expected.to validate_presence_of(:xml_id) }
+    it { is_expected.to validate_uniqueness_of(:xml_id).scoped_to([:fileable_id, :fileable_type]) }
 
     context 'when use_attached_file is true' do
       subject { build(:task_file, :with_attachment, use_attached_file: 'true') }

--- a/spec/models/task_file_spec.rb
+++ b/spec/models/task_file_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe TaskFile do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to belong_to(:fileable) }
     it { is_expected.to validate_presence_of(:xml_id) }
-    it { is_expected.to validate_uniqueness_of(:xml_id).scoped_to([:fileable_id, :fileable_type]) }
+    it { is_expected.to validate_uniqueness_of(:xml_id).scoped_to(%i[fileable_id fileable_type]) }
 
     context 'when use_attached_file is true' do
       subject { build(:task_file, :with_attachment, use_attached_file: 'true') }

--- a/spec/models/task_file_spec.rb
+++ b/spec/models/task_file_spec.rb
@@ -52,10 +52,41 @@ RSpec.describe TaskFile do
   end
 
   describe '#valid?' do
+    subject { build(:task_file, :with_task) }
+
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to belong_to(:fileable) }
     it { is_expected.to validate_presence_of(:xml_id) }
-    it { is_expected.to validate_uniqueness_of(:xml_id).scoped_to(%i[fileable_id fileable_type]) }
+
+    context 'with task which has another file with the same xml_id' do
+      subject(:file) { task.files.first }
+
+      let(:task) { build(:task, files: [build(:task_file, xml_id: '1'), build(:task_file, xml_id: '1')]) }
+
+      it 'has correct error' do
+        file.validate
+        expect(file.errors.full_messages).to include "Xml #{I18n.t('task_files.xml_id_not_unique')}"
+      end
+    end
+
+    context 'with task which has a test with another file with the same xml_id' do
+      subject(:file) { task.files.first }
+
+      let(:task) { build(:task, files: [build(:task_file, xml_id: '1')], tests: [build(:test, files: [build(:task_file, xml_id: '1')])]) }
+
+      it 'has correct error' do
+        file.validate
+        expect(file.errors.full_messages).to include "Xml #{I18n.t('task_files.xml_id_not_unique')}"
+      end
+    end
+
+    context 'with task which has a test with another file with the another xml_id' do
+      subject(:file) { task.files.first }
+
+      let(:task) { build(:task, files: [build(:task_file, xml_id: '1')], tests: [build(:test, files: [build(:task_file, xml_id: '2')])]) }
+
+      it { is_expected.to be_valid }
+    end
 
     context 'when use_attached_file is true' do
       subject { build(:task_file, :with_attachment, use_attached_file: 'true') }

--- a/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
+++ b/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
@@ -126,6 +126,14 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
           )
         end
       end
+
+      context 'when file has a xml_id' do
+        let(:file) { build(:task_file, xml_id: 42) }
+
+        it 'creates a task-file with the correct attribute' do
+          expect(proforma_task.files.first).to have_attributes(id: '42')
+        end
+      end
     end
 
     context 'when task has model solution' do

--- a/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
+++ b/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
 
       it 'creates a task-file with the correct attributes' do
         expect(proforma_task.files.first).to have_attributes(
-          id: file.id,
+          id: file.xml_id,
           content: file.content,
           filename: file.full_file_name,
           used_by_grader: file.used_by_grader,
@@ -160,7 +160,7 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
 
         it 'creates a model-solution with one file with correct attributes' do
           expect(proforma_task.model_solutions.first.files.first).to have_attributes(
-            id: ms_file.id,
+            id: ms_file.xml_id,
             content: ms_file.content,
             filename: ms_file.full_file_name,
             used_by_grader: ms_file.used_by_grader,
@@ -210,7 +210,7 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
 
       it 'creates a test with one file with correct attributes' do
         expect(proforma_task.tests.first.files.first).to have_attributes(
-          id: test_file.id,
+          id: test_file.xml_id,
           content: test_file.content,
           filename: test_file.full_file_name,
           used_by_grader: test_file.used_by_grader,

--- a/spec/support/shared_examples/exporter.rb
+++ b/spec/support/shared_examples/exporter.rb
@@ -72,7 +72,7 @@ RSpec.shared_examples 'task node with file' do
   end
 
   it 'adds id-attribute to file node' do
-    expect(xml.xpath("/task/files/file[@id!='ms-placeholder-file']").attribute('id').value).to eql file.id.to_s
+    expect(xml.xpath("/task/files/file[@id!='ms-placeholder-file']").attribute('id').value).to eql file.xml_id
   end
 
   it 'adds used-by-grader-attribute to file node' do


### PR DESCRIPTION
xml_id was added to task_files
xml_id is now required for files (the same as tests and model_solutions already) and will be automatically filled out in the form with a default value

fixes #807 
helps #808

