### PR TITLE
Adding an admin panel for the labels

### DIFF
--- a/app/assets/javascripts/labels.coffee
+++ b/app/assets/javascripts/labels.coffee
@@ -1,5 +1,15 @@
+max_label_length = 15
+verify_label_name = (label_name) ->
+  if label_name == ''
+    return I18n.t('labels.cannot_be_empty');
+  if label_name.length > max_label_length
+    return I18n.t('labels.too_long');
+  return 'OK';
+
+root = exports ? this;
+root.verify_label_name = verify_label_name;
+
 ready = ->
-  max_label_length = 15
   default_label_color = "e4e4e4"
   default_label_font_color = "000000"
 
@@ -17,10 +27,17 @@ ready = ->
       dataType: 'json',
       data: (params) ->
         query = {
-          search: params.term,
+          search: {name_i_cont: params.term},
           page: params.page || 1
         }
         return query;
+
+      processResults: (data) ->
+        return {
+          pagination: data.pagination
+          results: data.results.map (l) -> {id: l.name, text: l.name, label_color: l.color, label_font_color: l.font_color}
+        };
+
     }
 
     templateSelection: (data, container) ->
@@ -57,7 +74,7 @@ ready = ->
       term = $.trim(params.term)
       selection = $('.labels-select2-tag').select2('data').map (element) -> element.id
 
-      if term == '' || term.length > max_label_length || selection.includes(term)
+      if verify_label_name(term) != 'OK' || selection.includes(term)
         return null;
 
       return {

--- a/app/assets/javascripts/labels.coffee.erb
+++ b/app/assets/javascripts/labels.coffee.erb
@@ -1,4 +1,4 @@
-max_label_length = 15
+max_label_length = <%= Label::MAX_LENGTH %>
 verify_label_name = (label_name) ->
   if label_name == ''
     return I18n.t('labels.cannot_be_empty');

--- a/app/assets/javascripts/labels_index.coffee
+++ b/app/assets/javascripts/labels_index.coffee
@@ -1,0 +1,183 @@
+class LabelsTable
+  constructor: (@table_container) ->
+    @more_labels_loadable = true;
+    @waiting_for_response = false;
+    @last_loaded_page = 0;
+    @sort_by_column = "id";
+    @sort_by_order = "asc";
+    @name_filter = "";
+    @selected_label_ids = [];
+    @loaded_labels = {};
+
+    @table_body = @table_container.find('tbody');
+    @delete_labels_button  = $('#delete-labels-button');
+    @merge_labels_button   = $('#merge-labels-button');
+    @merge_labels_input    = $('#merge-labels-input');
+    @recolor_labels_button = $('#change-label-color-button');
+    @recolor_labels_input  = $('#color-labels-input');
+    @name_filter_input     = $('#label-name-filter-input');
+
+    @table_container.find('.sort-by-id').on 'click', => @sort_button_clicked('id');
+    @table_container.find('.sort-by-name').on 'click', => @sort_button_clicked('name');
+    @table_container.find('.sort-by-created-at').on 'click', => @sort_button_clicked('created_at');
+    @table_container.on 'scroll', (event) => @load_more_rows_if_necessary();
+    @name_filter_input.on 'change', (event) => @update_name_filter();
+
+    @delete_labels_button.on 'click', => @delete_selected_labels();
+    @merge_labels_button.on 'click', => @merge_selected_labels();
+    @recolor_labels_button.on 'click', => @recolor_selected_labels();
+
+    @reload_table();
+
+  update_name_filter: () =>
+    @name_filter = @name_filter_input.val();
+    @reload_table();
+
+  reload_table: () =>
+    @table_body.find('tr').remove();
+    @loaded_labels = {};
+    @selected_label_ids = [];
+    @more_labels_loadable = true;
+    @waiting_for_response = false;
+    @last_loaded_page = 0;
+    @load_more_rows_if_necessary();
+
+  append_new_row: (id, color, font_color, name, created_at, used_by_tasks) =>
+    @loaded_labels[id] = {name: name, used_by_tasks: used_by_tasks};
+
+    label = $("<div></div>")
+      .addClass('task_label')
+      .attr('style', "background-color: #{'#' + color}; color: #{'#' + font_color};")
+      .text(name);
+
+    new_row = $('<tr></tr>')
+      .append( $('<td></td>').text(id) )
+      .append( $('<td></td>').append(label) )
+      .append( $('<td></td>').text(created_at) )
+      .append( $('<td></td>').text(used_by_tasks) )
+      .attr('label_id', id);
+
+    new_row.on 'click', (event) => @on_row_clicked(event);
+    @table_body.append(new_row);
+
+  load_more_rows_if_necessary: () =>
+    if @more_labels_loadable && @waiting_for_response == false && @table_container.get(0).clientHeight + @table_container.get(0).scrollTop > @table_container.get(0).scrollHeight * 0.8
+      @send_data_request();
+
+  send_data_request: () =>
+    $.ajax({
+      url: "/labels/search",
+      type: "get",
+      data: {
+        page: @last_loaded_page + 1
+        search: {s: @sort_by_column + " " + @sort_by_order, name_i_cont: @name_filter}
+      },
+      success: @handle_data_response
+    });
+    @waiting_for_response = true;
+
+  handle_data_response: (response) =>
+    @more_labels_loadable = response.pagination.more;
+    @last_loaded_page += 1;
+    @waiting_for_response = false;
+
+    for new_label in response.results
+      @append_new_row(new_label.id, new_label.color, new_label.font_color, new_label.name, new_label.created_at, new_label.used_by_tasks);
+
+    @load_more_rows_if_necessary();
+
+  on_row_clicked: (event) =>
+    label_id = parseInt($(event.currentTarget).attr("label_id"));
+
+    if @selected_label_ids.includes(label_id)
+      @selected_label_ids = @selected_label_ids.filter (id) -> id != label_id
+      $(event.currentTarget).removeClass('selected');
+    else
+      @selected_label_ids.push(label_id);
+      $(event.currentTarget).addClass('selected');
+
+    if @selected_label_ids.length == 0
+      @merge_labels_input.val("");
+    else
+      most_used_selected_label_id = @selected_label_ids.reduce (max_id, id) => if @loaded_labels[id].used_by_tasks > @loaded_labels[max_id].used_by_tasks then id else max_id;
+      @merge_labels_input.val(@loaded_labels[most_used_selected_label_id].name);
+
+    @delete_labels_button.attr("disabled", @selected_label_ids.length == 0);
+    @merge_labels_button.attr("disabled", @selected_label_ids.length == 0);
+    @recolor_labels_button.attr("disabled", @selected_label_ids.length == 0);
+
+  sort_button_clicked: (sort_by) =>
+    $('.sort-by-id, .sort-by-name, .sort-by-created-at')
+      .removeClass('table-header-sort-down')
+      .removeClass('table-header-sort-up');
+
+    @sort_by_column = sort_by;
+
+    if @sort_by_order == 'desc'
+      @sort_by_order = 'asc';
+      $(event.target).addClass('table-header-sort-down');
+    else
+      @sort_by_order = 'desc';
+      $(event.target).addClass('table-header-sort-up');
+    @reload_table();
+
+  delete_selected_labels: () =>
+    confirm_msg = I18n.t('labels.index.delete_confirmation').replace('{selected_labels_count}', @selected_label_ids.length);
+
+    if (confirm(confirm_msg))
+      $.ajax({
+        url: "/labels",
+        type: "delete",
+        data: {
+          label_ids: @selected_label_ids
+        },
+        success: (response) => @reload_table();
+      });
+
+  merge_selected_labels: () =>
+    new_label_name = @merge_labels_input.val();
+    verification = verify_label_name(new_label_name);
+    if verification != 'OK'
+      alert(verification);
+      return;
+
+    selected_labels_count = @selected_label_ids.length;
+    confirm_msg = I18n.t('labels.index.merge_confirmation')
+      .replace('{selected_labels_count}', @selected_label_ids.length)
+      .replace('{new_merged_name}', new_label_name);
+
+    if (confirm(confirm_msg))
+      $.ajax({
+        url: "/labels/merge",
+        type: "get",
+        data: {
+          label_ids: @selected_label_ids,
+          new_label_name: new_label_name
+        },
+        success: (response) => @reload_table();
+      });
+
+  recolor_selected_labels: () =>
+    matched_color = @recolor_labels_input.val().match(/^#?([0-9A-Fa-f]{6})$/);
+    if matched_color == null
+      return;
+    new_color = matched_color[1];
+
+    confirm_msg = I18n.t('labels.index.change_color_confirmation').replace('{selected_labels_count}', @selected_label_ids.length);
+
+    if (confirm(confirm_msg))
+      $.ajax({
+        url: "/labels/set_color",
+        type: "get",
+        data: {
+          label_ids: @selected_label_ids,
+          new_color: new_color
+        },
+        success: (response) => @reload_table();
+      });
+
+
+$(document).on 'turbolinks:load', () ->
+  table_container = $('.labels-table-container');
+  if table_container.length
+    table = new LabelsTable(table_container);

--- a/app/assets/javascripts/labels_index.coffee
+++ b/app/assets/javascripts/labels_index.coffee
@@ -29,6 +29,11 @@ class LabelsTable
 
     @reload_table();
 
+  update_buttons: () =>
+    @delete_labels_button.attr("disabled", @selected_label_ids.length == 0);
+    @merge_labels_button.attr("disabled", @selected_label_ids.length == 0);
+    @recolor_labels_button.attr("disabled", @selected_label_ids.length == 0);
+
   update_name_filter: () =>
     @name_filter = @name_filter_input.val();
     @reload_table();
@@ -40,6 +45,7 @@ class LabelsTable
     @more_labels_loadable = true;
     @waiting_for_response = false;
     @last_loaded_page = 0;
+    @update_buttons();
     @load_more_rows_if_necessary();
 
   append_new_row: (id, color, font_color, name, created_at, used_by_tasks) =>
@@ -103,9 +109,7 @@ class LabelsTable
       most_used_selected_label_id = @selected_label_ids.reduce (max_id, id) => if @loaded_labels[id].used_by_tasks > @loaded_labels[max_id].used_by_tasks then id else max_id;
       @merge_labels_input.val(@loaded_labels[most_used_selected_label_id].name);
 
-    @delete_labels_button.attr("disabled", @selected_label_ids.length == 0);
-    @merge_labels_button.attr("disabled", @selected_label_ids.length == 0);
-    @recolor_labels_button.attr("disabled", @selected_label_ids.length == 0);
+    @update_buttons();
 
   sort_button_clicked: (sort_by) =>
     $('.sort-by-id, .sort-by-name, .sort-by-created-at')
@@ -170,8 +174,7 @@ class LabelsTable
             data: { color: new_color }
           })
         );
-      $.when.apply($, requests).then( () => @reload_table() );
-
+      $.when.apply($, requests).then(@reload_table);
 
 $(document).on 'turbolinks:load', () ->
   table_container = $('.labels-table-container');

--- a/app/assets/stylesheets/labels.scss
+++ b/app/assets/stylesheets/labels.scss
@@ -3,3 +3,36 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .ui-helper-hidden-accessible { position: absolute; left: -9999px; }
+
+
+.labels-table-container {
+  overflow-y: scroll;
+  height: 60vh;
+}
+
+.labels-table tbody tr.selected {
+  background: #0086b3;
+}
+
+.table-header-sort-down:after,
+.table-header-sort-up:after {
+  content: ' ';
+  position: relative;
+  left: 2px;
+  border: 8px solid transparent;
+}
+
+.table-header-sort-down:after {
+  top: 10px;
+  border-top-color: silver;
+}
+
+.table-header-sort-up:after {
+  bottom: 15px;
+  border-bottom-color: silver;
+}
+
+#color-labels-input {
+  padding: 3px;
+  margin: 1px;
+}

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -7,50 +7,38 @@ class LabelsController < ApplicationController
     redirect_to root_path, alert: t('controllers.authorization')
   end
 
-  def index
-    @search = {}
+  def index; end
+
+  def update
+    @label.update(params.permit(:color))
+  end
+
+  def destroy
+    @label.destroy
   end
 
   def merge
     label_ids = params[:label_ids]
-    new_name = params[:new_label_name]
 
-    if new_name.length.positive? && new_name.length < 15
-      new_label = Label.create(name: new_name)
-      new_label.tasks = Task.where(id: TaskLabel.select(:task_id).where(label_id: label_ids).distinct)
-      Label.where(id: label_ids).destroy_all
-    else
-      head :bad_request
+    ApplicationRecord.transaction do
+      Label.find(label_ids.first).update!(
+        name: params[:new_label_name],
+        tasks: Task.where(id: TaskLabel.select(:task_id).where(label_id: label_ids))
+      )
+      Label.destroy(label_ids[1..])
+    rescue StandardError => e
+      render json: e, status: :unprocessable_entity
+      raise ActiveRecord::Rollback
     end
   end
 
-  def set_color
-    new_color = params[:new_color]
-    if /^[0-9a-fA-F]{6}$/.match?(new_color)
-      updates = params[:label_ids].map { {'color' => new_color} }
-      Label.update(params[:label_ids], updates)
-    else
-      head :bad_request
-    end
-  end
-
-  def destroy
-    Label.where(id: params[:label_ids]).destroy_all
-  end
-
-  def search # rubocop:disable Metrics/AbcSize
+  def search
     paginated = Label.ransack(params[:search]).result.paginate(per_page: 3, page: params[:page])
 
-    render json: {
-      results: paginated.map do |l|
-        l.attributes.merge(
-          font_color: l.font_color,
-          used_by_tasks: l.tasks.count,
-          created_at: l.created_at.to_fs(:rfc822),
-          updated_at: l.updated_at.to_fs(:rfc822)
-        )
-      end,
-      pagination: {more: paginated.next_page.present?},
-    }
+    if current_user.role == 'admin' && params[:more_info]
+      paginated = paginated.includes(:tasks)
+    end
+
+    render json: {results: paginated.map(&:to_h), pagination: {more: paginated.next_page.present?}}
   end
 end

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -2,12 +2,54 @@
 
 class LabelsController < ApplicationController
   load_and_authorize_resource
-  def search
-    results = Label.ransack(name_i_cont: params[:search]).result
-    paginated = results.paginate(per_page: 3, page: params[:page])
+
+  rescue_from CanCan::AccessDenied do |_exception|
+    redirect_to root_path, alert: t('controllers.authorization')
+  end
+
+  def index
+    @search = {}
+  end
+
+  def merge
+    label_ids = params[:label_ids]
+    new_name = params[:new_label_name]
+
+    if new_name.length.positive? && new_name.length < 15
+      new_label = Label.create(name: new_name)
+      new_label.tasks = Task.where(id: TaskLabel.select(:task_id).where(label_id: label_ids).distinct)
+      Label.where(id: label_ids).destroy_all
+    else
+      head :bad_request
+    end
+  end
+
+  def set_color
+    new_color = params[:new_color]
+    if /^[0-9a-fA-F]{6}$/.match?(new_color)
+      updates = params[:label_ids].map { {'color' => new_color} }
+      Label.update(params[:label_ids], updates)
+    else
+      head :bad_request
+    end
+  end
+
+  def destroy
+    Label.where(id: params[:label_ids]).destroy_all
+  end
+
+  def search # rubocop:disable Metrics/AbcSize
+    paginated = Label.ransack(params[:search]).result.paginate(per_page: 3, page: params[:page])
 
     render json: {
-      results: paginated.map {|l| {id: l.name, text: l.name, label_color: l.color, label_font_color: l.font_color} },
+      results: paginated.map do |l|
+        l.attributes.merge(
+          font_color: l.font_color,
+          used_by_tasks: l.tasks.count,
+          created_at: l.created_at.to_fs(:rfc822),
+          updated_at: l.updated_at.to_fs(:rfc822)
+        )
+      end,
       pagination: {more: paginated.next_page.present?},
     }
   end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -62,4 +62,8 @@ class Label < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[name]
   end
+
+  def self.ransortable_attributes(_auth_object = nil)
+    %w[id name created_at]
+  end
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -5,7 +5,7 @@ class Label < ApplicationRecord
   has_many :tasks, through: :task_labels
 
   MAX_LENGTH = 15
-  validates :name, presence: true, length: {minimum: 1, maximum: MAX_LENGTH}
+  validates :name, presence: true, length: {minimum: 1, maximum: MAX_LENGTH}, uniqueness: {case_sensitive: false}
   validates :color, presence: true, format: {with: /\A[a-fA-F0-9]{6}\z/}
 
   before_validation :choose_label_color, if: -> { color.blank? }
@@ -66,10 +66,10 @@ class Label < ApplicationRecord
       name:,
       color:,
       font_color:,
-      used_by_tasks: tasks.loaded? ? tasks.size : 0,
+      used_by_tasks: (tasks.size if tasks.loaded?),
       created_at: created_at.to_fs(:rfc822),
       updated_at: updated_at.to_fs(:rfc822),
-    }
+    }.compact
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -4,7 +4,8 @@ class Label < ApplicationRecord
   has_many :task_labels, dependent: :destroy
   has_many :tasks, through: :task_labels
 
-  validates :name, presence: true
+  MAX_LENGTH = 15
+  validates :name, presence: true, length: {minimum: 1, maximum: MAX_LENGTH}
   validates :color, presence: true, format: {with: /\A[a-fA-F0-9]{6}\z/}
 
   before_validation :choose_label_color, if: -> { color.blank? }
@@ -58,6 +59,18 @@ class Label < ApplicationRecord
     483c46 3c6e71 70ae6e beee62 f4743b
     c33c54 254e70 37718e 8ee3ef aef3e7
   ].freeze
+
+  def to_h
+    {
+      id:,
+      name:,
+      color:,
+      font_color:,
+      used_by_tasks: tasks.loaded? ? tasks.size : 0,
+      created_at: created_at.to_fs(:rfc822),
+      updated_at: updated_at.to_fs(:rfc822),
+    }
+  end
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name]

--- a/app/views/labels/index.html.slim
+++ b/app/views/labels/index.html.slim
@@ -1,0 +1,30 @@
+.container[style="padding: 0px;"]
+  div.col-md-7
+    input.form-control[id="label-name-filter-input" type="text" placeholder="Filter By Name"]
+    br
+    .div.labels-table-container
+      table.table.table-bordered.table-striped.labels-table
+        thead
+          tr
+            th.sort-by-id.table-header-sort-down[style='width: 10%;'] ID
+            th.sort-by-name[style='width: 30%;'] Name
+            th.sort-by-created-at[style='width: 40%;'] Created At
+            th[style='width: 20%;'] Used By Tasks
+        tbody
+    br
+
+  .container.col-md-5
+    div
+      .input-group
+        span.input-group-btn
+          = button_tag t('labels.index.merge'), type: 'button', id: 'merge-labels-button', disabled: true, class: 'btn btn-primary'
+        input.form-control[id="merge-labels-input" type="text" placeholder="New Name"]
+
+    .div[style='margin-top: 10px;']
+      .input-group
+        span.input-group-btn
+          = button_tag t('labels.index.change_color_to'), id: 'change-label-color-button', disabled: true, class: 'btn btn-primary'
+        input.form-control[id="color-labels-input" type="color" value="#000000"]
+
+    .div[style='margin-top: 10px;']
+      = button_tag t('labels.index.delete'), id: 'delete-labels-button', disabled: true, class: 'btn btn-danger'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -832,9 +832,9 @@ en:
       merge: 'Merge And Rename To'
       delete: 'Delete selected'
       change_color_to: 'Change Color To'
-      delete_confirmation: 'This will delete the {selected_labels_count} selected label(s).'
-      merge_confirmation: 'This will merge the {selected_labels_count} selected label(s) and rename them to "{new_merged_name}"'
-      change_color_confirmation: 'This will change the color of the {selected_labels_count} selected label(s).'
+      delete_confirmation: 'This will delete the %{selected_labels_count} selected label(s).'
+      merge_confirmation: 'This will merge the %{selected_labels_count} selected label(s) and rename them to "%{new_merged_name}"'
+      change_color_confirmation: 'This will change the color of the %{selected_labels_count} selected label(s).'
     errorMessage: "prohibited this label from being saved."
 
   layouts:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -820,8 +820,8 @@ en:
       back: "Back"
       #submit:
     can_only_create_5: 'You can only add 5 labels'
-    too_long: 'The entered label name is too long'
-    cannot_be_empty: 'The entered label name is empty'
+    too_long: 'The label name entered is too long'
+    cannot_be_empty: 'The label name entered is empty'
 
     edit:
       header: "Editing Label"
@@ -829,12 +829,12 @@ en:
       header: "New Label"
       selection_suffix: " (new)"
     index:
-      merge: 'Merge And Rename To'
+      merge: 'Merge and Rename to'
       delete: 'Delete selected'
-      change_color_to: 'Change Color To'
-      delete_confirmation: 'This will delete the %{selected_labels_count} selected label(s).'
-      merge_confirmation: 'This will merge the %{selected_labels_count} selected label(s) and rename them to "%{new_merged_name}"'
-      change_color_confirmation: 'This will change the color of the %{selected_labels_count} selected label(s).'
+      change_color_to: 'Change Color to'
+      delete_confirmation: 'This will delete the %{selected_labels_count} label(s) selected.'
+      merge_confirmation: 'This will merge the %{selected_labels_count} label(s) selected and rename them to "%{new_merged_name}"'
+      change_color_confirmation: 'This will change the color of the %{selected_labels_count} label(s) selected.'
     errorMessage: "prohibited this label from being saved."
 
   layouts:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -820,12 +820,21 @@ en:
       back: "Back"
       #submit:
     can_only_create_5: 'You can only add 5 labels'
+    too_long: 'The entered label name is too long'
+    cannot_be_empty: 'The entered label name is empty'
 
     edit:
       header: "Editing Label"
     new:
       header: "New Label"
       selection_suffix: " (new)"
+    index:
+      merge: 'Merge And Rename To'
+      delete: 'Delete selected'
+      change_color_to: 'Change Color To'
+      delete_confirmation: 'This will delete the {selected_labels_count} selected label(s).'
+      merge_confirmation: 'This will merge the {selected_labels_count} selected label(s) and rename them to "{new_merged_name}"'
+      change_color_confirmation: 'This will change the color of the {selected_labels_count} selected label(s).'
     errorMessage: "prohibited this label from being saved."
 
   layouts:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,13 +60,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :labels, only: %i[index] do
+  resources :labels, only: %i[index update destroy] do
     collection do
       get :search
-      get :list
-      get :merge
-      get :set_color
-      delete :destroy
+      post :merge
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,8 +60,14 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :labels, only: [] do
-    get :search, on: :collection
+  resources :labels, only: %i[index] do
+    collection do
+      get :search
+      get :list
+      get :merge
+      get :set_color
+      delete :destroy
+    end
   end
 
   resources :task_files, only: [] do

--- a/spec/controllers/labels_controller_spec.rb
+++ b/spec/controllers/labels_controller_spec.rb
@@ -6,10 +6,13 @@ RSpec.describe LabelsController do
   render_views
 
   let(:user) { create(:user) }
-  let(:label) { create(:label) }
+  let(:label) { create(:label, name: 'example label', color: 'ffffff') }
+  let(:params) { {search: {name_i_cont: label.name}, page: 1} }
+
+  before { create(:task, labels: [label]) }
 
   describe 'GET #search' do
-    subject(:get_request) { get :search, params: {search: {name_i_cont: label.name}, page: 1} }
+    subject(:get_request) { get :search, params: }
 
     context 'without being signed in' do
       it 'redirects to other page' do
@@ -19,29 +22,109 @@ RSpec.describe LabelsController do
       end
     end
 
-    context 'with valid params' do
-      before { sign_in user }
-
-      it 'returns valid json' do
+    shared_examples 'json without tasks count' do
+      it 'returns valid json without tasks count' do
         get_request
         expect(JSON.parse(response.body, symbolize_names: true)).to eql(
           {
             pagination: {more: false},
-            results: [
-              label.attributes.merge(
-                font_color: label.font_color,
-                used_by_tasks: label.tasks.count,
-                created_at: label.created_at.to_fs(:rfc822), # LabelsController#search changes the time format to rfc822 before returning the labels
-                updated_at: label.updated_at.to_fs(:rfc822)
-              ).symbolize_keys!,
-            ],
+            results: [{
+              id: label.id,
+              name: 'example label',
+              color: 'ffffff',
+              font_color: '000000',
+              used_by_tasks: 0,
+              created_at: label.created_at.to_fs(:rfc822),
+              updated_at: label.updated_at.to_fs(:rfc822),
+            }],
           }
         )
       end
+    end
 
-      it 'returns response containing label' do
-        get_request
-        expect(response.parsed_body['results']).to include(a_hash_including('name' => label.name))
+    context 'when signed in as normal user' do
+      before { sign_in user }
+
+      context 'without requesting more info' do
+        include_examples 'json without tasks count'
+      end
+
+      context 'when requesting more info' do
+        subject(:get_request) { get :search, params: params.merge(more_info: true) }
+
+        include_examples 'json without tasks count'
+      end
+    end
+
+    context 'when signed in as admin' do
+      let(:admin) { create(:admin) }
+
+      before { sign_in admin }
+
+      context 'when not requesting more info' do
+        include_examples 'json without tasks count'
+      end
+
+      context 'when requesting more info' do
+        subject(:get_request) { get :search, params: params.merge(more_info: true) }
+
+        it 'returns valid json with more info' do
+          get_request
+          expect(JSON.parse(response.body, symbolize_names: true)).to eql(
+            {
+              pagination: {more: false},
+              results: [{
+                id: label.id,
+                name: 'example label',
+                color: 'ffffff',
+                font_color: '000000',
+                used_by_tasks: 1,
+                created_at: label.created_at.to_fs(:rfc822),
+                updated_at: label.updated_at.to_fs(:rfc822),
+              }],
+            }
+          )
+        end
+      end
+    end
+  end
+
+  describe 'GET #merge' do
+    subject(:merge_request) { get :merge, params: {label_ids:, new_name:} }
+
+    let!(:labels) { create_list(:label, 5) }
+    let(:label_ids) { labels[1..3].map(&:id) }
+    let(:new_name) { 'some new name' }
+
+    context 'without being signed in' do
+      it 'redirects to other page' do
+        merge_request
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
+    context 'when signed in as admin' do
+      let(:admin) { create(:admin) }
+
+      before { sign_in admin }
+
+      context 'with invalid new label name' do
+        let(:new_name) { '' }
+
+        it 'returns error' do
+          merge_request
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'with no labels to merge' do
+        let(:label_ids) { [] }
+
+        it 'returns error' do
+          merge_request
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
       end
     end
   end

--- a/spec/controllers/labels_controller_spec.rb
+++ b/spec/controllers/labels_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe LabelsController do
       end
     end
 
-    shared_examples 'json without tasks count' do
+    shared_examples 'json without the number of referrencing tasks' do
       it 'returns valid json without tasks count' do
         get_request
         expect(JSON.parse(response.body, symbolize_names: true)).to eql(
@@ -33,7 +33,6 @@ RSpec.describe LabelsController do
               name: 'example label',
               color: 'ffffff',
               font_color: '000000',
-              used_by_tasks: 0,
               created_at: label.created_at.to_fs(:rfc822),
               updated_at: label.updated_at.to_fs(:rfc822),
             }],
@@ -46,13 +45,13 @@ RSpec.describe LabelsController do
       before { sign_in user }
 
       context 'without requesting more info' do
-        include_examples 'json without tasks count'
+        include_examples 'json without the number of referrencing tasks'
       end
 
       context 'when requesting more info' do
         subject(:get_request) { get :search, params: params.merge(more_info: true) }
 
-        include_examples 'json without tasks count'
+        include_examples 'json without the number of referrencing tasks'
       end
     end
 
@@ -62,13 +61,13 @@ RSpec.describe LabelsController do
       before { sign_in admin }
 
       context 'when not requesting more info' do
-        include_examples 'json without tasks count'
+        include_examples 'json without the number of referrencing tasks'
       end
 
       context 'when requesting more info' do
         subject(:get_request) { get :search, params: params.merge(more_info: true) }
 
-        it 'returns valid json with more info' do
+        it 'returns a valid json with more info' do
           get_request
           expect(JSON.parse(response.body, symbolize_names: true)).to eql(
             {
@@ -90,14 +89,14 @@ RSpec.describe LabelsController do
   end
 
   describe 'GET #merge' do
-    subject(:merge_request) { get :merge, params: {label_ids:, new_name:} }
+    subject(:merge_request) { post :merge, params: {new_label_name:, label_ids: selected_labels.map(&:id)} }
 
     let!(:labels) { create_list(:label, 5) }
-    let(:label_ids) { labels[1..3].map(&:id) }
-    let(:new_name) { 'some new name' }
+    let(:selected_labels) { labels[1..3] }
+    let(:new_label_name) { 'some new name' }
 
     context 'without being signed in' do
-      it 'redirects to other page' do
+      it 'redirects to another page' do
         merge_request
         expect(response).to have_http_status(:redirect)
         expect(response).to redirect_to(root_url)
@@ -109,21 +108,46 @@ RSpec.describe LabelsController do
 
       before { sign_in admin }
 
-      context 'with invalid new label name' do
-        let(:new_name) { '' }
-
+      shared_examples 'error and flash message' do
         it 'returns error' do
           merge_request
           expect(response).to have_http_status(:unprocessable_entity)
         end
+
+        it 'sets flash message' do
+          expect { merge_request }.to change { flash[:alert] }
+        end
+      end
+
+      context 'with an invalid new label name' do
+        let(:new_label_name) { '' }
+
+        include_examples 'error and flash message'
+      end
+
+      context 'with an already existing new label name' do
+        let(:selected_labels) { labels[1..3] }
+        let(:new_label_name) { labels.first.name }
+
+        include_examples 'error and flash message'
       end
 
       context 'with no labels to merge' do
-        let(:label_ids) { [] }
+        let(:selected_labels) { [] }
 
-        it 'returns error' do
+        include_examples 'error and flash message'
+      end
+
+      context 'when the new label name is one of the selected labels except the first' do
+        let(:new_label_name) { selected_labels.second.name }
+
+        it 'renames the first label correctly' do
+          expect { merge_request }.to change { selected_labels.first.reload.name }.to(new_label_name)
+        end
+
+        it 'detroys the other labels' do
           merge_request
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(Label.where(id: selected_labels[1..].map(&:id))).not_to exist
         end
       end
     end

--- a/spec/features/labels_controller_spec.rb
+++ b/spec/features/labels_controller_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'LabelsController', js: true do
+  let(:admin) { create(:admin) }
+  let(:password) { attributes_for(:admin)[:password] }
+
+  before do
+    sign_in_with_js_driver(admin, password)
+  end
+
+  describe '#index' do
+    context 'when using name filter' do
+      let!(:matching_labels) { [create(:label, name: 'Loops'), create(:label, name: 'Java loops')] }
+      let!(:not_matching_labels) { [create(:label, name: 'label1'), create(:label, name: 'python for loop')] }
+
+      it 'filters by name correctly' do
+        visit(labels_path)
+        fill_in id: 'label-name-filter-input', with: 'loops'
+        find('input', id: 'label-name-filter-input').send_keys(:enter)
+        wait_for_ajax
+        matching_labels.each {|label| expect(page).to have_selector('.labels-table > tbody > tr > td > .task_label', text: label.name) }
+        not_matching_labels.each {|label| expect(page).not_to have_selector('.labels-table > tbody > tr > td > .task_label', text: label.name) }
+      end
+    end
+
+    context 'when merging labels' do
+      let!(:labels) { create_list(:label, 5) }
+      let(:new_name) { 'new label name' }
+
+      context 'when only renaming one label' do
+        subject(:renaming_action) do
+          visit(labels_path)
+          wait_for_ajax
+          find('.labels-table > tbody > tr > td > .task_label', text: labels[1].name).click
+          fill_in('merge-labels-input', with: new_name)
+          accept_prompt do
+            click_button('merge-labels-button')
+          end
+          wait_for_ajax
+        end
+
+        it 'renames the label' do
+          renaming_action
+          expect(Label.find_by(name: new_name)).not_to be_nil
+        end
+
+        it 'does not change the number of labels' do
+          expect { renaming_action }.not_to change(Label, :count)
+        end
+      end
+
+      context 'when merging multiple labels' do
+        subject(:merge_action) do
+          visit(labels_path)
+          wait_for_ajax
+          find('.labels-table > tbody > tr > td > .task_label', text: labels[1].name).click
+          find('.labels-table > tbody > tr > td > .task_label', text: labels[2].name).click
+          fill_in('merge-labels-input', with: new_name)
+          accept_prompt do
+            click_button('merge-labels-button')
+          end
+          wait_for_ajax
+        end
+
+        let!(:task) { create(:task, labels: labels[1..3]) }
+
+        before { merge_action }
+
+        it 'deletes the old labels' do
+          expect(Label.all).not_to include labels[1], labels[2]
+        end
+
+        it 'creates the new label' do
+          expect(Label.find_by(name: new_name)).not_to be_nil
+        end
+
+        it 'updates the tasks' do
+          expect(task.reload.labels).not_to include labels[1], labels[2]
+          expect(task.reload.label_names).to include new_name
+        end
+      end
+    end
+
+    context 'when deleting labels' do
+      subject(:deletion_action) do
+        visit(labels_path)
+        wait_for_ajax
+        find('.labels-table > tbody > tr > td > .task_label', text: labels[1].name).click
+        accept_prompt do
+          click_button('delete-labels-button')
+        end
+        wait_for_ajax
+      end
+
+      let!(:labels) { create_list(:label, 5) }
+      let!(:task) { create(:task, labels: labels[1..3]) }
+
+      it 'deletes the label' do
+        deletion_action
+        expect(Label.find_by(id: labels[1].id)).to be_nil
+      end
+
+      it 'removes the label from tasks' do
+        deletion_action
+        expect(task.reload.labels).not_to include labels[1]
+      end
+    end
+
+    context 'when recoloring labels' do
+      subject(:recolor_action) do
+        visit(labels_path)
+        wait_for_ajax
+        find('.labels-table > tbody > tr > td > .task_label', text: labels[1].name).click
+        find('.labels-table > tbody > tr > td > .task_label', text: labels[2].name).click
+        fill_in id: 'color-labels-input', with: '#000000'
+        accept_prompt do
+          click_button('change-label-color-button')
+        end
+        wait_for_ajax
+      end
+
+      let!(:labels) { create_list(:label, 5) }
+
+      it 'changes the color' do
+        recolor_action
+        expect(Label.find_by(id: labels[1].id).color).to eq '000000'
+        expect(Label.find_by(id: labels[2].id).color).to eq '000000'
+      end
+    end
+  end
+end

--- a/spec/features/labels_controller_spec.rb
+++ b/spec/features/labels_controller_spec.rb
@@ -11,7 +11,7 @@ describe 'LabelsController', js: true do
   end
 
   describe '#index' do
-    context 'when using name filter' do
+    context 'when using the name filter' do
       let!(:matching_labels) { [create(:label, name: 'Loops'), create(:label, name: 'Java loops')] }
       let!(:not_matching_labels) { [create(:label, name: 'label1'), create(:label, name: 'python for loop')] }
 
@@ -67,7 +67,7 @@ describe 'LabelsController', js: true do
         let!(:task) { create(:task, labels: labels[1..4]) }
         let(:merged_labels) { labels[1..2] }
 
-        it 'renames the first selected label' do
+        it 'renames the first label selected' do
           expect { merge_action }.to change { merged_labels.first.reload.name }.to new_name
         end
 


### PR DESCRIPTION
This adds an admin panel to manage the labels.
The admin panel and the select2 ajax requests now use the same LabelsController#search endpoint although the select2 does not need the additional information the admin panel uses. Maybe those should be separated into two endpoints?

For the tests I used feature specs because the admin panel has a lot of coffeescript code that I wanted to cover as well but I am not sure if its worth the increased test runtime. I tried to run the expensive "visit_page - clicking - form filling etc." logic just once per context to save some time but using "before(:all)" did not work with Capybara. The easiest solution would probably be to just merge all examples so there is only one example per context. What do you think?

This should also close #812 