### PR TITLE
Re-enabling testing frameworks for tests

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -219,7 +219,8 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def test_params
-    [:id, :title, :description, :internal_description, :test_type, :xml_id, :validity, :timeout, :_destroy, {files_attributes: file_params}]
+    [:id, :title, :testing_framework_id, :description, :internal_description, :test_type, :xml_id, :validity, :timeout, :_destroy,
+     {files_attributes: file_params}]
   end
 
   def model_solution_params

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -2,6 +2,7 @@
 
 class Test < ApplicationRecord
   belongs_to :task
+  belongs_to :testing_framework, optional: true
   has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy
   accepts_nested_attributes_for :files, allow_destroy: true
   validates :title, presence: true

--- a/app/models/testing_framework.rb
+++ b/app/models/testing_framework.rb
@@ -2,4 +2,8 @@
 
 class TestingFramework < ApplicationRecord
   has_many :tests, dependent: :restrict_with_error
+
+  def name_with_version
+    "#{name} #{version}"
+  end
 end

--- a/app/views/tasks/_test_form.html.slim
+++ b/app/views/tasks/_test_form.html.slim
@@ -2,6 +2,9 @@
   = test.label :title, t('tasks.tests.title'), class: 'form-label'
   = test.text_field :title, class: 'form-control'
 .field-element
+  = test.label :testing_framework, t('tasks.tests.framework'), class:'form-label'
+  = test.collection_select :testing_framework_id, TestingFramework.all, :id, :name_with_version, {include_blank: t('tasks.form.none')}, {class: 'form-control'}
+.field-element
   = test.label :description, t('tasks.tests.description'), class: 'form-label'
   = test.text_field :description, class: 'form-control'
 .field-element

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -291,6 +291,12 @@ legend.toggle-next
             = test.title
         .row
           .row-label
+            = t('tasks.tests.framework')
+            | :
+          .row-value
+            = test.testing_framework&.name_with_version  || t('tasks.form.none')
+        .row
+          .row-label
             = t('tasks.tests.description')
             | :
           .row-value

--- a/db/migrate/20230701105422_add_testing_framework_to_tests.rb
+++ b/db/migrate/20230701105422_add_testing_framework_to_tests.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTestingFrameworkToTests < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :tests, :testing_framework, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_01_095629) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_01_105422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -274,6 +274,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_095629) do
     t.string "timeout"
     t.bigint "task_id"
     t.jsonb "meta_data", default: {}
+    t.bigint "testing_framework_id"
+    t.index ["testing_framework_id"], name: "index_tests_on_testing_framework_id"
   end
 
   create_table "user_identities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -330,5 +332,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_095629) do
   add_foreign_key "task_labels", "tasks"
   add_foreign_key "tasks", "licenses"
   add_foreign_key "tests", "tasks"
+  add_foreign_key "tests", "testing_frameworks"
   add_foreign_key "user_identities", "users"
 end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -69,7 +69,7 @@ Label.create!(name: 'Data Structures', color: '3333CC')
 pl_java = ProgrammingLanguage.create!(language: 'Java', version: '17')
 pl_python = ProgrammingLanguage.create!(language: 'Python', version: '3.8')
 
-TestingFramework.create!(name: 'JUnit', version: '5')
+tf_junit = TestingFramework.create!(name: 'JUnit', version: '5')
 TestingFramework.create!(name: 'Pytest', version: '6')
 
 task1 = Task.create!(
@@ -114,7 +114,8 @@ task1_test1 = Test.create!(
   xml_id: '123456',
   validity: '1',
   timeout: '30',
-  task: task1
+  task: task1,
+  testing_framework: tf_junit
 )
 
 TaskFile.create!(

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -397,14 +397,14 @@ RSpec.describe TasksController do
 
       context 'when task has a test' do
         subject(:put_update) do
-          put :update, params: {id: task.to_param, task: changed_attributes.merge({'tests_attributes' => tests_attributes})}
+          put :update, params: {id: task.to_param, task: changed_attributes.merge(tests_attributes:)}
         end
 
         let(:test) { build(:test) }
         let(:new_testing_framework) { create(:testing_framework) }
         let!(:task) { create(:task, valid_attributes.merge(tests: [test])) }
 
-        let(:tests_attributes) { {'0' => test.attributes.merge('title' => 'new_test_title', 'testing_framework_id' => new_testing_framework.id)} }
+        let(:tests_attributes) { {'0': test.attributes.symbolize_keys.merge(title: 'new_test_title', testing_framework_id: new_testing_framework.id)} }
 
         it 'updates the requested task' do
           expect { put_update }.to change { task.reload.title }.to('new_title')

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -164,6 +164,16 @@ RSpec.describe TasksController do
         get_request
         expect(assigns(:tests)).to include(test)
       end
+
+      context 'when test has a framework' do
+        let(:testing_framework) { create(:testing_framework) }
+        let(:test) { create(:test, task:, testing_framework:) }
+
+        it "includes the frameworks's name and version in response" do
+          get_request
+          expect(response.body).to include(testing_framework.name_with_version)
+        end
+      end
     end
   end
 
@@ -391,16 +401,21 @@ RSpec.describe TasksController do
         end
 
         let(:test) { build(:test) }
+        let(:new_testing_framework) { create(:testing_framework) }
         let!(:task) { create(:task, valid_attributes.merge(tests: [test])) }
 
-        let(:tests_attributes) { {'0' => test.attributes.merge('title' => 'new_test_title')} }
+        let(:tests_attributes) { {'0' => test.attributes.merge('title' => 'new_test_title', 'testing_framework_id' => new_testing_framework.id)} }
 
         it 'updates the requested task' do
           expect { put_update }.to change { task.reload.title }.to('new_title')
         end
 
-        it 'updates the test' do
+        it "updates the test's title" do
           expect { put_update }.to change { task.tests.first.reload.title }.to('new_test_title')
+        end
+
+        it "updates the test's framework" do
+          expect { put_update }.to change { task.tests.first.reload.testing_framework }.to(new_testing_framework)
         end
       end
 

--- a/spec/factories/testing_framework.rb
+++ b/spec/factories/testing_framework.rb
@@ -2,7 +2,17 @@
 
 FactoryBot.define do
   factory :testing_framework, aliases: [:junit_testing_framework] do
-    name { 'JUnit' }
-    version { '4' }
+    name { 'Example Framework' }
+    sequence(:version, &:to_s)
+
+    trait :junit do
+      name { 'JUnit' }
+      version { '5' }
+    end
+
+    trait :pytest do
+      name { 'Pytest' }
+      version { '6' }
+    end
   end
 end


### PR DESCRIPTION
I thought about adding the testing framework info to the exported proforma xml but apparently proforma tests do not have any field where something like a testing framework would fit in.
There is test-configuration > test-meta-data but as far as I understand it this is meant for information on how to run the test?
Should we omit this or just add it next to the "title", "description", "internal description", ... fields?

Fixes #895 