### PR TITLE
Use common defaults for shared/form_errors

### DIFF
--- a/app/views/account_links/_form.html.slim
+++ b/app/views/account_links/_form.html.slim
@@ -1,6 +1,6 @@
 = form_for([@user, @account_link]) do |f|
   .mt-4
-    = render('shared/form_errors', object: @account_link, model: AccountLink, title: t('common.errors.model_not_saved'))
+    = render('shared/form_errors', object: @account_link)
     .field-element.form-group
       = f.label :name, AccountLink.human_attribute_name('name'), class: 'form-label'
       = f.text_field :name, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('.info.name'), class: 'form-control'

--- a/app/views/collections/_form.html.slim
+++ b/app/views/collections/_form.html.slim
@@ -1,6 +1,6 @@
 = form_for(@collection) do |f|
   .mt-5
-    = render('shared/form_errors', object: @collection, model: Collection, title: t('common.errors.model_not_saved'))
+    = render('shared/form_errors', object: @collection)
     .field-element.form-group
       = f.label :title, Collection.human_attribute_name('title'), class: 'form-label'
       = f.text_field :title, class: 'form-control'

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -1,6 +1,6 @@
 = form_for @group do |f|
   .mt-5
-    = render('shared/form_errors', object: @group, model: Group, title: t('common.errors.model_not_saved'))
+    = render('shared/form_errors', object: @group)
 
     .field-element.form-group
       = f.label :name, 'Title', class: 'form-label'

--- a/app/views/messages/_form.html.slim
+++ b/app/views/messages/_form.html.slim
@@ -1,6 +1,6 @@
 = form_for :message, url: user_messages_path(@user) do |f|
   .mt-5
-    = render('shared/form_errors', object: @message, model: Message, title: t('common.errors.model_not_saved'))
+    = render('shared/form_errors', object: @message)
 
     - if @recipient
       = f.hidden_field :recipient_hidden, value: @recipient.id

--- a/app/views/shared/_form_errors.html.slim
+++ b/app/views/shared/_form_errors.html.slim
@@ -3,7 +3,9 @@
     - if object.errors.size == 1
       = object.errors.full_messages.first
     - else
-      h4 = title % {model: model.model_name.human}
+      - model_class = defined? model ? model : object.class
+      - title_translation = defined? title ? title : t('common.errors.model_not_saved', model: model_class.model_name.human)
+      h4 = title_translation
       ul
         - object.errors.full_messages.each do |message|
           li = message

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,7 +1,7 @@
 .row
   .col-md-12.my-4
     = simple_form_for @task, html: { class: 'project exercise-validation', multipart: true } do |f|
-      = render('shared/form_errors', object: @task, model: Task, title: t('common.errors.model_not_saved'))
+      = render('shared/form_errors', object: @task)
       fieldset.form-group
         legend.toggle-next
           span.number = '1'

--- a/app/views/users/confirmations/new.html.slim
+++ b/app/views/users/confirmations/new.html.slim
@@ -4,7 +4,7 @@
     =< t('.resend_confirmation')
 
 = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-  = render('shared/form_errors', object: resource, model: resource.class, title: t('.validation_error'))
+  = render('shared/form_errors', object: resource, title: t('.validation_error'))
 
   .form-group.field-element
     = f.label :email, class: 'form-label'

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -4,7 +4,7 @@
     =< t('.change_pwd')
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-  = render('shared/form_errors', object: resource, model: resource.class, title: t('common.errors.changes_not_saved'))
+  = render('shared/form_errors', object: resource, title: t('common.errors.changes_not_saved'))
   = f.hidden_field :reset_password_token
 
   .form-group.field-element

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -4,7 +4,7 @@
     =< t('.forgot_pwd')
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render('shared/form_errors', object: resource, model: resource.class, title: t('.validation_error'))
+  = render('shared/form_errors', object: resource, title: t('.validation_error'))
 
   .form-group.field-element
     = f.label :email, class: 'form-label'

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -4,7 +4,7 @@
     =< t('.header')
 
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render('shared/form_errors', object: resource, model: resource.class, title: t('common.errors.changes_not_saved'))
+  = render('shared/form_errors', object: resource, title: t('common.errors.changes_not_saved'))
 
   .form-group.field-element
     = f.label :first_name, class: 'form-label'

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -4,7 +4,7 @@
     =< t('.header')
 
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = render('shared/form_errors', object: resource, model: resource.class, title: t('common.errors.model_not_saved'))
+  = render('shared/form_errors', object: resource)
 
   .form-group.field-element
     = f.label :first_name, class: 'form-label'

--- a/app/views/users/unlocks/new.html.slim
+++ b/app/views/users/unlocks/new.html.slim
@@ -4,7 +4,7 @@
     =< t('.resend_unlock')
 
 = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
-  = render('shared/form_errors', object: resource, model: resource.class, title: t('.validation_error'))
+  = render('shared/form_errors', object: resource, title: t('.validation_error'))
 
   .form-group.field-element
     = f.label :email, class: 'form-label'


### PR DESCRIPTION
I was wondering whether we could simplify the usage of the `shared/form_errors`, since some information could be extracted automatically. While I like the support for custom arguments, I also think we can remove some explicit reference.

This is just a suggestion and proof-of-concept, but I think it was worth to try it (and think we could also discuss merging it).