### PR TITLE
Enable dynamic page titles

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -55,6 +55,7 @@ class Ability
     can :access, :rails_admin
 
     can :manage, :all
+    cannot :index, User # There is no index page for users
   end
 
   def account_link_abilities(user)

--- a/app/models/account_link.rb
+++ b/app/models/account_link.rb
@@ -14,4 +14,12 @@ class AccountLink < ApplicationRecord
   def usable_by?(user)
     self.user == user || user.in?(shared_users)
   end
+
+  def self.parent_resource
+    User
+  end
+
+  def to_s
+    name
+  end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -23,4 +23,8 @@ class Collection < ApplicationRecord
       tasks.delete(task)
     end
   end
+
+  def to_s
+    title
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -76,6 +76,10 @@ class Group < ApplicationRecord
     group_membership_for(user)&.role_admin? && admins.size == 1
   end
 
+  def to_s
+    name
+  end
+
   private
 
   def admin_in_group

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,6 +16,10 @@ class Message < ApplicationRecord
     self.recipient_status = 'd' if recipient == user
   end
 
+  def self.parent_resource
+    User
+  end
+
   private
 
   def destroy_deleted_message

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -194,6 +194,10 @@ class Task < ApplicationRecord
     ISO_639.find(language.split('-').first).alpha2
   end
 
+  def to_s
+    title
+  end
+
   private
 
   def duplicate_tests

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,6 +136,10 @@ class User < ApplicationRecord
     }
   end
 
+  def to_s
+    name
+  end
+
   private
 
   def avatar_format

--- a/app/views/application/_breadcrumbs_and_title.html.slim
+++ b/app/views/application/_breadcrumbs_and_title.html.slim
@@ -26,7 +26,8 @@
   - active_action = t("breadcrumbs.#{controller_name}.#{params[:action]}")
 
 
-- title = "#{active_action} - #{application_name}"
+- title = "#{application_name}"
+- title = "#{active_action} - #{title}" unless %w[index show].include? params[:action]
 - content_for :breadcrumbs do
   .container.mb-4
     ul.breadcrumb.bg-body-secondary.px-3.py-2

--- a/app/views/application/_breadcrumbs_and_title.html.slim
+++ b/app/views/application/_breadcrumbs_and_title.html.slim
@@ -1,1 +1,50 @@
-- content_for :title, application_name
+- model = controller_path.classify.constantize rescue nil
+- if model
+  - object = model.find_by(id: params[:id])
+  - if (parent_model = model.try(:parent_resource))
+    - parent_route_key = parent_model.model_name.singular_route_key
+    - if params["#{parent_route_key}_id"].present?
+      - parent_object = object.try(parent_route_key) || parent_model.find_by(id: params["#{parent_route_key}_id"])
+      - parent_element = link_to_if(current_user && can?(:show, parent_object), parent_object, {controller: parent_model.model_name.route_key, action: :show, id: parent_object.id})
+      - parent_root_element = link_to_if(current_user && can?(:index, parent_model), parent_model.model_name.human(count: 2), {controller: parent_model.model_name.route_key, action: :index})
+      - root_element = link_to_if(current_user && can?(:index, model), model.model_name.human(count: 2), send(:"#{parent_route_key}_#{model.model_name.route_key}_path", parent_object))
+      - if object
+        - current_element = link_to_if(current_user && can?(:show, object), object, send(:"#{parent_route_key}_#{model.model_name.singular}_path", parent_object, object))
+    - else
+      - root_element = link_to_if(current_user && can?(:index, model), model.model_name.human(count: 2), {controller: model.model_name.route_key, action: :index})
+      - if object
+        - current_element = link_to_if(current_user && can?(:show, object), object, {controller: model.model_name.route_key, action: :show, id: object.id})
+  - else
+    - root_element = link_to_if(current_user && can?(:index, model), model.model_name.human(count: 2), {controller: model.model_name.route_key, action: :index})
+    - if object
+      - current_element = link_to_if(current_user && can?(:show, object), object, {controller: model.model_name.route_key, action: :show, id: object.id})
+  - if I18n.exists?("shared.#{params[:action]}")
+    - active_action = t("shared.#{params[:action]}", model: model&.model_name&.human)
+  - else
+    - active_action = t("#{controller_name}.index.#{params[:action]}", model: model&.model_name&.human)
+- else
+  - active_action = t("breadcrumbs.#{controller_name}.#{params[:action]}")
+
+
+- title = "#{active_action} - #{application_name}"
+- content_for :breadcrumbs do
+  .container.mb-4
+    ul.breadcrumb.bg-body-secondary.px-3.py-2
+      - if defined?(parent_root_element) && parent_root_element.present?
+        li.breadcrumb-item.small
+          = parent_root_element
+        li.breadcrumb-item.small
+          = parent_element
+        - title = "#{parent_object} - #{title}"
+      - if root_element.present?
+        li.breadcrumb-item.small
+          = root_element
+        - if current_element.present?
+          li.breadcrumb-item.small
+            = current_element
+          - title = "#{object} - #{title}"
+        - else
+          - title = "#{model.model_name.human(count: 2)} - #{title}"
+      li.breadcrumb-item.active.small
+        = active_action
+- content_for :title, title

--- a/config/locales/en/views/breadcrumbs.yml
+++ b/config/locales/en/views/breadcrumbs.yml
@@ -1,0 +1,36 @@
+---
+en:
+  breadcrumbs:
+    confirmations:
+      create: Confirm Account
+      new: Confirm Account
+      show: Confirm Account
+    home:
+      about: About
+      account_link_documentation: About Account Links
+      index: Cover Page
+    passwords:
+      create: Forgot Password
+      edit: Change Password
+      new: Forgot Password
+      update: Change Password
+    registrations:
+      create: Sign Up
+      edit: Update Profile
+      new: Sign Up
+      update: Update Profile
+    sessions:
+      create: Sign In
+      new: Sign In
+    unlocks:
+      create: Unlock Account
+      new: Unlock Account
+      show: Unlock Account
+  shared:
+    create: Create
+    delete: Delete
+    edit: Edit
+    index: Index
+    new: New
+    show: Show
+    update: Update

--- a/config/locales/en/views/collections.yml
+++ b/config/locales/en/views/collections.yml
@@ -12,6 +12,7 @@ en:
       errorMessage: prohibited this collection from being saved.
     index:
       new_collection: New Collection
+      view_shared: View Shared Collection
     new:
       header: New Collection
     show:

--- a/config/locales/en/views/messages.yml
+++ b/config/locales/en/views/messages.yml
@@ -14,6 +14,7 @@ en:
         view: View
       from: From
       no_messages: You do not have any messages.
+      reply: Reply
       sent: Sent
       to: To
       unknown: unknown


### PR DESCRIPTION
Thanks to the work performed in #1021, we can now enable dynamic page titles for CodeHarbor. This is done through a mechanism already used in CodeOcean (the code is mainly copied over). While the mechanism is not that easy to read (I agree!), it is relatively complete and works in many edge cases.

Unfortunately, we have to repeat some Devise-related translations. Otherwise, the Devise views would break in case of validation errors.