### PR TITLE
Add Mailer preview

### DIFF
--- a/app/views/access_request_mailer/send_contribution_request.html.erb
+++ b/app/views/access_request_mailer/send_contribution_request.html.erb
@@ -10,7 +10,7 @@
   If you want to make him a co-author or suggest Membership to a group click the link below.
   Otherwise ignore this Email. <br/>
   <br/>
-  <%= link_to 'CodeHarbor', sessions_email_link_url(user: @author)%>
+  <%= link_to 'CodeHarbor', user_messages_url(@author)%>
 </p>
 </body>
 </html>

--- a/app/views/access_request_mailer/send_contribution_request.text.erb
+++ b/app/views/access_request_mailer/send_contribution_request.text.erb
@@ -3,4 +3,4 @@ Hello <%= @author.name %>
 <%= @user.name %> asked to contribute to your Exercise "<%= @exercise.title %>".
 If you want to make him a co-author or suggest Membership to a group click the link below.
 Otherwise ignore this Email.
-<%= sessions_email_link_url(user: @author) %>
+<%= user_messages_url(@author) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,8 @@ module CodeHarbor
 
     # config.action_cable.mount_path = "#{ENV.fetch('RAILS_RELATIVE_URL_ROOT', '')}/cable"
 
+    config.action_mailer.preview_paths << Rails.root.join('spec/mailers/previews')
+
     # Specify default options for Rails generators
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid

--- a/spec/mailers/previews/access_request_mailer_preview.rb
+++ b/spec/mailers/previews/access_request_mailer_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'factory_bot_rails'
+
+class AccessRequestMailerPreview < ActionMailer::Preview
+  def send_access_request
+    group = FactoryBot.build(:group, id: 1)
+    admin = group.group_memberships.find(&:role_admin?).user
+    user = FactoryBot.build(:user)
+    AccessRequestMailer.send_access_request(user, admin, group)
+  end
+
+  def send_contribution_request
+    task = FactoryBot.build(:task)
+    author = task.user
+    author.id = 1
+    user = FactoryBot.build(:user)
+    AccessRequestMailer.send_contribution_request(author, task, user)
+  end
+end


### PR DESCRIPTION
These commits enable a preview of mails. Those are accessible at http://localhost:7500/rails/mailers/.