### PR TITLE
Redirect users after sign in to their desired page

### DIFF
--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -34,6 +34,7 @@ en:
       model_not_saved: "%{model} could not be saved due to errors:"
       not_authorized: You are not authorized for this action.
       not_found_error: You are not able to access this object or it doesn't exist
+      not_signed_in: You must be signed in to continue.
       something_went_wrong: Something went wrong
     locales:
       en: English

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CommentsController do
   describe 'GET #index' do
     subject(:get_request) { get :index, params: {task_id: task.id}, format: :js, xhr: true }
 
-    shared_examples 'error redirect' do
+    shared_examples 'error redirect' do |error_message|
       it 'redirects to root page' do
         get_request
         expect(response).to have_http_status :redirect
@@ -21,7 +21,7 @@ RSpec.describe CommentsController do
 
       it 'shows a flash message' do
         get_request
-        expect(flash[:alert]).to eq I18n.t('common.errors.not_authorized')
+        expect(flash[:alert]).to eq I18n.t("common.errors.#{error_message}")
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe CommentsController do
 
     context 'when not signed in' do
       context 'when task access level is private' do
-        it_behaves_like 'error redirect'
+        it_behaves_like 'error redirect', 'not_signed_in'
       end
 
       context 'when task access level is public' do
@@ -66,7 +66,7 @@ RSpec.describe CommentsController do
         end
 
         context 'when task is private' do
-          it_behaves_like 'error redirect'
+          it_behaves_like 'error redirect', 'not_authorized'
         end
       end
     end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -8,11 +8,26 @@ RSpec.describe HomeController do
   describe '#render_not_authorized' do
     before do
       allow(controller).to receive(:index) { controller.send(:render_not_authorized) }
+      sign_in user if defined?(user)
       get :index
     end
 
-    expect_flash_message(:alert, I18n.t('common.errors.not_authorized'))
-    expect_redirect(:root)
+    expect_flash_message(:alert, I18n.t('common.errors.not_signed_in'))
+    expect_redirect(:new_user_session)
+
+    context 'with an admin' do
+      let(:user) { create(:admin) }
+
+      expect_flash_message(:alert, I18n.t('common.errors.not_authorized'))
+      expect_redirect(:root)
+    end
+
+    context 'with an user' do
+      let(:user) { create(:user) }
+
+      expect_flash_message(:alert, I18n.t('common.errors.not_authorized'))
+      expect_redirect(:root)
+    end
   end
 
   describe '#render_not_found' do
@@ -22,19 +37,21 @@ RSpec.describe HomeController do
       get :index
     end
 
-    expect_flash_message(:alert, I18n.t('common.errors.not_authorized'))
-    expect_redirect(:root)
+    expect_flash_message(:alert, I18n.t('common.errors.not_signed_in'))
+    expect_redirect(:new_user_session)
 
     context 'with an admin' do
       let(:user) { create(:admin) }
 
       expect_flash_message(:alert, I18n.t('common.errors.not_found_error'))
+      expect_redirect(:root)
     end
 
     context 'with an user' do
       let(:user) { create(:user) }
 
       expect_flash_message(:alert, I18n.t('common.errors.not_authorized'))
+      expect_redirect(:root)
     end
   end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -126,14 +126,14 @@ RSpec.describe TasksController do
     context 'when no user is signed in' do
       before { sign_out user }
 
-      it 'redirects to root page' do
+      it 'redirects to sign-in page' do
         get_request
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(new_user_session_path)
       end
 
       it 'shows a flash message' do
         get_request
-        expect(flash[:alert]).to eq I18n.t('common.errors.not_authorized')
+        expect(flash[:alert]).to eq I18n.t('common.errors.not_signed_in')
       end
     end
   end


### PR DESCRIPTION
When a user is not signed in but accesses a restricted page, we currently only show a generic error message and redirect them to the root page. However, it would be a nice quality of life improvement to support them in signing in and then access the desired page immediately. This PR adds that functionality.