### PR TITLE
Making the LOM export dynamic and extending the exported attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rubyzip'
 gem 'figaro'
 # Translate
 gem 'i18n'
+gem 'iso-639'
 # Use slim format
 gem 'slim-rails', '>= 3.2.0'
 # Rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    iso-639 (0.3.6)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -574,6 +575,7 @@ DEPENDENCIES
   i18n
   i18n-js (< 4.0.0)
   image_processing
+  iso-639
   jbuilder (~> 2.11)
   jquery-rails (>= 4.3.5)
   jquery-ui-rails (>= 6.0.1)

--- a/app/controllers/bridges/bird/tasks_controller.rb
+++ b/app/controllers/bridges/bird/tasks_controller.rb
@@ -54,13 +54,13 @@ module Bridges
             title: 'Hello World in Java',
             description: 'Write a simple program that prints "Hello World".',
             internal_description: 'This is a simple exercise for your students to begin with Java.',
-            language: 'English'
+            language: 'en'
           ),
           Task.new(
             title: 'Hello World in Python',
             description: 'Write a simple program that prints "Hello World".',
             internal_description: 'This is a simple exercise for your students to begin with Python.',
-            language: 'English'
+            language: 'en'
           ),
         ]
       end

--- a/app/controllers/bridges/lom/tasks_controller.rb
+++ b/app/controllers/bridges/lom/tasks_controller.rb
@@ -9,7 +9,7 @@ module Bridges
       def show
         @task = Task.find(params[:id])
 
-        if @task.access_level_public? || @task.author?(current_user)
+        if @task.access_level_public? || @task.showable_by?(current_user)
           render xml: Nokogiri::XML::Builder.new(encoding: 'UTF-8') {|xml| sample_oml(xml) }
         else
           render plain: 'Forbidden', status: :forbidden

--- a/app/controllers/bridges/lom/tasks_controller.rb
+++ b/app/controllers/bridges/lom/tasks_controller.rb
@@ -2,16 +2,14 @@
 
 module Bridges
   module Lom
-    # rubocop:disable Metrics/ClassLength
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength
     class TasksController < ActionController::API
       OML_SCHEMA_PATH = Rails.root.join('vendor/assets/schemas/lom_1484.12.3-2020/lom.xsd')
 
       def show
         @task = Task.find(params[:id])
 
-        if @task.showable_by?(current_user)
+        if @task.access_level_public? || @task.author?(current_user)
           render xml: Nokogiri::XML::Builder.new(encoding: 'UTF-8') {|xml| sample_oml(xml) }
         else
           render plain: 'Forbidden', status: :forbidden

--- a/app/controllers/bridges/lom/tasks_controller.rb
+++ b/app/controllers/bridges/lom/tasks_controller.rb
@@ -9,10 +9,10 @@ module Bridges
       def show
         @task = Task.find(params[:id])
 
-        if @task.access_level_public? || @task.showable_by?(current_user)
+        if @task.lom_showable_by?(current_user)
           render xml: Nokogiri::XML::Builder.new(encoding: 'UTF-8') {|xml| sample_oml(xml) }
         else
-          render plain: 'Forbidden', status: :forbidden
+          render xml: Nokogiri::XML::Builder.new(encoding: 'UTF-8') {|xml| xml.error 'Access Denied' }, status: :forbidden
         end
       end
 

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -2,4 +2,10 @@
 
 class License < ApplicationRecord
   has_many :tasks, dependent: :restrict_with_error
+
+  validates :name, presence: true
+
+  def to_s
+    link.present? ? "#{name}: #{link}" : name
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -205,7 +205,7 @@ class Task < ApplicationRecord
   def primary_language_tag_in_iso639?
     if language.present?
       primary_tag = language.split('-').first
-      errors.add(primary_tag, I18n.t('tasks.form.errors.iso639_primary_tag')) unless ISO_639.find(primary_tag)
+      errors.add(:language, :not_iso639) unless ISO_639.find(primary_tag)
     end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -122,6 +122,10 @@ class Task < ApplicationRecord
     user.nil? ? false : user.can?(:destroy, self)
   end
 
+  def lom_showable_by?(user)
+    access_level_public? || showable_by?(user)
+  end
+
   # TODO: Find a better name for the methods
   def in_same_group?(user)
     in_same_group_member?(user) || in_same_group_admin?(user)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1053,7 +1053,7 @@ en:
         programming_language:
           not_empty_while_public: "Can't be empty while visibility is set to public"
         language: 'is not in the correct format. Please use one of the following formats: de / en-US'
-        iso639_primary_tag: 'is not a two letter ISO 639-1 or three letter ISO-639-2 language code'
+        iso639_primary_tag: 'is not a valid two or three letter language code'
       none: "None"
       additional_info: "Additional Information"
       no_license: "No License"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1047,6 +1047,7 @@ en:
         programming_language:
           not_empty_while_public: "Can't be empty while visibility is set to public"
         language: 'is not in the correct format. Please use one of the following formats: de / en-US'
+        iso639_primary_tag: 'is not a two letter ISO 639-1 or three letter ISO-639-2 language code'
       none: "None"
       additional_info: "Additional Information"
       no_license: "No License"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,12 @@
 
 en:
   activerecord:
+    errors:
+      models:
+        task:
+          attributes:
+            language:
+              not_iso639: "is not a two letter ISO 639-1 or three letter ISO-639-2 language code"
     attributes:
       exercise:
         execution_environment: Programming language

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -77,7 +77,7 @@ task1 = Task.create!(
   description: 'Write a simple program that prints "Hello World".',
   internal_description: 'This is a simple exercise for your students to begin with Java.',
   uuid: 'f15cb7a3-87eb-4c4c-a998-c33e25d44cdc',
-  language: 'English',
+  language: 'en',
   programming_language: pl_java,
   user: user1,
   meta_data: {
@@ -207,7 +207,7 @@ task2 = Task.create!(
   description: 'Write a simple program that prints "Hello World".',
   internal_description: 'This is a simple exercise for your students to begin with Python.',
   uuid: 'a85825d4-397b-4c65-8550-ae607f0a70e9',
-  language: 'English',
+  language: 'en',
   programming_language: pl_python,
   user: user1,
   meta_data: {

--- a/spec/controllers/bridges/lom/tasks_controller_spec.rb
+++ b/spec/controllers/bridges/lom/tasks_controller_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bridges::Lom::TasksController do
+  render_views
+
+  let(:user) { create(:user) }
+  let(:programming_language) { create(:programming_language) }
+  let(:license) { create(:license) }
+  let(:parent_uuid) { create(:task).uuid }
+  let(:public_task) { create(:task, :with_content, user:, parent_uuid:, programming_language:, license:, access_level: :public) }
+  let(:private_task) { create(:task, :with_content, user:, parent_uuid:, programming_language:, license:, access_level: :private) }
+
+  describe 'GET #show' do
+    subject(:get_request) { get :show, params: {id: task.to_param} }
+
+    shared_examples 'validate response LOM' do
+      it 'returns HTTP OK' do
+        expect(response).to have_http_status :ok
+      end
+
+      it 'returns valid LOM xml' do
+        get_request
+        schema = Nokogiri::XML::Schema(File.read(Bridges::Lom::TasksController::OML_SCHEMA_PATH))
+        expect(schema.validate(Nokogiri::XML(response.body))).to be_empty
+      end
+    end
+
+    context 'without being signed in' do
+      let(:task) { public_task }
+
+      it 'returns HTTP forbidden' do
+        get_request
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context 'when signed in as owner of the task' do
+      before { sign_in user }
+
+      context 'when task is public' do
+        let(:task) { public_task }
+
+        include_examples 'validate response LOM'
+      end
+
+      context 'when task is private' do
+        let(:task) { private_task }
+
+        include_examples 'validate response LOM'
+      end
+    end
+
+    context 'when signed in user is not owner of the task' do
+      before { sign_in create(:user) }
+
+      context 'when task is public' do
+        let(:task) { public_task }
+
+        include_examples 'validate response LOM'
+      end
+
+      context 'when task is private' do
+        let(:task) { private_task }
+
+        it 'returns HTTP forbidden' do
+          get_request
+          expect(response).to have_http_status :forbidden
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/bridges/lom/tasks_controller_spec.rb
+++ b/spec/controllers/bridges/lom/tasks_controller_spec.rb
@@ -26,14 +26,12 @@ RSpec.describe Bridges::Lom::TasksController do
       end
     end
 
+    before { allow(Task).to receive(:find).with(task.id.to_s).and_return(task) }
+
     context 'when allowed to access the LOM' do
       before { allow(task).to receive(:lom_showable_by?).and_return(true) }
 
-      it 'returns valid LOM xml' do
-        get_request
-        schema = Nokogiri::XML::Schema(File.read(Bridges::Lom::TasksController::OML_SCHEMA_PATH))
-        expect(schema.validate(Nokogiri::XML(response.body))).to be_empty
-      end
+      include_examples 'is a valid LOM response'
     end
 
     context 'when not allowed to access the LOM' do

--- a/spec/controllers/bridges/lom/tasks_controller_spec.rb
+++ b/spec/controllers/bridges/lom/tasks_controller_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe Bridges::Lom::TasksController do
   render_views
 
   let(:user) { create(:user) }
-  let(:programming_language) { create(:programming_language) }
+  let(:programming_language) { create(:programming_language, :ruby) }
   let(:license) { create(:license) }
   let(:parent_uuid) { create(:task).uuid }
-  let(:public_task) { create(:task, :with_content, user:, parent_uuid:, programming_language:, license:, access_level: :public) }
-  let(:private_task) { create(:task, :with_content, user:, parent_uuid:, programming_language:, license:, access_level: :private) }
+  let(:task) { create(:task, :with_content, :with_labels, user:, parent_uuid:, programming_language:, license:, access_level:) }
 
   describe 'GET #show' do
     subject(:get_request) { get :show, params: {id: task.to_param} }
 
-    shared_examples 'is a valid LOM reponse' do
+    shared_examples 'is a valid LOM response' do
       it 'returns HTTP OK' do
         expect(response).to have_http_status :ok
       end
@@ -28,16 +27,14 @@ RSpec.describe Bridges::Lom::TasksController do
     end
 
     context 'without being signed in' do
-      let(:task) { public_task }
-
       context 'when task is public' do
-        let(:task) { public_task }
+        let(:access_level) { :public }
 
-        include_examples 'is a valid LOM reponse'
+        include_examples 'is a valid LOM response'
       end
 
       context 'when task is private' do
-        let(:task) { private_task }
+        let(:access_level) { :private }
 
         it 'returns HTTP forbidden' do
           get_request
@@ -50,15 +47,15 @@ RSpec.describe Bridges::Lom::TasksController do
       before { sign_in user }
 
       context 'when task is public' do
-        let(:task) { public_task }
+        let(:access_level) { :public }
 
-        include_examples 'is a valid LOM reponse'
+        include_examples 'is a valid LOM response'
       end
 
       context 'when task is private' do
-        let(:task) { private_task }
+        let(:access_level) { :private }
 
-        include_examples 'is a valid LOM reponse'
+        include_examples 'is a valid LOM response'
       end
     end
 
@@ -66,13 +63,13 @@ RSpec.describe Bridges::Lom::TasksController do
       before { sign_in create(:user) }
 
       context 'when task is public' do
-        let(:task) { public_task }
+        let(:access_level) { :public }
 
-        include_examples 'is a valid LOM reponse'
+        include_examples 'is a valid LOM response'
       end
 
       context 'when task is private' do
-        let(:task) { private_task }
+        let(:access_level) { :private }
 
         it 'returns HTTP forbidden' do
           get_request
@@ -83,7 +80,7 @@ RSpec.describe Bridges::Lom::TasksController do
 
     context 'when signed in as a group member' do
       let(:group_member) { create(:user) }
-      let(:task) { private_task }
+      let(:access_level) { :private }
       let(:group_memberships) { [build(:group_membership, :with_admin), build(:group_membership, user: group_member)] }
 
       before do
@@ -91,7 +88,29 @@ RSpec.describe Bridges::Lom::TasksController do
         sign_in group_member
       end
 
-      include_examples 'is a valid LOM reponse'
+      include_examples 'is a valid LOM response'
+    end
+
+    context 'with additional details' do
+      let(:access_level) { :public }
+
+      context 'when no license is specified' do
+        let(:license) { nil }
+
+        include_examples 'is a valid LOM response'
+      end
+
+      context 'when ratings are available' do
+        before { create(:rating, task:, user:) }
+
+        include_examples 'is a valid LOM response'
+      end
+
+      context 'when comments are available' do
+        before { create(:comment, task:, user:) }
+
+        include_examples 'is a valid LOM response'
+      end
     end
   end
 end

--- a/spec/controllers/bridges/lom/tasks_controller_spec.rb
+++ b/spec/controllers/bridges/lom/tasks_controller_spec.rb
@@ -80,5 +80,18 @@ RSpec.describe Bridges::Lom::TasksController do
         end
       end
     end
+
+    context 'when signed in as a group member' do
+      let(:group_member) { create(:user) }
+      let(:task) { private_task }
+      let(:group_memberships) { [build(:group_membership, :with_admin), build(:group_membership, user: group_member)] }
+
+      before do
+        create(:group, group_memberships:, tasks: [task])
+        sign_in group_member
+      end
+
+      include_examples 'is a valid LOM reponse'
+    end
   end
 end

--- a/spec/controllers/bridges/lom/tasks_controller_spec.rb
+++ b/spec/controllers/bridges/lom/tasks_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Bridges::Lom::TasksController do
   describe 'GET #show' do
     subject(:get_request) { get :show, params: {id: task.to_param} }
 
-    shared_examples 'validate response LOM' do
+    shared_examples 'is a valid LOM reponse' do
       it 'returns HTTP OK' do
         expect(response).to have_http_status :ok
       end
@@ -30,9 +30,19 @@ RSpec.describe Bridges::Lom::TasksController do
     context 'without being signed in' do
       let(:task) { public_task }
 
-      it 'returns HTTP forbidden' do
-        get_request
-        expect(response).to have_http_status :forbidden
+      context 'when task is public' do
+        let(:task) { public_task }
+
+        include_examples 'is a valid LOM reponse'
+      end
+
+      context 'when task is private' do
+        let(:task) { private_task }
+
+        it 'returns HTTP forbidden' do
+          get_request
+          expect(response).to have_http_status :forbidden
+        end
       end
     end
 
@@ -42,13 +52,13 @@ RSpec.describe Bridges::Lom::TasksController do
       context 'when task is public' do
         let(:task) { public_task }
 
-        include_examples 'validate response LOM'
+        include_examples 'is a valid LOM reponse'
       end
 
       context 'when task is private' do
         let(:task) { private_task }
 
-        include_examples 'validate response LOM'
+        include_examples 'is a valid LOM reponse'
       end
     end
 
@@ -58,7 +68,7 @@ RSpec.describe Bridges::Lom::TasksController do
       context 'when task is public' do
         let(:task) { public_task }
 
-        include_examples 'validate response LOM'
+        include_examples 'is a valid LOM reponse'
       end
 
       context 'when task is private' do

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
       title {}
       description {}
     end
+
+    trait :with_labels do
+      labels { build_list(:label, 3) }
+    end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Task do
     it { is_expected.not_to be_able_to(:export_external_start, task) }
     it { is_expected.not_to be_able_to(:export_external_check, task) }
     it { is_expected.not_to be_able_to(:export_external_confirm, task) }
+    it { expect(task.lom_showable_by?(user)).to be false }
 
     context 'with a user' do
       let(:user) { create(:user) }
@@ -46,11 +47,15 @@ RSpec.describe Task do
       it { is_expected.not_to be_able_to(:export_external_check, task) }
       it { is_expected.not_to be_able_to(:export_external_confirm, task) }
 
+      it { expect(task.lom_showable_by?(user)).to be false }
+
       context 'when user is admin' do
         let(:user) { create(:admin) }
 
         it { is_expected.to be_able_to(:manage, described_class) }
         it { is_expected.to be_able_to(:manage, task) }
+
+        it { expect(task.lom_showable_by?(user)).to be true }
       end
 
       context 'when task is from user' do
@@ -70,6 +75,8 @@ RSpec.describe Task do
 
         it { is_expected.to be_able_to(:update, task) }
         it { is_expected.to be_able_to(:destroy, task) }
+
+        it { expect(task.lom_showable_by?(user)).to be true }
       end
 
       context 'when task has access_level "public"' do
@@ -84,6 +91,8 @@ RSpec.describe Task do
 
         it { is_expected.not_to be_able_to(:update, task) }
         it { is_expected.not_to be_able_to(:destroy, task) }
+
+        it { expect(task.lom_showable_by?(user)).to be true }
       end
 
       context 'when task is "private" and in same group' do
@@ -97,6 +106,8 @@ RSpec.describe Task do
         it { is_expected.to be_able_to(:update, task) }
         it { is_expected.to be_able_to(:duplicate, task) }
         it { is_expected.not_to be_able_to(:destroy, task) }
+
+        it { expect(task.lom_showable_by?(user)).to be true }
 
         context 'when user is group-admin' do
           let(:role) { :admin }

--- a/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
@@ -34,7 +34,7 @@ describe ProformaService::ConvertProformaTaskToTask do
         proglang: {name: 'proglang-name', version: 'proglang-version'},
         uuid:,
         parent_uuid: 'parent_uuid',
-        language: 'language',
+        language: 'en',
         meta_data:,
         model_solutions:,
         files:,
@@ -59,7 +59,7 @@ describe ProformaService::ConvertProformaTaskToTask do
         programming_language: be_an(ProgrammingLanguage).and(have_attributes(language: 'proglang-name', version: 'proglang-version')),
         uuid: proforma_task.uuid,
         parent_uuid: be_blank,
-        language: 'language',
+        language: 'en',
         files: be_empty,
         tests: be_empty,
         model_solutions: be_empty
@@ -381,7 +381,7 @@ describe ProformaService::ConvertProformaTaskToTask do
           programming_language: have_attributes(language: proforma_task.proglang[:name], version: proforma_task.proglang[:version]),
           uuid: task.uuid,
           parent_uuid: be_blank,
-          language: 'language',
+          language: 'en',
 
           files: be_empty,
           tests: be_empty,


### PR DESCRIPTION
There are still some LOM attributes missing or hardcoded (typical age range for example) but this should cover the most important things. Other LOM attributes can be filled in when the corresponding data is added to CodeHarbor.

I think the N+1 query in task_version could become a performance problem when the LOM data is being requested in bulk via OAI-PMH so maybe we should fix that soon.

This closes #947.

Edit: I noticed I broke some tests because of the new language validation so I had to change the example language used in some tests.