### PR TITLE
Making task show route accessible to guest users

### DIFF
--- a/app/assets/stylesheets/exercises.scss
+++ b/app/assets/stylesheets/exercises.scss
@@ -338,7 +338,7 @@ legend {
     width: 100%;
     text-align: center;
     display: block;
-    .btn-light,
+    .btn,
     .btn-group {
       width: 100%;
       margin-bottom: 5px;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
-  load_and_authorize_resource
+  load_and_authorize_resource :task
+  load_and_authorize_resource :comment, through: :task
+
   before_action :set_task
   before_action :set_comment, only: %i[edit update destroy]
   before_action :new_comment, only: :create

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,6 +4,9 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    # abilities for logged out users/guests
+    guest_abilities
+
     return unless user
 
     alias_action :create, :show, :update, :destroy, to: :crud
@@ -38,6 +41,12 @@ class Ability
 
     # Label
     label_abilities
+  end
+
+  def guest_abilities
+    can %i[show download], Task, &:access_level_public?
+
+    can %i[show read], Comment
   end
 
   def admin_abilities(user)

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -14,20 +14,29 @@
             span.fa.fa-star-o.overall-rating data-rating=i
         small
           .rating-dropdown
-            .btn.btn-sm#rate
-              => t('exercises.rate')
-              span.fa.fa-caret-down
-            .popup-rating
-              .rating data-task-id=@task.id
-                - if @user_rating
-                  - [*1..5].each do |i|
-                    - if @user_rating >= i
-                      span.fa.fa-star data-rating=i
-                    - else
+            - if can? :create, Rating
+              .btn.btn-sm#rate
+                => t('exercises.rate')
+                span.fa.fa-caret-down
+
+              .popup-rating
+                .rating data-task-id=@task.id
+                  - if @user_rating
+                    - [*1..5].each do |i|
+                      - if @user_rating >= i
+                        span.fa.fa-star data-rating=i
+                      - else
+                        span.fa.fa-star-o data-rating=i
+                  - else
+                    - [*1..5].each do |i|
                       span.fa.fa-star-o data-rating=i
-                - else
-                  - [*1..5].each do |i|
-                    span.fa.fa-star-o data-rating=i
+
+            - else
+              div[data-bs-toggle='tooltip' title=t('tasks.guest.disabled.tooltip') data-bs-delay=150]
+                .btn.btn-sm#rate
+                  => t('exercises.rate')
+                  span.fa.fa-caret-down
+
       /= render 'remove_state_tag', exercise: @task
 .row
   .col-md-12.my-3
@@ -103,18 +112,17 @@
         .col-auto.row-label
           = t('common.created_by')
           | :
-        - if !@task.user
-          .col.row-value
+        .col.row-value
+          - if !@task.user
             = t('users.undefined')
-        - elsif @task.user == current_user
-          .col.row-value
+          - elsif @task.user == current_user
             = t('users.yourself')
-        - elsif @task.user.first_name.nil?
-          .col.row-value
+          - elsif @task.user.first_name.nil?
             = "User#{@task.user.id}"
-        - else
-          .col.row-value
+          - elsif can? :show, @task.user
             = link_to @task.user.name, user_path(@task.user)
+          - else
+            = @task.user.name
       .row
         .col-auto.row-label
           = t('tasks.uuid')
@@ -152,7 +160,10 @@
           - @task.groups.each_with_index do |group, index|
             - if index > 0
               = ', '
-            = link_to group.name, group_path(group)
+            - if can? :show, group
+              = link_to group.name, group_path(group)
+            - else
+              = group.name
       .row
         .col-auto.row-label
           = t('tasks.show.license')
@@ -513,11 +524,12 @@
                         = file.usage_by_lms
 .row
   .col-md-4.col-sm-6.mb-3
-      .button-box.border.p-3.h-100
-        .button-description
-          = t('controllers.task.add_to_collection.hint')
-        .wrapper
-          /  = link_to t('exercises.show.add_to_cart'), add_to_cart_exercise_path(@task), method: 'post', class: 'btn btn-light'
+    .button-box.border.p-3.h-100
+      .button-description
+        = t('controllers.task.add_to_collection.hint')
+      .wrapper
+        /  = link_to t('exercises.show.add_to_cart'), add_to_cart_exercise_path(@task), method: 'post', class: 'btn btn-light'
+        - if can? :add_to_collection, @task
           .dropdown.btn-group
             = button_tag class: 'btn btn-light dropdown-toggle', 'data-bs-toggle': 'dropdown' do
               = t('tasks.show.add_to_collection')
@@ -529,13 +541,23 @@
               - else
                 li
                   = link_to t('tasks.show.add_collection'), new_collection_path(current_user)
+        - else
+          div[data-bs-toggle='tooltip' title=t('tasks.guest.disabled.tooltip') data-bs-delay=150]
+            = button_tag class: 'btn btn-outline-dark dropdown-toggle disabled', 'data-bs-toggle': 'dropdown' do
+              = t('tasks.show.add_to_collection')
+
   .col-md-4.col-sm-6.mb-3
-    - if can? :export, Task
-      .button-box.border.p-3.h-100
-        .button-description
-          = t('tasks.download')
-        .wrapper
+    .button-box.border.p-3.h-100
+      .button-description
+        = t('tasks.download')
+      .wrapper
+        - if can? :download, @task
           = link_to t('shared.download_zip'), download_task_path(@task), class: 'btn btn-light', 'data-turbolinks'=> false
+        - else
+          div[data-bs-toggle='tooltip' title=t('tasks.guest.disabled.tooltip') data-bs-delay=150]
+            = link_to t('shared.download_zip'), download_task_path(@task), class: 'btn btn-outline-dark disabled', 'data-turbolinks'=> false
+
+        - if can? :export, @task
           .dropdown.btn-group
             = button_tag class: 'btn btn-light dropdown-toggle', 'data-bs-toggle': 'dropdown' do
               = t('tasks.show.export')
@@ -548,6 +570,10 @@
               - else
                 li
                   = link_to t('tasks.show.define_account_link'), new_user_account_link_path(current_user)
+        - else
+          div[data-bs-toggle='tooltip' title=t('tasks.guest.disabled.tooltip') data-bs-delay=150]
+            = button_tag class: 'btn btn-outline-dark dropdown-toggle disabled', 'data-bs-toggle': 'dropdown' do
+              = t('tasks.show.export')
 
     /.button-box
       .button-description
@@ -577,10 +603,16 @@
       .comment-box.with-borders data-task=@task.id
         = form_for :comment, url: task_comments_path(@task), remote: true do |f|
           .write-comment
-            .input-group
-              = f.label 'new_comment_label', 'New Comment', class: 'input-group-text'
-              = f.text_field :text, class: 'form-control'
-              = f.submit class: 'btn btn-light'
+            - if can? :create, Comment
+              .input-group
+                = f.label 'new_comment_label', 'New Comment', class: 'input-group-text'
+                = f.text_field :text, class: 'form-control'
+                = f.submit class: 'btn btn-light'
+            - else
+              .input-group[data-bs-toggle='tooltip' title=t('tasks.guest.disabled.tooltip') data-bs-delay=150]
+                = f.label 'new_comment_label', 'New Comment', class: 'input-group-text'
+                = f.text_field :text, class: 'form-control', disabled: true
+                = f.submit class: 'btn btn-outline-dark disabled'
         .comment-body
 
     /.history-panel
@@ -612,10 +644,19 @@
               .input-group
                 = text_field_tag 'text', nil, form: 'report', class: 'form-control'
                 = submit_tag t('exercises.show.submit'), form: 'report', class: 'btn btn-light'
-      = link_to duplicate_task_path(@task), method: :post, class: 'btn btn-important' do
-        i.fa.fa-clone
-        =< t('tasks.show.duplicate')
-      = link_to t('tasks.show.back'), tasks_path, class: 'btn btn-important'
+
+      - if can? :duplicate, @task
+        = link_to duplicate_task_path(@task), method: :post, class: 'btn btn-important' do
+          i.fa.fa-clone
+          =< t('tasks.show.duplicate')
+      - else
+        div[data-bs-toggle='tooltip' title=t('tasks.guest.disabled.tooltip') data-bs-delay=150]
+          = link_to duplicate_task_path(@task), method: :post, class: 'btn btn-important disabled' do
+            i.fa.fa-clone
+            =< t('tasks.show.duplicate')
+
+      - if current_user.present?
+        = link_to t('tasks.show.back'), tasks_path, class: 'btn btn-important'
 
     /= form_tag report_exercise_path(@task), id: 'report'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1165,7 +1165,10 @@ en:
       updated: "Task successfully updated"
       destroyed: "Task successfully destroyed"
       duplicate_failed: "Task could not be duplicated"
-    download: "Download your Task as a zip file or export them directly to an autograder."
+    download: "Download this Task as a zip file."
+    guest:
+      disabled:
+        tooltip: "You need to be logged in to use this."
     export_task:
       error: An error occurred.
       title: Export task

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -6,25 +6,80 @@ RSpec.describe CommentsController do
   render_views
 
   let(:user) { create(:user) }
-  let(:task) { create(:task) }
-
-  before { sign_in user }
+  let(:task_owner) { user }
+  let(:access_level) { :private }
+  let(:task) { create(:task, user: task_owner, access_level:) }
 
   describe 'GET #index' do
-    it 'renders load_comments view' do
-      get :index, params: {task_id: task.id}, format: :js, xhr: true
-      expect(response).to render_template('load_comments')
+    subject(:get_request) { get :index, params: {task_id: task.id}, format: :js, xhr: true }
+
+    shared_examples 'error redirect' do
+      it 'redirects to root page' do
+        get_request
+        expect(response).to have_http_status :redirect
+      end
+
+      it 'shows a flash message' do
+        get_request
+        expect(flash[:alert]).to eq I18n.t('controllers.authorization')
+      end
     end
 
-    it 'answers with HTTP 200 OK' do
-      get :index, params: {task_id: task.id}, format: :js, xhr: true
-      expect(response).to have_http_status :ok
+    shared_examples 'successful response' do
+      it 'renders load_comments view' do
+        get_request
+        expect(response).to render_template('load_comments')
+      end
+
+      it 'answers with HTTP 200 OK' do
+        get_request
+        expect(response).to have_http_status :ok
+      end
+    end
+
+    context 'when not signed in' do
+      context 'when task access level is private' do
+        it_behaves_like 'error redirect'
+      end
+
+      context 'when task access level is public' do
+        let(:access_level) { :public }
+
+        it_behaves_like 'successful response'
+      end
+    end
+
+    context 'when signed in' do
+      before { sign_in user }
+
+      context 'when user is owner of task' do
+        it_behaves_like 'successful response'
+      end
+
+      context 'when user is not owner of task' do
+        let(:task_owner) { create(:user) }
+
+        context 'when task is public' do
+          let(:access_level) { :public }
+
+          it_behaves_like 'successful response'
+        end
+
+        context 'when task is private' do
+          it_behaves_like 'error redirect'
+        end
+      end
     end
   end
 
   describe 'GET #edit' do
+    let(:access_level) { :public }
+    let(:comment) { create(:comment, user:, task:) }
+
+    before { sign_in user }
+
     it 'answers with HTTP 200 OK' do
-      get :index, params: {task_id: task.id}, format: :js, xhr: true
+      get :edit, params: {task_id: task.id, id: comment.id}, format: :js, xhr: true
       expect(response).to have_http_status :ok
     end
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Comment do
     it { is_expected.not_to be_able_to(:new, described_class) }
     it { is_expected.not_to be_able_to(:manage, described_class) }
 
-    it { is_expected.not_to be_able_to(:show, comment) }
-    it { is_expected.not_to be_able_to(:read, comment) }
+    it { is_expected.to be_able_to(:show, comment) }
+    it { is_expected.to be_able_to(:read, comment) }
     it { is_expected.not_to be_able_to(:answer, comment) }
     it { is_expected.not_to be_able_to(:update, comment) }
     it { is_expected.not_to be_able_to(:destroy, comment) }


### PR DESCRIPTION
This allows users to view and download tasks without signing in. The idea is that OAI-PMH harvesters can present their users with working links for the records they fetched from CodeHarbor. 

The show.html.slim does get harder to read with this but I could not find a better approach.
I am looking forward to your feedback :)