### PR TITLE
781 small issue compilation extract collections and groups

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -289,3 +289,7 @@ fieldset.form-group {
 #logo {
   color: #406e8e;
 }
+
+.dropdown-title {
+  padding-left: 2px;
+}

--- a/app/assets/stylesheets/collections.css.scss
+++ b/app/assets/stylesheets/collections.css.scss
@@ -10,6 +10,8 @@ $collection-color: #000080;
 .collection-content {
   width: 60%;
   margin-bottom: 40px;
+  border-top: 1px solid lightgrey;
+
 }
 
 .nav-container .nav-btn-collection {
@@ -30,8 +32,18 @@ $collection-color: #000080;
 }
 
 .collection-subinfo {
-  margin-top: 5px;
-  font-size: 16px;
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  span {
+    i {
+      &:first-child {
+        width: 20px;
+      }
+    }
+
+    padding: 5px;
+  }
 }
 
 .collection-checkmark {
@@ -77,8 +89,4 @@ $collection-color: #000080;
 .collection-edit-visibility {
   width: unset;
   margin-right: 10px;
-}
-
-.lock-icon {
-  font-size: 20px;
 }

--- a/app/assets/stylesheets/collections.css.scss
+++ b/app/assets/stylesheets/collections.css.scss
@@ -6,10 +6,12 @@ $collection-color: #000080;
 .fa-solid.fa-folder-open {
   color: $collection-color;
 }
+
 .collection-content {
   width: 60%;
   margin-bottom: 40px;
 }
+
 .nav-container .nav-btn-collection {
   padding: 10px 15px;
 }
@@ -70,4 +72,13 @@ $collection-color: #000080;
       display: none;
     }
   }
+}
+
+.collection-edit-visibility {
+  width: unset;
+  margin-right: 10px;
+}
+
+.lock-icon {
+  font-size: 20px;
 }

--- a/app/assets/stylesheets/collections.css.scss
+++ b/app/assets/stylesheets/collections.css.scss
@@ -27,6 +27,21 @@ $collection-color: #000080;
   margin-right: 5px;
 }
 
+.collection-subinfo {
+  margin-top: 5px;
+  font-size: 16px;
+}
+
+.collection-checkmark {
+  width: 10px;
+  display: inline-block;
+  margin-right: 5px;
+}
+
+.create-collection {
+  margin: 0 10px;
+}
+
 #collection-tasks-sortable {
   .row {
     border-bottom: 1px solid #ccc;

--- a/app/assets/stylesheets/tasks.css.scss
+++ b/app/assets/stylesheets/tasks.css.scss
@@ -116,10 +116,3 @@
     margin-bottom: 0 !important;
   }
 }
-
-//.create-collection{
-//  display: flex;
-  .submit {
-    margin-bottom: 0 !important;
-  }
-//}

--- a/app/assets/stylesheets/tasks.css.scss
+++ b/app/assets/stylesheets/tasks.css.scss
@@ -104,3 +104,22 @@
 .task_label:first-child {
   margin-left: 0;
 }
+
+.dropdown-menu {
+  width: 100%;
+}
+
+.create-collection.input-group {
+  width: calc(100% - 20px);
+  .btn.submit {
+    width: unset;
+    margin-bottom: 0 !important;
+  }
+}
+
+//.create-collection{
+//  display: flex;
+  .submit {
+    margin-bottom: 0 !important;
+  }
+//}

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -157,6 +157,7 @@ class CollectionsController < ApplicationController
   end
 
   def collection_params
-    params.require(:collection).permit(:title, :task_ids, :visibility_level, :description, collection_tasks_attributes: collection_tasks_params)
+    params.require(:collection).permit(:title, :task_ids, :visibility_level, :description,
+      collection_tasks_attributes: collection_tasks_params)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -6,8 +6,7 @@ class CollectionsController < ApplicationController
   before_action :load_and_authorize_collection, except: %i[index new create create_ajax]
 
   def index
-    @collections = Collection.includes(:users, tasks: %i[user groups])
-      .where(collection_users: {user: current_user})
+    @collections = Collection.member(current_user).or(Collection.public_access).includes(:users, tasks: %i[user groups])
       .order(id: :asc)
       .paginate(page: params[:page], per_page: per_page_param)
       .load
@@ -162,6 +161,6 @@ class CollectionsController < ApplicationController
   end
 
   def collection_params
-    params.require(:collection).permit(:title, :task_ids, :description, collection_tasks_attributes: collection_tasks_params)
+    params.require(:collection).permit(:title, :task_ids, :visibility_level, :description, collection_tasks_attributes: collection_tasks_params)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -110,7 +110,7 @@ class CollectionsController < ApplicationController
   end
 
   def save_shared
-    return redirect_to user_messages_path(user), alert: t('.errors.already_member') if @collection.users.include? user
+    return redirect_to user_messages_path(current_user), alert: t('.errors.already_member') if @collection.users.include? current_user
 
     @collection.users << current_user
     if @collection.save

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -65,12 +65,8 @@ class CollectionsController < ApplicationController
   end
 
   def remove_task_ajax
-    if @collection.remove_task(params[:task])
-      redirect_to Task.find_by(id: params[:task]), notice: t('.success_notice')
-    else
-      flash.now[:alert] = t('.error')
-      head :ok
-    end
+    @collection.remove_task(params[:task])
+    redirect_to Task.find_by(id: params[:task]), notice: t('.success_notice')
   end
 
   def remove_all

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,6 +17,13 @@ class Collection < ApplicationRecord
 
   accepts_nested_attributes_for :collection_tasks, allow_destroy: true
 
+  scope :public_access, -> { where(visibility_level: :public) }
+  scope :member, lambda {|user|
+                   includes(:collection_users).where(collection_users: {user:})
+                 }
+
+  enum visibility_level: {private: 0, public: 1}, _default: :private, _prefix: true
+
   def add_task(task)
     tasks << task unless tasks.find_by(id: task.id)
   end

--- a/app/models/collection_user.rb
+++ b/app/models/collection_user.rb
@@ -3,4 +3,6 @@
 class CollectionUser < ApplicationRecord
   belongs_to :collection
   belongs_to :user
+
+  validates :user_id, uniqueness: {scope: :collection_id}
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -17,7 +17,7 @@ class CollectionPolicy < ApplicationPolicy
     admin? || collection.users.include?(@user) || collection.visibility_level_public?
   end
 
-  %i[create? create_ajax? show? update? edit? destroy? leave? add_task? remove_task? remove_task_ajax? remove_all? push_collection?
+  %i[create? create_ajax? update? edit? destroy? leave? add_task? remove_task? remove_task_ajax? remove_all? push_collection?
      download_all? share?].each do |action|
     define_method(action) { admin? || collection.users.include?(@user) }
   end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -13,12 +13,16 @@ class CollectionPolicy < ApplicationPolicy
     everyone
   end
 
-  %i[create? show? update? edit? destroy? leave? add_task? remove_task? remove_all? push_collection? download_all?
-     share? view_shared?].each do |action|
+  def show?
+    admin? || collection.users.include?(@user) || collection.visibility_level_public?
+  end
+
+  %i[create? create_ajax? show? update? edit? destroy? leave? add_task? remove_task? remove_task_ajax? remove_all? push_collection?
+     download_all? share?].each do |action|
     define_method(action) { admin? || collection.users.include?(@user) }
   end
 
-  def save_shared?
-    Message.received_by(@user).exists?(param_type: 'collection', param_id: collection.id) || admin?
+  %i[save_shared? view_shared?].each do |action|
+    define_method(action) { Message.received_by(@user).exists?(param_type: 'collection', param_id: collection.id) || admin? }
   end
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -17,7 +17,7 @@ class CollectionPolicy < ApplicationPolicy
     admin? || collection.users.include?(@user) || collection.visibility_level_public?
   end
 
-  %i[create? create_ajax? update? edit? destroy? leave? add_task? remove_task? remove_task_ajax? remove_all? push_collection?
+  %i[create? update? edit? destroy? leave? add_task? remove_task? remove_all? push_collection?
      download_all? share?].each do |action|
     define_method(action) { admin? || collection.users.include?(@user) }
   end

--- a/app/views/collections/_collections.html.slim
+++ b/app/views/collections/_collections.html.slim
@@ -14,6 +14,11 @@
     .card-header
       h6
         span= collection.title
+        - if collection.visibility_level_public?
+          i.fa-solid.fa-lock-open.float-end title=(t('collections.visibility.public'))
+        - else
+          i.fa-solid.fa-lock.float-end title=(t('collections.visibility.private'))
+
     .card-body
       .row.px-3
         .col
@@ -44,7 +49,8 @@
                     = link_to task.title, task_path(task), class: 'btn btn-light disabled'
         .col-auto
           .btn-group.float-end aria-label="..." role="group"
-            - if policy(collection).edit?
+            - if policy(collection).show?
               = link_to t('common.button.view'), collection_path(collection), class: 'btn btn-light'
+            - if policy(collection).edit?
               = link_to t('common.button.edit'), edit_collection_path(collection), class: 'btn btn-light'
 = render('shared/pagination', collection: @collections)

--- a/app/views/collections/_form.html.slim
+++ b/app/views/collections/_form.html.slim
@@ -9,7 +9,7 @@
         = f.label :description, Collection.human_attribute_name('description'), class: 'form-label'
         = f.text_area :description, class: 'form-control', rows: 10
       .field-element
-        = f.label :visibility_level,  Collection.human_attribute_name("visibility_level"), class: 'form-label collection-edit-visibility'
+        = f.label :visibility_level, Collection.human_attribute_name("visibility_level"), class: 'form-label collection-edit-visibility'
         .radio-switch
           = f.radio_button :visibility_level, :public, value: :public, checked: true
           = label_tag 'collection_visibility_level_public', t('collections.visibility.public'), class: 'radio-left'

--- a/app/views/collections/_form.html.slim
+++ b/app/views/collections/_form.html.slim
@@ -8,6 +8,14 @@
       .field-element
         = f.label :description, Collection.human_attribute_name('description'), class: 'form-label'
         = f.text_area :description, class: 'form-control', rows: 10
+      .field-element
+      = f.label :visibility_level,  Collection.human_attribute_name("visibility_level"), class: 'form-label collection-edit-visibility'
+      .radio-switch
+        = f.radio_button :visibility_level, :public, value: :public, checked: true
+        = label_tag 'collection_visibility_level_public', t('collections.visibility.public'), class: 'radio-left'
+        = f.radio_button :visibility_level, :private, value: :private
+        = label_tag 'collection_visibility_level_private', t('collections.visibility.private'), class: 'radio-right'
+
       - if @collection.persisted?
         .field-element
           = f.label :tasks, Collection.human_attribute_name('tasks'), class: 'form-label'

--- a/app/views/collections/_form.html.slim
+++ b/app/views/collections/_form.html.slim
@@ -9,12 +9,12 @@
         = f.label :description, Collection.human_attribute_name('description'), class: 'form-label'
         = f.text_area :description, class: 'form-control', rows: 10
       .field-element
-      = f.label :visibility_level,  Collection.human_attribute_name("visibility_level"), class: 'form-label collection-edit-visibility'
-      .radio-switch
-        = f.radio_button :visibility_level, :public, value: :public, checked: true
-        = label_tag 'collection_visibility_level_public', t('collections.visibility.public'), class: 'radio-left'
-        = f.radio_button :visibility_level, :private, value: :private
-        = label_tag 'collection_visibility_level_private', t('collections.visibility.private'), class: 'radio-right'
+        = f.label :visibility_level,  Collection.human_attribute_name("visibility_level"), class: 'form-label collection-edit-visibility'
+        .radio-switch
+          = f.radio_button :visibility_level, :public, value: :public, checked: true
+          = label_tag 'collection_visibility_level_public', t('collections.visibility.public'), class: 'radio-left'
+          = f.radio_button :visibility_level, :private, value: :private
+          = label_tag 'collection_visibility_level_private', t('collections.visibility.private'), class: 'radio-right'
 
       - if @collection.persisted?
         .field-element

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -88,7 +88,7 @@
           =< t('common.button.edit')
         - if @collection.users.include? current_user
           = link_to leave_collection_path(@collection), class: 'btn btn-important', method: :post, data: { confirm: @collection.users.count == 1 ? t('.leave.deletion_warning') : t('common.sure') } do
-            = t('.button.leave')
+            = @collection.users.count == 1 ? t('.button.delete') : t('.button.leave')
 
         = link_to t('common.button.back'), collections_path, class: 'btn btn-important'
 

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -75,7 +75,7 @@
                 | :
               .input-group
                 = text_field_tag 'user', nil, form: 'share', class: 'form-control'
-                = submit_tag t('.button.share'), form: 'share', class: 'btn btn-light', type: 'button'
+                = submit_tag t('.button.share'), form: 'share', class: 'btn btn-light'
           .dropup.btn-group
             = button_tag class: 'btn btn-important dropdown-toggle', 'data-bs-toggle': 'dropdown' do
               => t('common.button.export')

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -2,20 +2,25 @@
   .std-heading
     i.fa-solid.fa-folder-open
     =<> @collection.title
-    - if @collection.visibility_level_public?
-      i.fa-solid.fa-lock-open.lock-icon title=(t('collections.visibility.public'))
-    - else
-      i.fa-solid.fa-lock.lock-icon title=(t('collections.visibility.private'))
-    div.collection-subinfo
-      i.fa-solid.fa-users
-      - if @collection.users.length == 1
-        =< t('.no_other_user')
-      - else
-        =< t('.num_of_other_users', count: @collection.users.length - 1)
-
+    hr.mb-2
 .row
-  .col-md-12.mt-4
-    .collection-content
+  .col-md-12
+    .collection-subinfo
+      span
+        - if @collection.visibility_level_public?
+          i.fa-solid.fa-lock-open.lock-icon
+          =< t('.visibility.public')
+        - else
+          i.fa-solid.fa-lock.lock-icon
+          =< t('.visibility.private')
+      span
+        i.fa-solid.fa-users
+        - if @collection.users.length == 1
+          =< t('.no_other_user')
+        - else
+          =< t('.num_of_other_users', count: @collection.users.length - 1)
+
+    .collection-content.mt-2.pt-2
       .description.collapsable.w-100
         - if @collection.description.blank?
           span style=("color: gray")

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -15,10 +15,10 @@
           =< t('.visibility.private')
       span
         i.fa-solid.fa-users
-        - if @collection.users.length == 1
+        - if @collection.users.size == 1
           =< t('.no_other_user')
         - else
-          =< t('.num_of_other_users', count: @collection.users.length - 1)
+          =< t('.num_of_other_users', count: @collection.users.size - 1)
 
     .collection-content.mt-2.pt-2
       .description.collapsable.w-100
@@ -75,7 +75,7 @@
               => t('.button.share')
               span.caret
             .dropdown-menu#share-menu
-              .dropdown-header style="padding-left: 2px;"
+              .dropdown-header.dropdown-title
                 = t('.type_hint')
                 | :
               .input-group
@@ -103,8 +103,8 @@
             i.fa-solid.fa-pen-to-square
             =< t('common.button.edit')
           - if @collection.users.include? current_user
-            = link_to leave_collection_path(@collection), class: 'btn btn-important', method: :post, data: { confirm: @collection.users.count == 1 ? t('.leave.deletion_warning') : t('common.sure') } do
-              = @collection.users.count == 1 ? t('.button.delete') : t('.button.leave')
+            = link_to leave_collection_path(@collection), class: 'btn btn-important', method: :post, data: { confirm: @collection.users.size == 1 ? t('.leave.deletion_warning') : t('common.sure') } do
+              = @collection.users.size == 1 ? t('.button.delete') : t('.button.leave')
         = link_to t('common.button.back'), collections_path, class: 'btn btn-important'
 
 = form_tag share_collection_path, id: 'share'

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -2,6 +2,13 @@
   .std-heading
     i.fa-solid.fa-folder-open
     =< @collection.title
+    div.collection-subinfo
+      i.fa-solid.fa-users
+      - if @collection.users.length == 1
+        =< t('.no_other_user')
+      - else
+        =< t('.num_of_other_users', count: @collection.users.length - 1)
+
 .row
   .col-md-12.mt-4
     .collection-content

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -1,7 +1,11 @@
 .header
   .std-heading
     i.fa-solid.fa-folder-open
-    =< @collection.title
+    =<> @collection.title
+    - if @collection.visibility_level_public?
+      i.fa-solid.fa-lock-open.lock-icon title=(t('collections.visibility.public'))
+    - else
+      i.fa-solid.fa-lock.lock-icon title=(t('collections.visibility.private'))
     div.collection-subinfo
       i.fa-solid.fa-users
       - if @collection.users.length == 1
@@ -56,22 +60,22 @@
 .row
   .col-md-12
     .actions.btn-group[role="group"]
-      - if @user
+      - if action_name == 'view_shared'
         = link_to t('.button.collaborate'), save_shared_collection_path(@collection), method: 'post', class: 'btn btn-important'
         = link_to t('common.button.back'), user_messages_path(current_user), class: 'btn btn-important'
       - else
-        .btn-group
-          = button_tag type: 'button', 'data-bs-toggle': 'dropdown', aria: {haspopup: "true", expanded: "false"}, class: 'btn btn-important nav-btn-exercise dropdown-toggle split' do
-            => t('.button.share')
-            span.caret
-          .dropdown-menu#share-menu
-            .dropdown-header style="padding-left: 2px;"
-              = t('.type_hint')
-              | :
-            .input-group
-              = text_field_tag 'user', nil, form: 'share', class: 'form-control'
-              = submit_tag t('.button.share'), form: 'share', class: 'btn btn-light', type: 'button'
         - if policy(@collection).edit?
+          .btn-group
+            = button_tag type: 'button', 'data-bs-toggle': 'dropdown', aria: {haspopup: "true", expanded: "false"}, class: 'btn btn-important nav-btn-exercise dropdown-toggle split' do
+              => t('.button.share')
+              span.caret
+            .dropdown-menu#share-menu
+              .dropdown-header style="padding-left: 2px;"
+                = t('.type_hint')
+                | :
+              .input-group
+                = text_field_tag 'user', nil, form: 'share', class: 'form-control'
+                = submit_tag t('.button.share'), form: 'share', class: 'btn btn-light', type: 'button'
           .dropup.btn-group
             = button_tag class: 'btn btn-important dropdown-toggle', 'data-bs-toggle': 'dropdown' do
               => t('common.button.export')
@@ -90,13 +94,12 @@
                     = acc_link.name
               - else
                 = link_to t('.define_account_link'), new_user_account_link_path(current_user), class: 'dropdown-item'
-        = link_to edit_collection_path(@collection), class: 'btn btn-important' do
-          i.fa-solid.fa-pen-to-square
-          =< t('common.button.edit')
-        - if @collection.users.include? current_user
-          = link_to leave_collection_path(@collection), class: 'btn btn-important', method: :post, data: { confirm: @collection.users.count == 1 ? t('.leave.deletion_warning') : t('common.sure') } do
-            = @collection.users.count == 1 ? t('.button.delete') : t('.button.leave')
-
+          =  link_to edit_collection_path(@collection), class: 'btn btn-important' do
+            i.fa-solid.fa-pen-to-square
+            =< t('common.button.edit')
+          - if @collection.users.include? current_user
+            = link_to leave_collection_path(@collection), class: 'btn btn-important', method: :post, data: { confirm: @collection.users.count == 1 ? t('.leave.deletion_warning') : t('common.sure') } do
+              = @collection.users.count == 1 ? t('.button.delete') : t('.button.leave')
         = link_to t('common.button.back'), collections_path, class: 'btn btn-important'
 
 = form_tag share_collection_path, id: 'share'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -17,7 +17,7 @@
             = button_tag type: 'button', 'data-bs-toggle': 'dropdown', aria: {haspopup: "true", expanded: "false"}, class: 'btn btn-main nav-btn-exercise dropdown-toggle split' do
               span.caret
             ul.dropdown-menu.rounded-0.shadow-sm#xml-import
-              li.dropdown-header style="padding-left: 2px;"
+              li.dropdown-header.dropdown-title
                 = t('.button.import_zip')
               li
                 = file_field_tag 'task_import', accept: '.zip', class: 'inputfile'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -478,10 +478,10 @@
             = button_tag class: 'btn btn-light dropdown-toggle', 'data-bs-toggle': 'dropdown' do
               = t('.button.add_to_collection')
             ul.scrollable.dropdown-menu[role="menu"]
-              - current_user.collections.reverse.each do |collection|
+              - current_user.collections.order(created_at: :desc).each do |collection|
                 li
                   - if collection.tasks.include?(@task)
-                    = link_to remove_task_collection_path(collection, task: @task), method: :patch, class: 'dropdown-item', data: { confirm: t('.remove_task_from_collection_warning') } do
+                    = link_to remove_task_collection_path(collection, task: @task, return_to_task: true), method: :patch, class: 'dropdown-item', data: { confirm: t('.remove_task_from_collection_warning') } do
                       span.collection-checkmark
                         = "✓ #{collection.title}"
                   - else
@@ -492,7 +492,7 @@
               li
                 hr.dropdown-divider
               li
-                = form_with model: Collection.new, url: create_ajax_collections_path do |f|
+                = form_with model: Collection.new, url: collections_path do |f|
                   .create-collection.input-group
                     = f.text_field :title, class: 'form-control', placeholder: t('.create_collection_placeholder')
                     = f.hidden_field :task_ids, value: @task.id

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -478,13 +478,25 @@
             = button_tag class: 'btn btn-light dropdown-toggle', 'data-bs-toggle': 'dropdown' do
               = t('.button.add_to_collection')
             ul.scrollable.dropdown-menu[role="menu"]
-              - if !current_user.collections.empty?
-                - current_user.collections.reverse.each do |collection|
-                  li
-                    = link_to collection.title, add_to_collection_task_path(collection: collection), method: 'post', class: 'dropdown-item'
-              - else
+              - current_user.collections.reverse.each do |collection|
                 li
-                  = link_to t('.button.add_collection'), new_collection_path(current_user)
+                  - if collection.tasks.include?(@task)
+                    = link_to remove_task_collection_path(collection, task: @task), method: :patch, class: 'dropdown-item', data: { confirm: t('.remove_task_from_collection_warning') } do
+                      span.collection-checkmark
+                        = "✓ #{collection.title}"
+                  - else
+                    = link_to add_to_collection_task_path(collection: collection), method: :post, class: 'dropdown-item' do
+                      span.collection-checkmark
+                        = collection.title
+
+              li
+                hr.dropdown-divider
+              li
+                = form_with model: Collection.new, url: create_ajax_collections_path do |f|
+                  .create-collection.input-group
+                    = f.text_field :title, class: 'form-control', placeholder: t('.create_collection_placeholder')
+                    = f.hidden_field :task_ids, value: @task.id
+                    = f.submit class: 'btn btn-light submit', value: t('.button.create_collection')
         - else
           div[data-bs-toggle='tooltip' title=t('.guest.disabled.tooltip') data-bs-delay=150]
             = button_tag class: 'btn btn-outline-dark dropdown-toggle disabled', 'data-bs-toggle': 'dropdown' do

--- a/config/locales/de/controllers/collections.yml
+++ b/config/locales/de/controllers/collections.yml
@@ -1,6 +1,9 @@
 ---
 de:
   collections:
+    create:
+      error: Die Aufgabensammlung konnte nicht angelegt werden.
+      success_notice: Die Aufgabensammlung wurde erfolgreich angelegt. (Die Aufgabe wurde automatisch hinzugefügt)
     leave:
       left_successfully: Sie haben die Aufgabensammlung erfolgreich verlassen.
     push_collection:
@@ -12,6 +15,8 @@ de:
     remove_task:
       cannot_remove_alert: Sie können diese Aufgabe nicht entfernen.
     save_shared:
+      errors:
+        already_member: Sie sind bereits ein Mitglied dieser Aufgabensammlung.
       success_notice: Sie können jetzt an dieser Aufgabensammlung zusammenarbeiten.
     share:
       success_notice: Ihre Aufgabensammlung wurde gesendet.

--- a/config/locales/de/views/collections.yml
+++ b/config/locales/de/views/collections.yml
@@ -20,6 +20,7 @@ de:
     show:
       button:
         collaborate: Zusammenarbeiten
+        delete: Aufgabensammlung löschen
         leave: Verlassen
         share: Aufgabensammlung teilen
       define_account_link: Bitte erstellen Sie zuerst einen Account-Link
@@ -29,6 +30,16 @@ de:
         deletion_warning: Sie sind der/die letzte Benutzer:in in dieser Aufgabensammlung. Wenn Sie gehen, wird diese Aufgabensammlung dauerhaft gelöscht! Sind Sie sicher?
       locked_exercise_hint: 'Hinweis: Für Aufgaben mit einem Schloss-Symbol müssen Sie zuerst Zugriff beantragen, um sie anzeigen zu können.'
       noExercisesAdded: Keine Aufgabe hinzugefügt
+      no_other_user: Kein/Keine anderer/andere Benutzer:in hat Zugriff auf diese Aufgabensammlung
+      num_of_other_users:
+        one: Ein/Eine anderer/andere Benutzer:in hat Zugriff auf diese Aufgabensammlung
+        other: "%{count} andere Benutzer:innen haben Zugriff auf diese Aufgabensammlung"
       shared_by: Geteilt von
       temporarily_disabled: Vorübergehend deaktiviert
       type_hint: Geben Sie die E-Mail-Adresse des/der Benutzer:in ein
+      visibility:
+        private: Diese Aufgabensammlung ist privat
+        public: Diese Aufgabensammlung ist öffentlich
+    visibility:
+      private: Privat
+      public: Öffentlich

--- a/config/locales/de/views/tasks.yml
+++ b/config/locales/de/views/tasks.yml
@@ -82,13 +82,14 @@ de:
     show:
       add_to_collection_hint: Speichern Sie Aufgaben für später, indem Sie sie zu einer Sammlung hinzufügen.
       button:
-        add_collection: Aufgabensammlung hinzufügen
         add_to_collection: Zu Sammlung hinzufügen
+        create_collection: Neue Sammlung anlegen
         download_as_zip: Diese Aufgabe als ZIP-Datei herunterladen.
         export: Exportieren
         export_tasks: Aufgaben exportieren
         rate: Bewerten
         show_comments: Kommentare anzeigen
+      create_collection_placeholder: Name der Sammlung
       define_account_link: Bitte definieren Sie zuerst einen Account-Link
       export_to: Exportieren nach
       guest:
@@ -98,6 +99,7 @@ de:
       no_license: Keine
       no_model_solution_present: Keine Musterlösungen vorhanden
       no_tests: Keine Tests enthalten
+      remove_task_from_collection_warning: Sind Sie sicher, dass Sie diese Aufgabe aus der Sammlung entfernen wollen?
       undefined: Benutzer:in undefiniert
       yourself: Ihnen selbst
     tasks:

--- a/config/locales/en/controllers/collections.yml
+++ b/config/locales/en/controllers/collections.yml
@@ -1,9 +1,6 @@
 ---
 en:
   collections:
-    create:
-      error: The collection could not be created
-      success_notice: Collection has succefully been created. (The task was automatically added)
     create_ajax:
       error: The collection could not be created.
       success_notice: The collection has successfully been created. (The task has automatically been added)

--- a/config/locales/en/controllers/collections.yml
+++ b/config/locales/en/controllers/collections.yml
@@ -1,6 +1,12 @@
 ---
 en:
   collections:
+    create:
+      error: The collection could not be created
+      success_notice: Collection has succefully been created. (The task was automatically added)
+    create_ajax:
+      error: The collection could not be created.
+      success_notice: The collection has successfully been created. (The task has automatically been added)
     leave:
       left_successfully: You successfully left the collection.
     push_collection:
@@ -11,7 +17,12 @@ en:
       success_notice: All Tasks were successfully removed
     remove_task:
       cannot_remove_alert: You cannot remove this task.
+    remove_task_ajax:
+      error: Task could not be removed from collection.
+      success_notice: Task has successfully been removed from collection.
     save_shared:
+      errors:
+        already_member: You are already a member of this collection.
       success_notice: You can now collaborate to this collection.
     share:
       success_notice: Your collection has been sent.

--- a/config/locales/en/controllers/collections.yml
+++ b/config/locales/en/controllers/collections.yml
@@ -1,7 +1,7 @@
 ---
 en:
   collections:
-    create_ajax:
+    create:
       error: The collection could not be created.
       success_notice: The collection has successfully been created. (The task has automatically been added)
     leave:
@@ -14,8 +14,6 @@ en:
       success_notice: All Tasks were successfully removed
     remove_task:
       cannot_remove_alert: You cannot remove this task.
-    remove_task_ajax:
-      success_notice: Task has successfully been removed from collection.
     save_shared:
       errors:
         already_member: You are already a member of this collection.

--- a/config/locales/en/controllers/collections.yml
+++ b/config/locales/en/controllers/collections.yml
@@ -15,7 +15,6 @@ en:
     remove_task:
       cannot_remove_alert: You cannot remove this task.
     remove_task_ajax:
-      error: Task could not be removed from collection.
       success_notice: Task has successfully been removed from collection.
     save_shared:
       errors:

--- a/config/locales/en/views/collections.yml
+++ b/config/locales/en/views/collections.yml
@@ -22,6 +22,7 @@ en:
         collaborate: Collaborate
         leave: Leave
         share: Share Collection
+        delete: Delete Collection
       define_account_link: Please define an account link first
       download_no_exercises: Download not possible without exercises
       export_to: Export to

--- a/config/locales/en/views/collections.yml
+++ b/config/locales/en/views/collections.yml
@@ -20,9 +20,9 @@ en:
     show:
       button:
         collaborate: Collaborate
+        delete: Delete Collection
         leave: Leave
         share: Share Collection
-        delete: Delete Collection
       define_account_link: Please define an account link first
       download_no_exercises: Download not possible without exercises
       export_to: Export to
@@ -33,3 +33,8 @@ en:
       shared_by: Shared by
       temporarily_disabled: Temporarily disabled
       type_hint: Type in the users email address
+      no_other_user: No other user has access to this collection
+      num_of_other_users:
+        one: One other user has access to this collection
+        other: "%{count} other users have access to this collection"
+

--- a/config/locales/en/views/collections.yml
+++ b/config/locales/en/views/collections.yml
@@ -37,6 +37,9 @@ en:
       shared_by: Shared by
       temporarily_disabled: Temporarily disabled
       type_hint: Type in the users email address
+      visibility:
+        private: This collection is private
+        public: This collection is public
     visibility:
       private: Private
       public: Public

--- a/config/locales/en/views/collections.yml
+++ b/config/locales/en/views/collections.yml
@@ -30,11 +30,13 @@ en:
         deletion_warning: You are the last user in this collection. If you leave, this collection will be permanently deleted! Are you sure?
       locked_exercise_hint: 'Hint: For exercises marked with a lock you have to request access first before you can view them.'
       noExercisesAdded: No Exercise Added
-      shared_by: Shared by
-      temporarily_disabled: Temporarily disabled
-      type_hint: Type in the users email address
       no_other_user: No other user has access to this collection
       num_of_other_users:
         one: One other user has access to this collection
         other: "%{count} other users have access to this collection"
-
+      shared_by: Shared by
+      temporarily_disabled: Temporarily disabled
+      type_hint: Type in the users email address
+    visibility:
+      private: Private
+      public: Public

--- a/config/locales/en/views/tasks.yml
+++ b/config/locales/en/views/tasks.yml
@@ -82,13 +82,14 @@ en:
     show:
       add_to_collection_hint: Save Tasks for later by adding them to a collection.
       button:
-        add_collection: Add Collection
-        add_to_collection: Add to collection
+        add_to_collection: Add to Collection
+        create_collection: Create new Collection
         download_as_zip: Download this Task as a ZIP file.
         export: Export
         export_tasks: Export Tasks
         rate: Rate
         show_comments: Show Comments
+      create_collection_placeholder: Collection name
       define_account_link: Please define an account link first
       export_to: Export to
       guest:
@@ -98,6 +99,7 @@ en:
       no_license: None
       no_model_solution_present: No Model Solutions present
       no_tests: No tests included
+      remove_task_from_collection_warning: Are you sure you want to remove this Task from the Collection?
       undefined: User undefined
       yourself: yourself
     tasks:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,12 +36,17 @@ Rails.application.routes.draw do
   end
 
   resources :collections do
+    collection do
+      post :create_ajax
+    end
+
     member do
       get :download_all
       get :view_shared # ???
 
       patch :remove_all
       patch :remove_task
+      patch :remove_task_ajax
 
       post :push_collection # later
       post :save_shared # ???

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,17 +36,12 @@ Rails.application.routes.draw do
   end
 
   resources :collections do
-    collection do
-      post :create_ajax
-    end
-
     member do
       get :download_all
       get :view_shared # ???
 
       patch :remove_all
       patch :remove_task
-      patch :remove_task_ajax
 
       post :push_collection # later
       post :save_shared # ???

--- a/db/migrate/20240402140747_add_visibility_level_to_collections.rb
+++ b/db/migrate/20240402140747_add_visibility_level_to_collections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVisibilityLevelToCollections < ActiveRecord::Migration[7.1]
+  def change
+    add_column :collections, :visibility_level, :integer, null: false, limit: 2, default: 0, comment: 'Used as enum in Rails'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_29_215957) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_02_140747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_29_215957) do
     t.datetime "updated_at", null: false
     t.string "title"
     t.string "description", default: "", null: false
+    t.integer "visibility_level", limit: 2, default: 0, null: false, comment: "Used as enum in Rails"
   end
 
   create_table "comments", id: :serial, force: :cascade do |t|

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -252,11 +252,13 @@ RSpec.describe CollectionsController do
 
   describe 'POST #view_shared' do
     let(:collection_owner) { create(:user) }
-    let(:collection) { create(:collection, valid_attributes.merge(users: [collection_owner, user])) }
+    let(:collection) { create(:collection, valid_attributes.merge(users: [collection_owner])) }
     let(:get_request) { get :view_shared, params: }
     let(:params) { {id: collection.id, user: collection_owner.id} }
 
     context 'when user has been invited' do
+      before { create(:message, sender: collection.users.first, recipient: user, param_type: 'collection', param_id: collection.id, text: 'Invitation') }
+
       it 'assigns collection' do
         get_request
         expect(assigns(:collection)).to eq(collection)

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -114,48 +114,11 @@ RSpec.describe CollectionsController do
   end
 
   describe 'POST #create' do
-    context 'with valid params' do
-      it 'creates a new Collection' do
-        expect do
-          post :create, params: {collection: valid_attributes}
-        end.to change(Collection, :count).by(1)
-      end
-
-      it 'assigns a newly created collection as @collection' do
-        post :create, params: {collection: valid_attributes}
-        expect(assigns(:collection)).to be_a(Collection)
-      end
-
-      it 'persists @collection' do
-        post :create, params: {collection: valid_attributes}
-        expect(assigns(:collection)).to be_persisted
-      end
-
-      it 'redirects to the created collection' do
-        post :create, params: {collection: valid_attributes}
-        expect(response).to redirect_to(collections_path)
-      end
-    end
-
-    context 'with invalid params' do
-      it 'assigns a newly created but unsaved collection as @collection' do
-        post :create, params: {collection: invalid_attributes}
-        expect(assigns(:collection)).to be_a_new(Collection)
-      end
-
-      it "re-renders the 'new' template" do
-        post :create, params: {collection: invalid_attributes}
-        expect(response).to render_template('new')
-      end
-    end
-  end
-
-  describe 'POST #create_ajax' do
-    let(:post_request) { post :create_ajax, params: {collection: collection_params} }
-    let(:collection_params) { valid_attributes.merge(task_ids: task.id) }
-    let(:task) { create(:task) }
+    let(:post_request) { post :create, params: {collection: collection_params} }
 
     context 'with valid params' do
+      let(:collection_params) { valid_attributes }
+
       it 'creates a new Collection' do
         expect do
           post_request
@@ -172,23 +135,64 @@ RSpec.describe CollectionsController do
         expect(assigns(:collection)).to be_persisted
       end
 
-      it 'redirects to the submitted task' do
+      it 'redirects to the created collection' do
         post_request
-        expect(response).to redirect_to(task_path(task))
+        expect(response).to redirect_to(collections_path)
+      end
+
+      context 'with task_id' do
+        let(:collection_params) { valid_attributes.merge(task_ids: task.id) }
+        let(:task) { create(:task) }
+
+        it 'creates a new Collection' do
+          expect do
+            post_request
+          end.to change(Collection, :count).by(1)
+        end
+
+        it 'assigns a newly created collection as @collection' do
+          post_request
+          expect(assigns(:collection)).to be_a(Collection)
+        end
+
+        it 'persists @collection' do
+          post_request
+          expect(assigns(:collection)).to be_persisted
+        end
+
+        it 'redirects to the submitted task' do
+          post_request
+          expect(response).to redirect_to(task_path(task))
+        end
       end
     end
 
     context 'with invalid params' do
       let(:collection_params) { invalid_attributes }
 
-      it 'does not create a new Collection' do
-        expect do
-          post_request
-        end.not_to change(Collection, :count)
+      it 'assigns a newly created but unsaved collection as @collection' do
+        post_request
+        expect(assigns(:collection)).to be_a_new(Collection)
       end
 
-      it 'flashes an error' do
-        expect { post_request }.to change { flash[:alert] }.to(I18n.t('collections.create_ajax.error'))
+      it "re-renders the 'new' template" do
+        post_request
+        expect(response).to render_template('new')
+      end
+
+      context 'with task_id' do
+        let(:collection_params) { invalid_attributes.merge(task_ids: task.id) }
+        let(:task) { create(:task) }
+
+        it 'does not create a new Collection' do
+          expect do
+            post_request
+          end.not_to change(Collection, :count)
+        end
+
+        it 'flashes an error' do
+          expect { post_request }.to change { flash[:alert] }.to(I18n.t('collections.create.error'))
+        end
       end
     end
   end
@@ -262,33 +266,31 @@ RSpec.describe CollectionsController do
   describe 'PATCH #remove_task' do
     let(:collection) { create(:collection, valid_attributes.merge(users: [user])) }
     let!(:task) { create(:task, collections: [collection]) }
-    let(:patch_request) { patch :remove_task, params: {id: collection.id, task: task.id} }
-
-    it 'removes task from collection' do
-      expect { patch_request }.to change(collection.reload.tasks, :count).by(-1)
-    end
-  end
-
-  describe 'PATCH #remove_task_ajax' do
-    let(:collection) { create(:collection, valid_attributes.merge(users: [user])) }
-    let!(:task) { create(:task, collections: [collection]) }
-    let(:patch_request) { patch :remove_task_ajax, params: remove_task_params }
+    let(:patch_request) { patch :remove_task, params: remove_task_params }
     let(:remove_task_params) { {id: collection.id, task: task.id} }
 
     it 'removes task from collection' do
       expect { patch_request }.to change(collection.reload.tasks, :count).by(-1)
     end
 
-    it 'redirects to the submitted task' do
-      patch_request
-      expect(response).to redirect_to(task_path(task))
-    end
+    context 'when return_to_task is true' do
+      let(:remove_task_params) { {id: collection.id, task: task.id, return_to_task: true} }
 
-    context 'with invalid params' do
-      let(:remove_task_params) { {id: collection.id, task: create(:task).id} }
+      it 'removes task from collection' do
+        expect { patch_request }.to change(collection.reload.tasks, :count).by(-1)
+      end
 
-      it 'does not remove task from collection' do
-        expect { patch_request }.not_to change(collection.reload.tasks, :count)
+      it 'redirects to the submitted task' do
+        patch_request
+        expect(response).to redirect_to(task_path(task))
+      end
+
+      context 'with invalid params' do
+        let(:remove_task_params) { {id: collection.id, task: create(:task).id} }
+
+        it 'does not remove task from collection' do
+          expect { patch_request }.not_to change(collection.reload.tasks, :count)
+        end
       end
     end
   end

--- a/spec/factories/collection_user.rb
+++ b/spec/factories/collection_user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :collection_user do
+    user
+    collection
+  end
+end

--- a/spec/models/collection_user_spec.rb
+++ b/spec/models/collection_user_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionUser do
+  describe 'validations' do
+    subject { build(:collection_user) }
+
+    it { is_expected.to belong_to(:collection) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:collection_id) }
+  end
+end

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -27,7 +27,13 @@ RSpec.describe CollectionPolicy do
     context 'when collection is from user' do
       let(:collection_user) { user }
 
-      it { is_expected.to forbid_only_actions(%i[save_shared]) }
+      it { is_expected.to forbid_only_actions(%i[save_shared view_shared]) }
+    end
+
+    context 'when user has an invitation' do
+      before { create(:message, sender: collection_user, recipient: user, param_type: 'collection', param_id: collection.id, text: 'Invitation') }
+
+      it { is_expected.to permit_only_actions(%i[index new save_shared view_shared]) }
     end
   end
 end


### PR DESCRIPTION
Tackles most collection issues from #781 

- [x] add fast collection creation in task/show
- [x] prevent a user joining a collection multiple times (validation, error handling)
- [x] show count of users in collection/show (to preserve anonymity, since we have no collection admin)
- [x] rename leave button to delete, if user is last member of collection
- [x] `view_shared` didn't work at all
- [x] fix  tests
- [x] add tests

Additional tasks after review/discusstion:
- [x] add collection visibility
  - [x] default private => only members can see it
  - [x] optional public

Will be handled in different PR(s):
- [ ] show # of open invitations (since they can be used to get access at any time)
- [ ] consume invitations
- [ ] public collections can be saved by any user (but not edited) (follow)
- [ ] collection can be assigned to group (edit rights)