### PR TITLE
Update from proforma to proformaxml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'twitter-bootstrap-rails'
 gem 'ace-rails-ap'
 gem 'acts-as-taggable-on', '~> 9.0'
 gem 'config'
-gem 'dachsfisch', github: 'openHPI/dachsfisch'
 gem 'faraday'
 gem 'font-awesome-rails', '>= 4.7.0.5'
 gem 'image_processing'
@@ -71,7 +70,7 @@ gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false
 gem 'nokogiri'
-gem 'proforma', github: 'openHPI/proforma', tag: 'v0.9.1'
+gem 'proformaxml'
 gem 'rails_admin', '~> 3.1'
 gem 'ransack'
 gem 'select2-rails', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,3 @@
-GIT
-  remote: https://github.com/openHPI/dachsfisch.git
-  revision: c74d5a3d74685a0838d369fe3dcbbb9166d50a5b
-  specs:
-    dachsfisch (0.1.0)
-      nokogiri (>= 1.14.1, < 2.0.0)
-
-GIT
-  remote: https://github.com/openHPI/proforma.git
-  revision: 10642d8d4ec27e0bdaa27482dac6b6c7e47bc660
-  tag: v0.9.1
-  specs:
-    proforma (0.9.1)
-      activemodel (>= 5.2.3, < 8.0.0)
-      activesupport (>= 5.2.3, < 8.0.0)
-      nokogiri (>= 1.10.2, < 2.0.0)
-      rubyzip (>= 1.2.2, < 3.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -135,6 +117,8 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dachsfisch (0.1.0)
+      nokogiri (>= 1.14.1, < 2.0.0)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -328,6 +312,12 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.3)
+    proformaxml (0.10.0)
+      activemodel (>= 5.2.3, < 8.0.0)
+      activesupport (>= 5.2.3, < 8.0.0)
+      dachsfisch (>= 0.1.0, < 1.0.0)
+      nokogiri (>= 1.10.2, < 2.0.0)
+      rubyzip (>= 1.2.2, < 3.0.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -571,7 +561,6 @@ DEPENDENCIES
   coffee-rails (>= 5.0.0)
   concurrent-ruby
   config
-  dachsfisch!
   database_cleaner
   devise (~> 4.9)
   devise-bootstrap-views (~> 1.0)
@@ -603,7 +592,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0)
   omniauth-saml (~> 2.0)
   pg (>= 0.18, < 2.0)
-  proforma!
+  proformaxml
   pry-byebug
   pry-rails
   puma

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CodeHarbor
-CodeHarbor is a repository system for automatically gradeable programming exercises and enables instructors to exchange of such exxercises via the [ProFormA XML](https://github.com/ProFormA/proformaxml) format across diverse code assessment systems.
+CodeHarbor is a repository system for automatically gradeable programming exercises and enables instructors to exchange of such exercises via the [ProFormA XML](https://github.com/ProFormA/proformaxml) format across diverse code assessment systems.
 
 
 ## Current Status on `master`

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -102,7 +102,7 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
       message: t('controllers.task.import.successfully_imported', title: task_title),
       actions: render_to_string(partial: 'import_actions', locals: {task: proforma_task, imported: true}),
     }
-  rescue Proforma::ProformaError, ActiveRecord::RecordInvalid => e
+  rescue ProformaXML::ProformaError, ActiveRecord::RecordInvalid => e
     render json: {
       status: 'failure',
       message: t('controllers.task.import.import_failed', title: task_title, error: e.message),
@@ -128,7 +128,7 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
     ProformaService::Import.call(zip: tempfile, user:)
 
     render json: t('controllers.exercise.import_proforma_xml.success'), status: :created
-  rescue Proforma::ProformaError
+  rescue ProformaXML::ProformaError
     render json: t('controllers.exercise.import_proforma_xml.invalid'), status: :bad_request
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/app/errors/proformaxml/invalid_zip.rb
+++ b/app/errors/proformaxml/invalid_zip.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module Proforma
+module ProformaXML
   class InvalidZip < StandardError; end
 end

--- a/app/errors/proformaxml/mimetype_error.rb
+++ b/app/errors/proformaxml/mimetype_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module Proforma
+module ProformaXML
   class MimetypeError < StandardError; end
 end

--- a/app/services/proforma_service/convert_task_to_proforma_task.rb
+++ b/app/services/proforma_service/convert_task_to_proforma_task.rb
@@ -15,7 +15,7 @@ module ProformaService
     private
 
     def create_task
-      Proforma::Task.new(
+      ProformaXML::Task.new(
         {
           title: @task.title,
           description:,
@@ -44,7 +44,7 @@ module ProformaService
 
     def model_solutions
       @task.model_solutions.map do |model_solution|
-        Proforma::ModelSolution.new(
+        ProformaXML::ModelSolution.new(
           id: model_solution.xml_id,
           description: model_solution.description,
           internal_description: model_solution.internal_description,
@@ -57,7 +57,7 @@ module ProformaService
 
     def tests
       @task.tests.map do |test|
-        Proforma::Test.new(
+        ProformaXML::Test.new(
           id: test.xml_id,
           title: test.title,
           description: test.description,
@@ -71,7 +71,7 @@ module ProformaService
     end
 
     def task_file(file)
-      task_file = Proforma::TaskFile.new(
+      task_file = ProformaXML::TaskFile.new(
         id: file.xml_id,
         filename: file.full_file_name,
         used_by_grader: file.used_by_grader || false,

--- a/app/services/proforma_service/convert_zip_to_proforma_tasks.rb
+++ b/app/services/proforma_service/convert_zip_to_proforma_tasks.rb
@@ -20,7 +20,7 @@ module ProformaService
 
     def execute
       if xml_present?
-        importer = Proforma::Importer.new(zip: @zip_file)
+        importer = ProformaXML::Importer.new(zip: @zip_file)
         result = importer.perform
         task = result[:task]
         tasks = [{path: @path, uuid: task.uuid, task:}]

--- a/app/services/proforma_service/export_task.rb
+++ b/app/services/proforma_service/export_task.rb
@@ -11,7 +11,7 @@ module ProformaService
     def execute
       @proforma_task = ConvertTaskToProformaTask.call(task: @task, options: @options)
       namespaces = [{prefix: 'CodeOcean', uri: 'codeocean.openhpi.de'}]
-      exporter = Proforma::Exporter.new(task: @proforma_task, custom_namespaces: namespaces)
+      exporter = ProformaXML::Exporter.new(task: @proforma_task, custom_namespaces: namespaces)
       exporter.perform
     end
   end

--- a/app/services/proforma_service/import.rb
+++ b/app/services/proforma_service/import.rb
@@ -10,7 +10,7 @@ module ProformaService
 
     def execute
       if single_task?
-        importer = Proforma::Importer.new(zip: @zip)
+        importer = ProformaXML::Importer.new(zip: @zip)
         import_result = importer.perform
         ProformaService::ImportTask.call(proforma_task: import_result[:task], user: @user)
       else
@@ -50,7 +50,7 @@ module ProformaService
 
       filenames.any? {|f| f[/\.xml$/] }
     rescue Zip::Error
-      raise Proforma::InvalidZip
+      raise ProformaXML::InvalidZip
     end
   end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,7 +12,6 @@
 #   inflect.uncountable %w( fish sheep )
 # end
 
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'ProformaXML'
+end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -771,7 +771,7 @@ RSpec.describe TasksController do
     end
 
     context 'when import fails with ProformaError' do
-      before { allow(ProformaService::Import).to receive(:call).and_raise(Proforma::PreImportValidationError) }
+      before { allow(ProformaService::Import).to receive(:call).and_raise(ProformaXML::PreImportValidationError) }
 
       it 'responds with correct status code' do
         post_request

--- a/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
@@ -6,7 +6,7 @@ describe ProformaService::ConvertProformaTaskToTask do
   describe '.new' do
     subject(:convert_to_task_service) { described_class.new(proforma_task:, user:, task:) }
 
-    let(:proforma_task) { Proforma::Task.new }
+    let(:proforma_task) { ProformaXML::Task.new }
     let(:user) { build(:user) }
     let(:task) { build(:task) }
 
@@ -27,7 +27,7 @@ describe ProformaService::ConvertProformaTaskToTask do
     subject(:convert_to_task_service) { described_class.call(proforma_task:, user:, task:) }
 
     let(:proforma_task) do
-      Proforma::Task.new(
+      ProformaXML::Task.new(
         title: 'title',
         description:,
         internal_description: 'internal_description',
@@ -97,7 +97,7 @@ describe ProformaService::ConvertProformaTaskToTask do
     context 'when proforma_task has a file' do
       let(:files) { [file] }
       let(:file) do
-        Proforma::TaskFile.new(
+        ProformaXML::TaskFile.new(
           id: 'id',
           content:,
           filename: 'filename.txt',
@@ -175,7 +175,7 @@ describe ProformaService::ConvertProformaTaskToTask do
       end
 
       context 'when file is a model-solution-placeholder (needed by proforma until issue #5 is resolved)' do
-        let(:file) { Proforma::TaskFile.new(id: 'ms-placeholder-file') }
+        let(:file) { ProformaXML::TaskFile.new(id: 'ms-placeholder-file') }
 
         it 'leaves files empty' do
           expect(convert_to_task_service.files).to be_empty
@@ -186,7 +186,7 @@ describe ProformaService::ConvertProformaTaskToTask do
     context 'when proforma_task has a model-solution' do
       let(:model_solutions) { [model_solution] }
       let(:model_solution) do
-        Proforma::ModelSolution.new(
+        ProformaXML::ModelSolution.new(
           id: 'ms-id',
           description: 'description',
           internal_description: 'internal-description',
@@ -195,7 +195,7 @@ describe ProformaService::ConvertProformaTaskToTask do
       end
       let(:ms_files) { [ms_file] }
       let(:ms_file) do
-        Proforma::TaskFile.new(
+        ProformaXML::TaskFile.new(
           id: 'ms-file',
           content: 'content',
           filename: 'filename.txt',
@@ -226,7 +226,7 @@ describe ProformaService::ConvertProformaTaskToTask do
       end
 
       context 'when proforma_task has two model-solutions' do
-        let(:model_solutions) { [model_solution, Proforma::ModelSolution.new(id: 'ms-id-2', files: [])] }
+        let(:model_solutions) { [model_solution, ProformaXML::ModelSolution.new(id: 'ms-id-2', files: [])] }
 
         it 'creates a task with two model-solutions' do
           expect(convert_to_task_service.model_solutions).to have(2).items
@@ -245,7 +245,7 @@ describe ProformaService::ConvertProformaTaskToTask do
     context 'when proforma_task has a test' do
       let(:tests) { [test] }
       let(:test) do
-        Proforma::Test.new(
+        ProformaXML::Test.new(
           id: 'test-id',
           title: 'title',
           description: 'description',
@@ -259,7 +259,7 @@ describe ProformaService::ConvertProformaTaskToTask do
       let(:test_meta_data) {}
       let(:test_files) { [test_file] }
       let(:test_file) do
-        Proforma::TaskFile.new(
+        ProformaXML::TaskFile.new(
           id: 'test_file_id',
           content: 'testfile-content',
           filename: 'testfile.txt',
@@ -303,7 +303,7 @@ describe ProformaService::ConvertProformaTaskToTask do
       context 'when test has multiple files' do
         let(:test_files) { [test_file, test_file2] }
         let(:test_file2) do
-          Proforma::TaskFile.new(
+          ProformaXML::TaskFile.new(
             id: 'test_file2_id',
             content: 'testfile2-content',
             filename: 'testfile2.txt',
@@ -351,11 +351,11 @@ describe ProformaService::ConvertProformaTaskToTask do
       context 'when proforma_task has multiple tests' do
         let(:tests) { [test, test2] }
         let(:test2) do
-          Proforma::Test.new(files: test_files2)
+          ProformaXML::Test.new(files: test_files2)
         end
         let(:test_files2) { [test_file2] }
         let(:test_file2) do
-          Proforma::TaskFile.new(
+          ProformaXML::TaskFile.new(
             id: 'test_file_id2',
             content: 'testfile-content',
             filename: 'testfile.txt',
@@ -410,7 +410,7 @@ describe ProformaService::ConvertProformaTaskToTask do
       context 'with file, model solution and test' do
         let(:files) { [file] }
         let(:file) do
-          Proforma::TaskFile.new(
+          ProformaXML::TaskFile.new(
             id: 'id',
             content: 'content',
             filename: 'filename.txt',
@@ -423,7 +423,7 @@ describe ProformaService::ConvertProformaTaskToTask do
         end
         let(:tests) { [test] }
         let(:test) do
-          Proforma::Test.new(
+          ProformaXML::Test.new(
             id: 'test-id',
             title: 'title',
             description: 'description',
@@ -434,7 +434,7 @@ describe ProformaService::ConvertProformaTaskToTask do
         end
         let(:test_files) { [test_file] }
         let(:test_file) do
-          Proforma::TaskFile.new(
+          ProformaXML::TaskFile.new(
             id: 'test_file_id',
             content: 'testfile-content',
             filename: 'testfile.txt',
@@ -447,7 +447,7 @@ describe ProformaService::ConvertProformaTaskToTask do
         end
         let(:model_solutions) { [model_solution] }
         let(:model_solution) do
-          Proforma::ModelSolution.new(
+          ProformaXML::ModelSolution.new(
             id: 'ms-id',
             description: 'ms-description',
             files: ms_files
@@ -455,7 +455,7 @@ describe ProformaService::ConvertProformaTaskToTask do
         end
         let(:ms_files) { [ms_file] }
         let(:ms_file) do
-          Proforma::TaskFile.new(
+          ProformaXML::TaskFile.new(
             id: 'ms-file',
             content: 'ms-content',
             filename: 'ms-filename.txt',

--- a/spec/services/proforma_service/convert_zip_to_proforma_tasks_spec.rb
+++ b/spec/services/proforma_service/convert_zip_to_proforma_tasks_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe ProformaService::ConvertZipToProformaTasks do
     subject(:convert_zip_to_tasks) { described_class.call(zip_file:) }
 
     let(:zip_file) { fixture_file_upload('proforma_import/testfile.zip', 'application/zip') }
-    let(:importer) { instance_double(Proforma::Importer, perform: importer_result) }
+    let(:importer) { instance_double(ProformaXML::Importer, perform: importer_result) }
     let(:importer_result) { {task:, custom_namespaces: []} }
-    let(:task) { instance_double(Proforma::Task, uuid: 'uuid') }
+    let(:task) { instance_double(ProformaXML::Task, uuid: 'uuid') }
 
-    before { allow(Proforma::Importer).to receive(:new).and_return(importer) }
+    before { allow(ProformaXML::Importer).to receive(:new).and_return(importer) }
 
     it 'returns an array with a hash for the task' do
       expect(convert_zip_to_tasks).to eql [{path: 'testfile.zip', uuid: 'uuid', task:}]

--- a/spec/services/proforma_service/import_task_spec.rb
+++ b/spec/services/proforma_service/import_task_spec.rb
@@ -6,7 +6,7 @@ describe ProformaService::ImportTask do
   describe '.new' do
     subject(:import_proforma_task) { described_class.new(proforma_task:, user:) }
 
-    let(:proforma_task) { Proforma::Task.new }
+    let(:proforma_task) { ProformaXML::Task.new }
     let(:user) { build(:user) }
 
     it 'assigns proforma_task' do
@@ -35,7 +35,7 @@ describe ProformaService::ImportTask do
     end
 
     context 'when proforma_task does not provide valid information' do
-      let(:proforma_task) { Proforma::Task.new }
+      let(:proforma_task) { ProformaXML::Task.new }
 
       it 'does not create an task in db' do
         expect { import_proforma_task }.to raise_error(ActiveRecord::RecordInvalid).and(avoid_change(Task, :count))
@@ -86,7 +86,7 @@ describe ProformaService::ImportTask do
       end
 
       context 'when proforma_task does not provide valid information' do
-        let(:proforma_task) { Proforma::Task.new(uuid: task.uuid) }
+        let(:proforma_task) { ProformaXML::Task.new(uuid: task.uuid) }
 
         it 'does not create an task in db' do
           expect { import_proforma_task }.to raise_error(ActiveRecord::RecordInvalid).and(avoid_change(Task, :count))

--- a/spec/services/proforma_service/proforma_task_from_cached_file_spec.rb
+++ b/spec/services/proforma_service/proforma_task_from_cached_file_spec.rb
@@ -36,7 +36,7 @@ describe ProformaService::ProformaTaskFromCachedFile do
     let(:import_type) { 'import' }
 
     it 'returns a task' do
-      expect(task_from_cached_file).to be_a Proforma::Task
+      expect(task_from_cached_file).to be_a ProformaXML::Task
     end
 
     it 'sets the attributes of task' do

--- a/spec/support/shared_examples/exporter.rb
+++ b/spec/support/shared_examples/exporter.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'zipped task node xml' do
   end
 
   it 'contains through schema validatable xml' do
-    expect(Proforma::Validator.new(xml_with_namespaces).perform).to be_empty
+    expect(ProformaXML::Validator.new(xml_with_namespaces).perform).to be_empty
   end
 
   it 'adds task root-node' do


### PR DESCRIPTION
This PR switches to the official proformaxml gem, as published on RubyGems.org

I also decided to rename the custom error class, besides not required technically. However, I haven't renamed the services, which we could still do.
