### PR TITLE
Fix small interoperability issues

### DIFF
--- a/app/services/proforma_service/convert_task_to_proforma_task.rb
+++ b/app/services/proforma_service/convert_task_to_proforma_task.rb
@@ -38,7 +38,8 @@ module ProformaService
     def description
       return @task.description if @options[:description_format] == 'md'
 
-      ApplicationController.helpers.render_markdown(@task.description)
+      string = ApplicationController.helpers.render_markdown(@task.description)
+      string.scan(/<\w/).length == 1 ? string.gsub(%r{</?p>}, '') : string
     end
 
     def proglang
@@ -83,7 +84,7 @@ module ProformaService
         filename: file.full_file_name,
         used_by_grader: file.used_by_grader || false,
         visible: file.visible,
-        usage_by_lms: file.usage_by_lms || 'download',
+        usage_by_lms: file.usage_by_lms,
         internal_description: file.internal_description
       )
       add_content_to_task_file(file, task_file)

--- a/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
+++ b/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
     it 'creates a task with all basic attributes' do
       expect(proforma_task).to have_attributes(
         title: task.title,
-        description: ApplicationController.helpers.render_markdown(task.description),
+        description: 'description',
         internal_description: task.internal_description,
         proglang: {
           name: task.programming_language.language,
@@ -57,19 +57,23 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
       )
     end
 
-    context 'with options' do
-      let(:convert_to_proforma_task) { described_class.new(task:, options:) }
-      let(:options) { {} }
+    context 'with complex description' do
+      let(:description) { "first part\n\nsecond part" }
 
-      it 'converts the description markdown to text' do
-        expect(proforma_task).to have_attributes(description: ApplicationController.helpers.render_markdown(task.description))
-      end
+      context 'with options' do
+        let(:convert_to_proforma_task) { described_class.new(task:, options:) }
+        let(:options) { {} }
 
-      context 'when options contain description_format md' do
-        let(:options) { {description_format: 'md'} }
+        it 'converts the description markdown to text' do
+          expect(proforma_task).to have_attributes(description: "<p>first part</p>\n\n<p>second part</p>")
+        end
 
-        it 'does not convert the description markdown' do
-          expect(proforma_task).to have_attributes(description: task.description)
+        context 'when options contain description_format md' do
+          let(:options) { {description_format: 'md'} }
+
+          it 'does not convert the description markdown' do
+            expect(proforma_task).to have_attributes(description: task.description)
+          end
         end
       end
     end
@@ -102,8 +106,8 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
       context 'when file has no "usage_by_lms" defined' do
         let(:file) { build(:task_file) }
 
-        it 'creates a task-file with the correct default value' do
-          expect(proforma_task.files.first).to have_attributes(usage_by_lms: 'download')
+        it 'does not set usage_by_lms' do
+          expect(proforma_task.files.first).to have_attributes(usage_by_lms: nil)
         end
       end
 

--- a/spec/services/proforma_service/export_task_spec.rb
+++ b/spec/services/proforma_service/export_task_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ProformaService::ExportTask do
     let(:export_service) { described_class.new(task:) }
     let(:task) do
       create(:task,
+        description:,
         internal_description: 'internal_description',
         uuid: SecureRandom.uuid,
         programming_language: build(:programming_language, :ruby),
@@ -26,6 +27,7 @@ RSpec.describe ProformaService::ExportTask do
         tests:,
         model_solutions:)
     end
+    let(:description) { 'description ' }
     let(:files) { [] }
     let(:tests) { [] }
     let(:model_solutions) { [] }
@@ -48,8 +50,16 @@ RSpec.describe ProformaService::ExportTask do
       expect(xml.xpath('/task/title').text).to eql task.title
     end
 
-    it 'adds description node with correct content (html) to task node' do
-      expect(xml.xpath('/task/description').text).to eql ApplicationController.helpers.render_markdown(task.description)
+    it 'adds description node with correct content (simple string) to task node' do
+      expect(xml.xpath('/task/description').text).to eql 'description'
+    end
+
+    context 'with complex description' do
+      let(:description) { "first part\n\nsecond part" }
+
+      it 'adds description node with correct content (simple string) to task node' do
+        expect(xml.xpath('/task/description').text).to eql "<p>first part</p>\n\n<p>second part</p>"
+      end
     end
 
     it 'adds proglang node with correct content to task node' do


### PR DESCRIPTION
Proforma Export:
- fix forcing default usage-of-lms
- simplify simple description strings