### PR TITLE
Translate CodeHarbor to German

### DIFF
--- a/app/assets/javascripts/flash_message.js.coffee
+++ b/app/assets/javascripts/flash_message.js.coffee
@@ -5,7 +5,7 @@ show_ajax_message = (msg, type) ->
   $("#flash-#{type}").delay(6000).slideUp 'medium'
 
 $(document).ajaxComplete (event, request) ->
-  msg = request.getResponseHeader("X-Message")
+  msg = decodeURI(request.getResponseHeader("X-Message"))
   type = request.getResponseHeader("X-Message-Type")
   show_ajax_message msg, type unless type == 'empty' #use whatever popup, notification or whatever plugin you want
 

--- a/app/assets/javascripts/labels.coffee.erb
+++ b/app/assets/javascripts/labels.coffee.erb
@@ -95,4 +95,4 @@ clear_input = ->
   $('.labels-select2-tag').siblings(".select2").find("textarea").val("");
   return
 
-$(document).on 'turbolinks:load', ready
+$(document).on('select2:locales:loaded', ready)

--- a/app/assets/javascripts/labels.coffee.erb
+++ b/app/assets/javascripts/labels.coffee.erb
@@ -1,10 +1,11 @@
 max_label_length = <%= Label::MAX_LENGTH %>
+
 verify_label_name = (label_name) ->
   if label_name == ''
     return I18n.t('labels.javascripts.cannot_be_empty');
   if label_name.length > max_label_length
     return I18n.t('labels.javascripts.too_long');
-  return 'OK';
+  return I18n.t('labels.javascripts.ok');
 
 root = exports ? this;
 root.verify_label_name = verify_label_name;
@@ -14,6 +15,7 @@ ready = ->
   default_label_font_color = "000000"
 
   $('.labels-select2-tag').select2
+    language: I18n.locale
     width: '100%'
     tags: true
     multiple: true
@@ -74,7 +76,7 @@ ready = ->
       term = $.trim(params.term)
       selection = $('.labels-select2-tag').select2('data').map (element) -> element.id
 
-      if verify_label_name(term) != 'OK' || selection.includes(term)
+      if verify_label_name(term) != I18n.t('labels.javascripts.ok') || selection.includes(term)
         return null;
 
       return {
@@ -84,7 +86,7 @@ ready = ->
       }
 
     formatSelectionTooBig: (limit) ->
-      I18n.t('labels.javascripts.can_only_create_5')
+      I18n.t('labels.javascripts.max_limit_reached', {limit: limit})
 
     $('.labels-select2-tag').on 'select2:select', clear_input
   return

--- a/app/assets/javascripts/tasks_export.coffee
+++ b/app/assets/javascripts/tasks_export.coffee
@@ -30,7 +30,7 @@ exportTaskStart = (taskID) ->
       $messageDiv.html(response.message)
       $actionsDiv.html(response.actions)
     error: (_xhr, _textStatus, message) ->
-      alert('error:' + message);
+      alert("#{I18n.t('common.javascripts.error')}: #{message}");
   })
 
 exportConfirm = (taskId, accountLinkId, pushType) ->
@@ -52,7 +52,7 @@ exportConfirm = (taskId, accountLinkId, pushType) ->
       else
         $taskDiv.addClass 'import-export-failure'
     error: (_xhr, _textStatus, message) ->
-      alert('error:' + message)
+      alert("#{I18n.t('common.javascripts.error')}: #{message}")
   })
 
 root = exports ? this;

--- a/app/assets/javascripts/tasks_form.coffee
+++ b/app/assets/javascripts/tasks_form.coffee
@@ -7,11 +7,13 @@ $(document).on('turbolinks:load', ready)
 
 initializeLoadSelect2 = ->
   $('#task_programming_language_id').select2
+    language: I18n.locale
     tags: false
     width: '100%'
     multiple: false
 
   $('.my-group').select2
+    language: I18n.locale
     width: '100%'
     multiple: true
     closeOnSelect: false

--- a/app/assets/javascripts/tasks_form.coffee
+++ b/app/assets/javascripts/tasks_form.coffee
@@ -1,9 +1,6 @@
-ready =->
-  initializeLoadSelect2()
+ready = ->
   initializeFileTypeSelection()
   initializeVisibilityWarning()
-
-$(document).on('turbolinks:load', ready)
 
 initializeLoadSelect2 = ->
   $('#task_programming_language_id').select2
@@ -32,3 +29,7 @@ initializeVisibilityWarning = ->
       warning_message.removeClass('d-none')
   $('#task_access_level_public').on 'change', ->
       warning_message.addClass('d-none')
+
+
+$(document).on('turbolinks:load', ready)
+$(document).on('select2:locales:loaded', initializeLoadSelect2)

--- a/app/assets/javascripts/tasks_import.coffee
+++ b/app/assets/javascripts/tasks_import.coffee
@@ -39,8 +39,8 @@ importStart = () ->
     success: (response) ->
       if response.status == 'failure'
         alert(response.message)
-    error: (a, b, c) ->
-      alert('error: ' + c)
+    error: (_xhr, _textStatus, message) ->
+      alert("#{I18n.t('common.javascripts.error')}: #{message}")
   })
 
 importConfirm = (importId, subfileId, importType) ->
@@ -61,6 +61,6 @@ importConfirm = (importId, subfileId, importType) ->
         $taskDiv.addClass 'import-export-success'
       else
         $taskDiv.addClass 'import-export-failure'
-    error: (a, b, c) ->
-      alert('error: ' + c)
+    error: (_xhr, _textStatus, message) ->
+      alert("#{I18n.t('common.javascripts.error')}: #{message}")
   })

--- a/app/assets/javascripts/tasks_index.coffee
+++ b/app/assets/javascripts/tasks_index.coffee
@@ -1,5 +1,4 @@
 ready = ->
-  initializeSelect2()
   initCollapsable($('.description'), '95px')
   window.addEventListener 'resize', -> initCollapsable($('.description'), '95px')
   initializeDynamicHideShow()
@@ -7,7 +6,6 @@ ready = ->
   initializeIndexComments()
   initializeInputFieldEnterCallback()
 
-$(document).on('turbolinks:load', ready)
 
 initializeDynamicHideShow = ->
   $('body').on 'click', '.more-btn-wrapper', (event) ->
@@ -103,13 +101,7 @@ intializeAdvancedFilter = ->
       $drop.removeClass('fa-caret-down').addClass('fa-caret-up')
 
   if $('#order_param')
-#    $('#' + order.value).addClass('active')
     $('#order_created').addClass('active')
-
-  #  $('#order_rating').click ->
-  #    $('#order_rating').addClass('active')
-  #    $('#order_created').removeClass('active')
-  #    document.getElementById('order_param').value = 'order_rating'
 
   $('#order_created').click ->
     $('#order_created').addClass('active')
@@ -144,3 +136,7 @@ initializeInputFieldEnterCallback = ->
       return
     $('.search-submit-button-tag').click();
     event.preventDefault();
+
+
+$(document).on('turbolinks:load', ready)
+$(document).on('select2:locales:loaded', initializeSelect2)

--- a/app/assets/javascripts/tasks_index.coffee
+++ b/app/assets/javascripts/tasks_index.coffee
@@ -16,10 +16,12 @@ initializeDynamicHideShow = ->
 
 initializeSelect2 = ->
   $('.defaultSelect2').select2
+    language: I18n.locale
     minimumResultsForSearch: 10
     width: '100%'
 
   $('.language-box').select2
+    language: I18n.locale
     width: '100%'
     multiple: true
     closeOnSelect: false

--- a/app/assets/javascripts/tasks_ratings.coffee
+++ b/app/assets/javascripts/tasks_ratings.coffee
@@ -44,6 +44,6 @@ initializeRatings = ->
               $('.overall-rating[data-rating='+num+']').removeClass("fa-star").removeClass("fa-solid").addClass("fa-star-half-stroke")
             else
               $('.overall-rating[data-rating='+num+']').removeClass("fa-star-half-stroke").removeClass("fa-solid").addClass("fa-star").addClass("fa-regular")
-      error: (a, b, c) ->
-        alert("error:" + c);
+      error: (_xhr, _textStatus, message) ->
+        alert("#{I18n.t('common.javascripts.error')}: #{message}");
     })

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,10 +97,35 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def switch_locale(&) # rubocop:disable Metrics/AbcSize
-    session[:locale] = sanitize_locale(params[:custom_locale] || params[:locale] || session[:locale])
-    locale = session[:locale] || http_accept_language.compatible_language_from(I18n.available_locales) || I18n.default_locale
+  def sanitized_locale_param
+    sanitize_locale(params[:locale])
+  end
+
+  def sanitized_session_locale
+    sanitize_locale(session[:locale])
+  end
+
+  def sanitized_user_preferred_locale
+    return if current_user.nil?
+
+    sanitize_locale(current_user.preferred_locale)
+  end
+
+  def choose_locale
+    sanitized_locale_param ||
+      sanitized_session_locale ||
+      sanitized_user_preferred_locale ||
+      http_accept_language.compatible_language_from(I18n.available_locales) ||
+      I18n.default_locale
+  end
+
+  def switch_locale(&)
+    locale = choose_locale
+    session[:locale] = locale
     Sentry.set_extras(locale:)
+    if current_user.present? && locale != sanitized_user_preferred_locale
+      current_user.update(preferred_locale: locale)
+    end
     I18n.with_locale(locale, &)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
   def flash_to_headers
     return unless request.xhr?
 
-    response.headers['X-Message'] = flash_message
+    response.headers['X-Message'] = ERB::Util.url_encode(flash_message)
     response.headers['X-Message-Type'] = flash_type.to_s
 
     flash.discard # don't want the flash to appear when you reload page

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -115,8 +115,7 @@ class CollectionsController < ApplicationController
 
   def share_message
     user = User.find_by(email: params[:user])
-    text = t('collections.share_message.text', user: current_user.name, collection: @collection.title, locale: :en)
-    Message.new(sender: current_user, recipient: user, param_type: 'collection', param_id: @collection.id, text:)
+    Message.new(sender: current_user, recipient: user, param_type: 'collection', param_id: @collection.id)
   end
 
   def push_exercises

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -115,7 +115,7 @@ class CollectionsController < ApplicationController
 
   def share_message
     user = User.find_by(email: params[:user])
-    text = t('collections.share_message.text', user: current_user.name, collection: @collection.title)
+    text = t('collections.share_message.text', user: current_user.name, collection: @collection.title, locale: :en)
     Message.new(sender: current_user, recipient: user, param_type: 'collection', param_id: @collection.id, text:)
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -122,6 +122,7 @@ class GroupsController < ApplicationController
       recipient: user,
       text: t('groups.send_deny_access_message.message', user: current_user.name, group: group.name),
       param_type: 'group_declined',
+      param_id: group.id,
       sender_status: 'd')
   end
 

--- a/app/helpers/authenticated_url_helper.rb
+++ b/app/helpers/authenticated_url_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AuthenticatedUrlHelper
+  class << self
+    def add_query_parameters(url, parameters)
+      parsed_url = URI.parse url
+
+      # Add the given parameters to the query string
+      query_params = CGI.parse(parsed_url.query || '').with_indifferent_access
+      query_params.merge!(parameters)
+
+      # Add the query string back to the URL
+      parsed_url.query = URI.encode_www_form(query_params)
+
+      # Return the full URL
+      parsed_url.to_s
+    rescue URI::InvalidURIError
+      url
+    end
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -47,7 +47,12 @@ import 'jquery-ui/themes/base/sortable.css'
 // I18n locales
 import { I18n } from "i18n-js";
 import locales from "../../tmp/locales.json";
-Object.keys(locales).forEach(locale => import(`select2/dist/js/i18n/${locale}`));
+
+Promise.all(
+    Object.keys(locales).map(locale => import(`select2/dist/js/i18n/${locale}`))
+).then(() =>
+    document.dispatchEvent(new Event("select2:locales:loaded"))
+);
 
 // Fetch user locale from html#lang.
 // This value is being set on `app/views/layouts/application.html.slim` and

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -47,6 +47,7 @@ import 'jquery-ui/themes/base/sortable.css'
 // I18n locales
 import { I18n } from "i18n-js";
 import locales from "../../tmp/locales.json";
+Object.keys(locales).forEach(locale => import(`select2/dist/js/i18n/${locale}`));
 
 // Fetch user locale from html#lang.
 // This value is being set on `app/views/layouts/application.html.slim` and

--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -5,13 +5,17 @@ class AccessRequestMailer < ApplicationMailer
     @user = user
     @admin = admin
     @group = group
-    mail(to: @admin.email, subject: "#{user.name} wants to access your Group '#{group.name}'")
+    I18n.with_locale(@admin.preferred_locale || I18n.default_locale) do
+      mail(to: @admin.email, subject: t('groups.access_request_mailer.subject', user: @user.name, group: @group.name))
+    end
   end
 
   def send_contribution_request(author, exercise, user)
     @author = author
     @exercise = exercise
     @user = user
-    mail(to: @author.email, subject: "#{user.name} wants to contribute to your Exercise '#{exercise.title}'")
+    I18n.with_locale(@author.preferred_locale || I18n.default_locale) do
+      mail(to: @author.email, subject: t('tasks.access_request_mailer.subject', user: @user.name, task: @exercise.title))
+    end
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Message < ApplicationRecord
-  validates :text, presence: true
+  validates :text, presence: true, unless: -> { %w[group_requested group_accepted group_declined collection].include?(param_type) }
 
   belongs_to :sender, class_name: 'User', inverse_of: :sent_messages
   belongs_to :recipient, class_name: 'User', inverse_of: :received_messages
@@ -18,7 +18,7 @@ class Message < ApplicationRecord
 
   def text # rubocop:disable Metrics/AbcSize
     case param_type
-      when 'group'
+      when 'group_requested'
         I18n.t('groups.send_access_request_message.message', user: sender.name, group: Group.find(param_id).name)
       when 'group_accepted'
         I18n.t('groups.send_grant_access_messages.message', user: sender.name, group: Group.find(param_id).name)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,6 +16,21 @@ class Message < ApplicationRecord
     self.recipient_status = 'd' if recipient == user
   end
 
+  def text # rubocop:disable Metrics/AbcSize
+    case param_type
+      when 'group'
+        I18n.t('groups.send_access_request_message.message', user: sender.name, group: Group.find(param_id).name)
+      when 'group_accepted'
+        I18n.t('groups.send_grant_access_messages.message', user: sender.name, group: Group.find(param_id).name)
+      when 'group_declined'
+        I18n.t('groups.send_deny_access_message.message', user: sender.name, group: Group.find(param_id).name)
+      when 'collection'
+        I18n.t('collections.share_message.text', user: sender.name, collection: Collection.find(param_id).title)
+      else
+        super
+    end
+  end
+
   def self.parent_resource
     User
   end

--- a/app/views/access_request_mailer/send_access_request.html.erb
+++ b/app/views/access_request_mailer/send_access_request.html.erb
@@ -4,13 +4,13 @@
   <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
 </head>
 <body>
-<h3>Hello <%= @admin.name %></h3>
+<h3><%= t('groups.access_request_mailer.greeting', user: @admin.name) %></h3>
 <p>
-  <%= @user.name %> asked to join your group "<%= @group.name %>" <br/>
-  If you want to give your permission click on the link below. <br/>
-  Otherwise ignore this Email. <br/>
+  <%= t('groups.access_request_mailer.message_line1', user: @user.name, group: @group.name) %> <br/>
+  <%= t('groups.access_request_mailer.message_line2') %> <br/>
+  <%= t('groups.access_request_mailer.message_line3') %> <br/>
   <br/>
-  <%= link_to 'Confirm Request', group_url(@group)%>
+  <%= link_to t('groups.access_request_mailer.confirm_request'), group_url(@group)%>
 </p>
 </body>
 </html>

--- a/app/views/access_request_mailer/send_access_request.text.erb
+++ b/app/views/access_request_mailer/send_access_request.text.erb
@@ -1,6 +1,6 @@
-Hello <%= @admin.name %>
+<%= t('groups.access_request_mailer.greeting', user: @admin.name) %>
 
-<%= @user.name %> asked to join your group "<%= @group.name %>"
-If you want to give your permission click on the link below.
-Otherwise ignore this Email.
+<%= t('groups.access_request_mailer.message_line1', user: @user.name, group: @group.name) %>
+<%= t('groups.access_request_mailer.message_line2') %>
+<%= t('groups.access_request_mailer.message_line3') %>
 <%= group_url(@group)%>

--- a/app/views/access_request_mailer/send_contribution_request.html.erb
+++ b/app/views/access_request_mailer/send_contribution_request.html.erb
@@ -4,13 +4,13 @@
   <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
 </head>
 <body>
-<h3>Hello <%= @author.name %></h3>
+<h3><%= t('tasks.access_request_mailer.greeting', user: @author.name) %></h3>
 <p>
-  <%= @user.name %> asked to contribute to your Exercise "<%= @exercise.title %>".
-  If you want to make him a co-author or suggest Membership to a group click the link below.
-  Otherwise ignore this Email. <br/>
+  <%= t('tasks.access_request_mailer.message_line1', user: @user.name, task: @exercise.title) %> <br/>
+  <%= t('tasks.access_request_mailer.message_line2') %> <br/>
+  <%= t('tasks.access_request_mailer.message_line3') %> <br/>
   <br/>
-  <%= link_to 'CodeHarbor', user_messages_url(@author)%>
+  <%= link_to t('common.app_name'), user_messages_url(@author)%>
 </p>
 </body>
 </html>

--- a/app/views/access_request_mailer/send_contribution_request.text.erb
+++ b/app/views/access_request_mailer/send_contribution_request.text.erb
@@ -1,6 +1,7 @@
-Hello <%= @author.name %>
+<%= t('tasks.access_request_mailer.greeting', user: @author.name) %>
 
-<%= @user.name %> asked to contribute to your Exercise "<%= @exercise.title %>".
-If you want to make him a co-author or suggest Membership to a group click the link below.
-Otherwise ignore this Email.
+<%= t('tasks.access_request_mailer.message_line1', user: @user.name, task: @exercise.title) %>
+<%= t('tasks.access_request_mailer.message_line2') %>
+<%= t('tasks.access_request_mailer.message_line3') %>
+
 <%= user_messages_url(@author) %>

--- a/app/views/account_links/_form.html.slim
+++ b/app/views/account_links/_form.html.slim
@@ -14,7 +14,7 @@
       = f.label :api_key, AccountLink.human_attribute_name('api_key'), class: 'form-label'
       .input-group
         = f.text_field :api_key, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('.info.token'), class: 'form-control'
-        = button_tag "Generate", type: 'button', class: 'generate-api-key-token btn btn-light'
+        = button_tag t('.button.generate'), type: 'button', class: 'generate-api-key-token btn btn-light'
     .form-group
       .actions.btn-group[role="group"]
         = f.submit t('.button.save'), class: 'btn btn-important'

--- a/app/views/application/_locale_selector.html.slim
+++ b/app/views/application/_locale_selector.html.slim
@@ -1,7 +1,7 @@
 li.nav-item.dropdown
-  a.nav-link.dropdown-toggle.me-3 data-bs-toggle='dropdown' href='#'
+  a.nav-link.px-3.dropdown-toggle data-bs-toggle='dropdown' href='#'
     = t("common.locales.#{I18n.locale}")
     span.caret
-  ul.dropdown-menu.p-0.mt-1 role='menu'
+  ul.dropdown-menu.rounded-0 role='menu'
     - I18n.available_locales.sort_by { |locale| t("common.locales.#{locale}") }.each do |locale|
       li = link_to(t("common.locales.#{locale}"), AuthenticatedUrlHelper.add_query_parameters(request.url, locale: locale), 'data-turbolinks' => "false", class: 'dropdown-item')

--- a/app/views/application/_navigation_collection_link.html.slim
+++ b/app/views/application/_navigation_collection_link.html.slim
@@ -3,4 +3,4 @@
   li.nav-item
     = link_to(send(path), class: "nav-link px-3 #{active_class(send(path))}") do
       = yield
-      =< defined?(text) ? text : model.model_name.collection.capitalize
+      =< defined?(text) ? text : model.model_name.human(count: :many).capitalize

--- a/app/views/comments/_edit.html.slim
+++ b/app/views/comments/_edit.html.slim
@@ -4,9 +4,9 @@
       = f.text_field :text, class: 'form-control'
     .actions.btn-group.float-end role="group"
       - if policy(@comment).edit?
-        = f.submit class: 'btn btn-light btn-sm' do
+        = button_tag type: 'submit', class: 'btn btn-light btn-sm' do
           i.fa-solid.fa-floppy-disk
-          =< "Save"
+          =< t('common.button.save')
         = link_to task_comment_path(@task, @comment), class: 'btn btn-light btn-sm', method: :delete, remote: true, data: {confirm: t('common.sure')}
           i.fa-solid.fa-trash-can
           =< t('common.button.delete')

--- a/app/views/comments/_task_comments.html.slim
+++ b/app/views/comments/_task_comments.html.slim
@@ -11,7 +11,7 @@
       .comment-user
         = comment.user.name
         .float-end.created-at
-          = t('common.created_at') + ': '
+          = t('common.created') + ': '
           = t('.time_ago', time: time_ago_in_words(comment.created_at))
       .comment-text.collapsable data-task=@task.id data-comment=comment.id
         = comment.text

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -3,11 +3,11 @@
     = render('shared/form_errors', object: @group)
 
     .field-element.form-group
-      = f.label :name, 'Title', class: 'form-label'
+      = f.label :name, Group.human_attribute_name('name'), class: 'form-label'
       = f.text_field :name, class: 'form-control'
     .field-element.form-group
-      = f.label :description, 'Description', class: 'form-label'
-      br/
+      = f.label :description, Group.human_attribute_name('description'), class: 'form-label'
+      br
       .controls
         = f.text_field :description, class: 'form-control'
     br

--- a/app/views/groups/_groups.html.slim
+++ b/app/views/groups/_groups.html.slim
@@ -4,10 +4,10 @@
       .row
         .col-md-12
           h3 style=("color: #777777")
-            = 'You do not have groups yet'
+            = t('.no_groups_yet')
           br
           p style=("color: #777777")
-            = 'You can create groups to connect with other users and handle exercise access.'
+            = t('.create_groups_tip')
           br
           br
 - @groups.each do |group|
@@ -28,12 +28,12 @@
             = group.description
           .btn-group.float-end aria-label="..." role="group"
             - if policy(group).show?
-              = link_to 'Show', group, class: 'btn btn-light'
+              = link_to t('common.button.show'), group, class: 'btn btn-light'
               - if policy(group).edit?
-                = link_to 'Edit', edit_group_path(group), class: 'btn btn-light'
-                = link_to 'Destroy', group, data: {confirm: t('common.sure')}, method: :delete, class: 'btn btn-light'
+                = link_to t('common.button.edit'), edit_group_path(group), class: 'btn btn-light'
+                = link_to t('common.button.delete'), group, data: {confirm: t('common.sure')}, method: :delete, class: 'btn btn-light'
             - elsif group.applicants.include?(current_user)
-              = 'Wait to get accepted'
+              = t('.wait_to_get_accepted')
             - else
-              = link_to 'Request Membership', request_access_group_path(group), method: :post, class: 'btn btn-light'
+              = link_to t('groups.shared.button.request_membership'), request_access_group_path(group), method: :post, class: 'btn btn-light'
 = render('shared/pagination', collection: @groups)

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -3,12 +3,12 @@
   .row
     .col-md-12
       .btn-group[role="group"]
-        = link_to 'My Groups', groups_path(option: 'mine'), class: 'btn btn-main btn-tab-group', id: 'mine'
-        = link_to 'All Groups', groups_path(option: 'all'), class: 'btn btn-main btn-tab-group', id: 'all'
+        = link_to t('.button.my_groups'), groups_path(option: 'mine'), class: 'btn btn-main btn-tab-group', id: 'mine'
+        = link_to t('.button.all_groups'), groups_path(option: 'all'), class: 'btn btn-main btn-tab-group', id: 'all'
 
       - if policy(Group).new?
         = link_to new_group_path, class: 'btn btn-main nav-btn-group float-end' do
           i.fa-solid.fa-plus style=("color: #660000")
-          =< 'New Group'
+          =< t('.button.new_group')
 br
 = render 'groups'

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -74,7 +74,7 @@
 br
 .actions.btn-group[role="group"]
   - if policy(@group).request_access?
-    = link_to t('.button.request_membership'), request_access_group_path(@group), method: :post, class: 'btn btn-important'
+    = link_to t('groups.shared.button.request_membership'), request_access_group_path(@group), method: :post, class: 'btn btn-important'
   - if policy(@group).edit?
     = link_to edit_group_path(@group), class: 'btn btn-important' do
       i.fa-solid.fa-pen-to-square

--- a/app/views/labels/index.html.slim
+++ b/app/views/labels/index.html.slim
@@ -1,16 +1,16 @@
 .container[style="padding: 0px;"]
   .row
     div.col-md-7
-      input.form-control[id="label-name-filter-input" type="text" placeholder="Filter By Name"]
+      input.form-control[id="label-name-filter-input" type="text" placeholder=t('.filter_by_name')]
       br
       .div.labels-table-container
         table.table.table-bordered.table-striped.labels-table
           thead
             tr
-              th.sort-by-id.table-header-sort-down[style='width: 10%;'] ID
-              th.sort-by-name[style='width: 30%;'] Name
-              th.sort-by-created-at[style='width: 40%;'] Created At
-              th[style='width: 20%;'] Used By Tasks
+              th.sort-by-id.table-header-sort-down[style='width: 10%;'] = t('.id')
+              th.sort-by-name[style='width: 30%;'] = Label.human_attribute_name(:name)
+              th.sort-by-created-at[style='width: 40%;'] = t('common.created_at')
+              th[style='width: 20%;'] = t('.used_by_tasks')
           tbody
       br
 
@@ -18,7 +18,7 @@
       div
         .input-group
           = button_tag t('.merge'), type: 'button', id: 'merge-labels-button', disabled: true, class: 'btn btn-primary'
-          input.form-control[id="merge-labels-input" type="text" placeholder="New Name"]
+          input.form-control[id="merge-labels-input" type="text" placeholder=t('.new_name')]
 
       .div[style='margin-top: 10px;']
         .input-group

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -29,6 +29,7 @@ html lang="#{I18n.locale || I18n.default_locale}" data-default-locale="#{I18n.de
             #navbar-collapse.collapse.navbar-collapse
               = render('navigation')
               ul.navbar-nav.ms-auto
+                = render('locale_selector', cached: true)
                 = render('session')
       main
         div data-controller=controller_name

--- a/app/views/messages/index.html.slim
+++ b/app/views/messages/index.html.slim
@@ -43,8 +43,8 @@ br
             = message.recipient ? message.recipient.name : t('.unknown')
         .message-body
           .message-text
-            => message.text
-            .btn-group
+            = message.text
+            .btn-group.ms-3
               -if message.param_type == 'exercise'
                 = link_to  t('.button.view'), exercise_path(message.param_id), class: 'btn btn-light btn-sm'
                 = link_to add_author_exercise_path(message.param_id, user: message.sender.id), method: :post, class: 'btn btn-light btn-sm' do

--- a/app/views/messages/index.html.slim
+++ b/app/views/messages/index.html.slim
@@ -25,7 +25,7 @@ br
           span.fa-regular.fa-file-lines
         - elsif message.param_type == 'collection'
           span.fa-solid.fa-folder-open
-        - elsif message.param_type == 'group' || message.param_type == 'group_accepted' || message.param_type == 'group_declined'
+        - elsif message.param_type == 'group_requested' || message.param_type == 'group_accepted' || message.param_type == 'group_declined'
           span.fa-solid.fa-users
         - elsif message.param_type == 'report'
           span.fa-solid.fa-gear
@@ -56,7 +56,7 @@ br
               - if message.param_type == 'collection'
                 = link_to  t('.button.view'), view_shared_collection_path(message.param_id, user: message.sender), class: 'btn btn-light btn-sm'
                 = link_to t('.button.save_collection'), save_shared_collection_path(message.param_id), method: 'post', class: 'btn btn-light btn-sm'
-              - if message.param_type == 'group'
+              - if message.param_type == 'group_requested'
                 = link_to t('.button.view'), group_path(message.param_id), class: 'btn btn-light btn-sm'
                 = link_to grant_access_group_path(message.param_id, user: message.sender.id), method: :post, class: 'btn btn-light btn-sm' do
                   i.fa-solid.fa-plus style=("color:#008000")

--- a/app/views/shared/_form_errors.html.slim
+++ b/app/views/shared/_form_errors.html.slim
@@ -3,8 +3,8 @@
     - if object.errors.size == 1
       = object.errors.full_messages.first
     - else
-      - model_class = defined? model ? model : object.class
-      - title_translation = defined? title ? title : t('common.errors.model_not_saved', model: model_class.model_name.human)
+      - model_class = defined?(model) ? model : object.class
+      - title_translation = defined?(title) ? title : t('common.errors.model_not_saved', model: model_class.model_name.human)
       h4 = title_translation
       ul
         - object.errors.full_messages.each do |message|

--- a/app/views/tasks/_file_config.html.slim
+++ b/app/views/tasks/_file_config.html.slim
@@ -4,11 +4,11 @@
     = file.label :used_by_grader, TaskFile.human_attribute_name('used_by_grader'), class: 'form-label', style: 'width: unset; margin-right: 10px;'
     .radio-switch
       = file.radio_button :used_by_grader, true, value: true
-      = file.label :used_by_grader_true, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'yes', class: 'radio-left small-radio radio-half' do
+      = file.label :used_by_grader_true, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('common.button.yes'), class: 'radio-left small-radio radio-half' do
         span.fa-stack
           i.fa-solid.fa-check.fa-stack-1x.fa-2x
       = file.radio_button :used_by_grader, false, value: false
-      = file.label :used_by_grader_false, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'no', class: 'radio-right small-radio radio-half' do
+      = file.label :used_by_grader_false, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('common.button.no'), class: 'radio-right small-radio radio-half' do
         span.fa-stack
           i.fa-solid.fa-xmark.fa-stack-1x.fa-2x
 
@@ -16,15 +16,15 @@
     = file.label :used_by_grader, TaskFile.human_attribute_name('visible'), class: 'form-label', style: 'width: unset; margin-right: 10px;'
     .radio-switch
       = file.radio_button :visible, 'yes', value: 'yes', checked: true
-      = file.label :visible_yes, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'yes', class: 'radio-left small-radio radio-third' do
+      = file.label :visible_yes, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('common.button.yes'), class: 'radio-left small-radio radio-third' do
         span.fa-stack
           i.fa-regular.fa-eye.fa-stack-1x.fa-2x
       = file.radio_button :visible, 'no', value: 'no'
-      = file.label :visible_no, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'no', class: 'radio-right radio-left small-radio radio-third' do
+      = file.label :visible_no, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('common.button.no'), class: 'radio-right radio-left small-radio radio-third' do
         span.fa-stack
           i.fa-regular.fa-eye-slash.fa-stack-1x.fa-2x
       = file.radio_button :visible, 'delayed', value: 'delayed'
-      = file.label :visible_delayed, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'delayed', class: 'radio-right small-radio radio-third' do
+      = file.label :visible_delayed, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('.delayed'), class: 'radio-right small-radio radio-third' do
         span.fa-stack
           i.fa-regular.fa-clock.fa-stack-1x.fa-2x
 
@@ -32,14 +32,14 @@
     = file.label :usage_by_lms, TaskFile.human_attribute_name('usage_by_lms'), class: 'form-label', style: 'width: unset; margin-right: 10px;'
     .radio-switch
       = file.radio_button :usage_by_lms, 'edit', value: 'edit'
-      = file.label :usage_by_lms_edit, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'edit', class: 'radio-left small-radio radio-third' do
+      = file.label :usage_by_lms_edit, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('common.button.edit'), class: 'radio-left small-radio radio-third' do
         span.fa-stack
           i.fa-solid.fa-pencil.fa-stack-1x.fa-2x
       = file.radio_button :usage_by_lms, 'display', value: 'display'
-      = file.label :usage_by_lms_display, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'display', class: 'radio-right radio-left small-radio radio-third' do
+      = file.label :usage_by_lms_display, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('.display'), class: 'radio-right radio-left small-radio radio-third' do
         span.fa-stack
           i.fa-regular.fa-eye.fa-stack-1x.fa-2x
       = file.radio_button :usage_by_lms, 'download', value: 'download'
-      = file.label :usage_by_lms_download, data: {toggle: 'tooltip', placement: 'bottom'}, title: 'download', class: 'radio-right small-radio radio-third' do
+      = file.label :usage_by_lms_download, data: {toggle: 'tooltip', placement: 'bottom'}, title: t('.download'), class: 'radio-right small-radio radio-third' do
         span.fa-stack
           i.fa-solid.fa-download.fa-stack-1x.fa-2x

--- a/app/views/tasks/_tasks.html.slim
+++ b/app/views/tasks/_tasks.html.slim
@@ -88,8 +88,8 @@
       = form_for :comment, url: task_comments_path(task), remote: true do |f|
         .write-comment
           .input-group
-            = f.label 'new_comment_label', t('.button.new_comment'), class: 'input-group-text'
+            = f.label 'new_comment_label', t('tasks.shared.new_comment'), class: 'input-group-text'
             = f.text_field :text, class: 'form-control'
-            = f.submit class: 'btn btn-light'
+            = f.submit t('common.button.save_object', model: Comment.model_name.human), class: 'btn btn-light'
       .comment-body
 = render('shared/pagination', collection: @tasks)

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -45,9 +45,9 @@
                   b = t('.search.order')
                 .btn-group.btn-group-vertical[role="group"]
                   div
-                    = sort_link(@search, :created_at)
+                    = sort_link(@search, :created_at, t('.search.creation_date'))
                   div
-                    = sort_link(@search, :average_rating)
+                    = sort_link(@search, :average_rating, t('.search.average_rating'))
               .stars.col-4
                 p
                   b = t('.search.min_stars')
@@ -61,7 +61,7 @@
             span.row.p-2
               .other.col-4
                 p
-                  b = t('.search.created')
+                  b = t('common.created')
                 span.form-group
                   = f.select 'created_before_days', options_for_select({t('.search.all_time') => 0, t('.search.today') => 1, t('.search.last_week') => 7, t('.search.last_month') => 30}, selected: @created_before_days), {}, class: 'form-control defaultSelect2 ransack-filter'
               .labels.col-4

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -512,7 +512,7 @@
                   li
                     = link_to acc_link.name, export_external_start_task_path(account_link: acc_link), method: :post, remote: true, class: 'dropdown-item export-test'
               - else
-                li
+                li.p-2.px-3
                   = link_to t('.define_account_link'), new_user_account_link_path(current_user)
         - else
           div[data-bs-toggle='tooltip' title=t('.guest.disabled.tooltip') data-bs-delay=150]
@@ -530,14 +530,14 @@
           .write-comment
             - if policy(Comment).new?
               .input-group
-                = f.label 'new_comment_label', 'New Comment', class: 'input-group-text'
+                = f.label 'new_comment_label', t('tasks.shared.new_comment'), class: 'input-group-text'
                 = f.text_field :text, class: 'form-control'
-                = f.submit class: 'btn btn-light'
+                = f.submit t('common.button.save_object', model: Comment.model_name.human), class: 'btn btn-light'
             - else
               .input-group[data-bs-toggle='tooltip' title=t('.guest.disabled.tooltip') data-bs-delay=150]
-                = f.label 'new_comment_label', 'New Comment', class: 'input-group-text'
+                = f.label 'new_comment_label',  t('tasks.shared.new_comment'), class: 'input-group-text'
                 = f.text_field :text, class: 'form-control', disabled: true
-                = f.submit class: 'btn btn-outline-dark disabled'
+                = f.submit t('common.button.save_object', model: Comment.model_name.human), class: 'btn btn-outline-dark disabled'
         .comment-body
 
     .actions.btn-group[role="group"]

--- a/app/views/users/confirmations/new.html.slim
+++ b/app/views/users/confirmations/new.html.slim
@@ -1,10 +1,10 @@
 .header.mb-5
   .std-heading
     i.fa-solid.fa-envelope style='color: #444444'
-    =< t('.resend_confirmation')
+    =< t('devise.confirmations.new.resend_confirmation_instructions')
 
 = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-  = render('shared/form_errors', object: resource, title: t('.validation_error'))
+  = render('shared/form_errors', object: resource, title: t('users.shared.validation_error'))
 
   .form-group.field-element
     = f.label :email, class: 'form-label'
@@ -20,7 +20,7 @@
     .btn-group[role='group']
       = button_tag type: 'submit', class: 'btn btn-important' do
         i.fa-solid.fa-envelope
-        =< t('.resend_confirmation')
+        =< t('devise.confirmations.new.resend_confirmation_instructions')
       = link_to :back, class: 'btn btn-important' do
         i.fa-solid.fa-xmark style=('color: gray')
         =< t('common.button.back')

--- a/app/views/users/mailer/confirmation_instructions.html.slim
+++ b/app/views/users/mailer/confirmation_instructions.html.slim
@@ -1,5 +1,5 @@
-p = I18n.t(:'devise.mailer.confirmation_instructions.greeting', name: @resource.name || @email)
+p = t('devise.mailer.confirmation_instructions.greeting', recipient: @resource.name || @email)
 
-p = I18n.t(:'devise.mailer.confirmation_instructions.p1')
+p = t('.p1')
 
-p = link_to I18n.t(:'devise.mailer.confirmation_instructions.action'), confirmation_url(@resource, confirmation_token: @token)
+p = link_to t('devise.mailer.confirmation_instructions.action'), confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/users/mailer/confirmation_instructions.text.slim
+++ b/app/views/users/mailer/confirmation_instructions.text.slim
@@ -1,5 +1,5 @@
-== I18n.t(:'devise.mailer.confirmation_instructions.greeting', name: @resource.name || @email)
+== t('devise.mailer.confirmation_instructions.greeting', recipient: @resource.name || @email)
 == "\n\n"
-== I18n.t(:'devise.mailer.confirmation_instructions.p1')
+== t('.p1')
 == "\n\n"
 == confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/users/mailer/email_changed.html.slim
+++ b/app/views/users/mailer/email_changed.html.slim
@@ -1,6 +1,6 @@
-p = I18n.t(:'devise.mailer.email_changed.greeting', name: @resource.name || @email)
+p = t('devise.mailer.email_changed.greeting', recipient: @resource.name || @email)
 
 - if @resource.try(:unconfirmed_email?)
-  p = I18n.t(:'devise.mailer.email_changed.p1', unconfirmed_email: @resource.unconfirmed_email)
+  p = t('devise.mailer.email_changed.message_unconfirmed', email: @resource.unconfirmed_email)
 - else
-  p = I18n.t(:'devise.mailer.email_changed.p2', email: @resource.email)
+  p = t('devise.mailer.email_changed.message', email: @resource.email)

--- a/app/views/users/mailer/email_changed.text.slim
+++ b/app/views/users/mailer/email_changed.text.slim
@@ -1,6 +1,6 @@
-== I18n.t(:'devise.mailer.email_changed.greeting', name: @resource.name || @email)
+== t('devise.mailer.email_changed.greeting', recipient: @resource.name || @email)
 == "\n\n"
 - if @resource.try(:unconfirmed_email?)
-  == I18n.t(:'devise.mailer.email_changed.p1', unconfirmed_email: @resource.unconfirmed_email)
+  == t('devise.mailer.email_changed.message_unconfirmed', email: @resource.unconfirmed_email)
 - else
-  == I18n.t(:'devise.mailer.email_changed.p2', email: @resource.email)
+  == t('devise.mailer.email_changed.message', email: @resource.email)

--- a/app/views/users/mailer/password_change.html.slim
+++ b/app/views/users/mailer/password_change.html.slim
@@ -1,3 +1,3 @@
-p = I18n.t(:'devise.mailer.password_change.greeting', name: @resource.name || @resource.email)
+p = t('devise.mailer.password_change.greeting', recipient: @resource.name || @resource.email)
 
-p = I18n.t(:'devise.mailer.password_change.p1')
+p = t('devise.mailer.password_change.message')

--- a/app/views/users/mailer/password_change.text.slim
+++ b/app/views/users/mailer/password_change.text.slim
@@ -1,3 +1,3 @@
-== I18n.t(:'devise.mailer.password_change.greeting', name: @resource.name || @resource.email)
+== t('devise.mailer.password_change.greeting', recipient: @resource.name || @resource.email)
 == "\n\n"
-== I18n.t(:'devise.mailer.password_change.p1')
+== t('devise.mailer.password_change.message')

--- a/app/views/users/mailer/reset_password_instructions.html.slim
+++ b/app/views/users/mailer/reset_password_instructions.html.slim
@@ -1,9 +1,9 @@
-p = I18n.t(:'devise.mailer.reset_password_instructions.greeting', name: @resource.name || @resource.email)
+p = t('devise.mailer.reset_password_instructions.greeting', recipient: @resource.name || @resource.email)
 
-p = I18n.t(:'devise.mailer.reset_password_instructions.p1')
+p = t('devise.mailer.reset_password_instructions.instruction')
 
-p = link_to I18n.t(:'devise.mailer.reset_password_instructions.action'), edit_password_url(@resource, reset_password_token: @token)
+p = link_to t('devise.mailer.reset_password_instructions.action'), edit_password_url(@resource, reset_password_token: @token)
 
-p = I18n.t(:'devise.mailer.reset_password_instructions.p2')
+p = t('devise.mailer.reset_password_instructions.instruction_2')
 
-p = I18n.t(:'devise.mailer.reset_password_instructions.p3')
+p = t('devise.mailer.reset_password_instructions.instruction_3')

--- a/app/views/users/mailer/reset_password_instructions.text.slim
+++ b/app/views/users/mailer/reset_password_instructions.text.slim
@@ -1,9 +1,9 @@
-== I18n.t(:'devise.mailer.reset_password_instructions.greeting', name: @resource.name || @resource.email)
+== t('devise.mailer.reset_password_instructions.greeting', recipient: @resource.name || @resource.email)
 == "\n\n"
-== I18n.t(:'devise.mailer.reset_password_instructions.p1')
+== t('devise.mailer.reset_password_instructions.instruction')
 == "\n\n"
 == edit_password_url(@resource, reset_password_token: @token)
 == "\n\n"
-== I18n.t(:'devise.mailer.reset_password_instructions.p2')
+== t('devise.mailer.reset_password_instructions.instruction_2')
 == "\n\n"
-== I18n.t(:'devise.mailer.reset_password_instructions.p3')
+== t('devise.mailer.reset_password_instructions.instruction_3')

--- a/app/views/users/mailer/unlock_instructions.html.slim
+++ b/app/views/users/mailer/unlock_instructions.html.slim
@@ -1,7 +1,7 @@
-p = I18n.t(:'devise.mailer.unlock_instructions.greeting', name: @resource.name || @resource.email)
+p = t('devise.mailer.unlock_instructions.greeting', recipient: @resource.name || @resource.email)
 
-p = I18n.t(:'devise.mailer.unlock_instructions.p1')
+p = t('devise.mailer.unlock_instructions.message')
 
-p = I18n.t(:'devise.mailer.unlock_instructions.p2')
+p = t('devise.mailer.unlock_instructions.instruction')
 
-p = link_to I18n.t(:'devise.mailer.unlock_instructions.action'), unlock_url(@resource, unlock_token: @token)
+p = link_to t('devise.mailer.unlock_instructions.action'), unlock_url(@resource, unlock_token: @token)

--- a/app/views/users/mailer/unlock_instructions.text.slim
+++ b/app/views/users/mailer/unlock_instructions.text.slim
@@ -1,7 +1,7 @@
-== I18n.t(:'devise.mailer.unlock_instructions.greeting', name: @resource.name || @resource.email)
+== t('devise.mailer.unlock_instructions.greeting', recipient: @resource.name || @resource.email)
 == "\n\n"
-== I18n.t(:'devise.mailer.unlock_instructions.p1')
+== t('devise.mailer.unlock_instructions.message')
 == "\n\n"
-== I18n.t(:'devise.mailer.unlock_instructions.p2')
+== t('devise.mailer.unlock_instructions.instruction')
 == "\n\n"
 == unlock_url(@resource, unlock_token: @token)

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -1,27 +1,27 @@
 .header.mb-5
   .std-heading
     i.fa-solid.fa-key style='color: #444444'
-    =< t('.change_pwd')
+    =< t('devise.passwords.edit.change_your_password')
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
   = render('shared/form_errors', object: resource, title: t('common.errors.changes_not_saved'))
   = f.hidden_field :reset_password_token
 
   .form-group.field-element
-    = f.label :password, t('users.shared.password_new'), class: 'form-label'
+    = f.label :password, t('devise.passwords.edit.new_password'), class: 'form-label'
     = f.password_field :password,
             required: true,
             autofocus: true,
-            placeholder: t('users.shared.password_new'),
+            placeholder: t('devise.passwords.edit.new_password'),
             autocomplete: 'new-password',
             class: 'form-control'
     - if @minimum_password_length
-      small.form-text.text-body-secondary = t('users.shared.minimum_password_length', count: @minimum_password_length)
+      small.form-text.text-body-secondary = t('devise.shared.minimum_password_length', count: @minimum_password_length)
   .form-group.field-element
     = f.label :password_confirmation, t('users.shared.password_new_confirmation'), class: 'form-label'
     = f.password_field :password_confirmation,
             required: true,
-            placeholder: t('users.shared.password_new'),
+            placeholder: t('devise.passwords.edit.new_password'),
             autocomplete: 'new-password',
             class: 'form-control'
 
@@ -29,7 +29,7 @@
     .btn-group[role='group']
       = button_tag type: 'submit', class: 'btn btn-important' do
         i.fa-solid.fa-key
-        =< t('.change_my_pwd')
+        =< t('devise.passwords.edit.change_my_password')
       = link_to :back, class: 'btn btn-important' do
         i.fa-solid.fa-xmark style=('color: gray')
         =< t('common.button.back')

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -1,10 +1,10 @@
 .header.mb-5
   .std-heading
     i.fa-solid.fa-key style='color: #444444'
-    =< t('.forgot_pwd')
+    =< t('devise.passwords.new.forgot_your_password')
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render('shared/form_errors', object: resource, title: t('.validation_error'))
+  = render('shared/form_errors', object: resource, title: t('users.shared.validation_error'))
 
   .form-group.field-element
     = f.label :email, class: 'form-label'
@@ -19,7 +19,7 @@
     .btn-group[role='group']
       = button_tag type: 'submit', class: 'btn btn-important' do
         i.fa-solid.fa-key
-        =< t('.send_reset_pwd')
+        =< t('devise.passwords.new.send_me_reset_password_instructions')
       = link_to :back, class: 'btn btn-important' do
         i.fa-solid.fa-xmark style=('color: gray')
         =< t('common.button.back')

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -1,7 +1,7 @@
 .header.mb-5
   .std-heading
     i.fa-solid.fa-user style='color: #444444'
-    =< t('.header')
+    =< t('devise.registrations.edit.title', resource: User.model_name.human)
 
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = render('shared/form_errors', object: resource, title: t('common.errors.changes_not_saved'))
@@ -30,21 +30,21 @@
             autocomplete: 'email',
             class: 'form-control'
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-      p = t('.waiting_confirmation', email: resource.unconfirmed_email)
+      p = t('devise.registrations.edit.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email)
 
   .form-group.field-element
-    = f.label :password, t('users.shared.password_new'), class: 'form-label'
+    = f.label :password, t('devise.passwords.edit.new_password'), class: 'form-label'
     = f.password_field :password,
             required: false,
-            placeholder: t('users.shared.password_new'),
+            placeholder: t('devise.passwords.edit.new_password'),
             autocomplete: 'new-password',
             class: 'form-control'
-    small.form-text.text-body-secondary = t('.leave_blank')
+    small.form-text.text-body-secondary = t('devise.registrations.edit.leave_blank_if_you_don_t_want_to_change_it')
   .form-group.field-element
     = f.label :password_confirmation, t('users.shared.password_new_confirmation'), class: 'form-label'
     = f.password_field :password_confirmation,
             required: false,
-            placeholder: t('users.shared.password_new'),
+            placeholder: t('devise.passwords.edit.new_password'),
             autocomplete: 'new-password',
             class: 'form-control'
 
@@ -54,16 +54,16 @@
     = f.label :current_password, class: 'form-label'
     = f.password_field :current_password,
             required: true,
-            placeholder: t('.password_current'),
+            placeholder: User.human_attribute_name('current_password'),
             autocomplete: 'current-password',
             class: 'form-control'
-    small.form-text.text-body-secondary = t('.confirm_w_pwd')
+    small.form-text.text-body-secondary = t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes')
 
   .form-group.py-3
     .btn-group[role='group']
       = button_tag type: 'submit', class: 'btn btn-important' do
         i.fa-solid.fa-user
-        =< t('.update_user')
+        =< t('common.button.update')
       = link_to :back, class: 'btn btn-important' do
         i.fa-solid.fa-xmark style=('color: gray')
         =< t('common.button.back')

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,7 +1,7 @@
 .header.mb-5
   .std-heading
     i.fa-solid.fa-user style='color: #444444'
-    =< t('.header')
+    =< t('devise.registrations.new.sign_up')
 
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render('shared/form_errors', object: resource)
@@ -34,16 +34,16 @@
     = f.label :password, class: 'form-label'
     = f.password_field :password,
             required: true,
-            placeholder: t('.password'),
+            placeholder: User.human_attribute_name('password'),
             autocomplete: 'current-password',
             class: 'form-control'
     - if @minimum_password_length
-      small.form-text.text-body-secondary = t('users.shared.minimum_password_length', count: @minimum_password_length)
+      small.form-text.text-body-secondary = t('devise.shared.minimum_password_length', count: @minimum_password_length)
   .form-group.field-element
     = f.label :password_confirmation, class: 'form-label'
     = f.password_field :password_confirmation,
             required: true,
-            placeholder: t('.password'),
+            placeholder: User.human_attribute_name('password'),
             autocomplete: 'current-password',
             class: 'form-control'
 

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -2,21 +2,21 @@
   .header.mb-5
     .std-heading
       i.fa-solid.fa-right-to-bracket style='color: #444444'
-      =< t('users.sessions.new.header')
+      =< t('devise.sessions.new.sign_in')
   = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
     .form-group.field-element
       = f.label :email, class: 'form-label'
       = f.email_field :email,
               required: true,
               autofocus: true,
-              placeholder: t('users.sessions.new.email.placeholder'),
+              placeholder: User.human_attribute_name('email'),
               autocomplete: 'email',
               class: 'form-control'
     .form-group.field-element
       = f.label :password, class: 'form-label'
       = f.password_field :password,
               required: true,
-              placeholder: t('users.sessions.new.password.placeholder'),
+              placeholder: User.human_attribute_name('password'),
               autocomplete: 'current-password',
               class: 'form-control'
     - if devise_mapping.rememberable?

--- a/app/views/users/shared/_links.html.slim
+++ b/app/views/users/shared/_links.html.slim
@@ -8,19 +8,19 @@
     br
 
   - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-    = link_to t('.forgot_pwd'), new_password_path(resource_name)
+    = link_to t('devise.shared.links.forgot_your_password'), new_password_path(resource_name)
     br
 
   - if devise_mapping.confirmable? && controller_name != 'confirmations'
-    = link_to t('.no_confirmation'), new_confirmation_path(resource_name)
+    = link_to t('devise.shared.links.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name)
     br
 
   - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-    = link_to t('.no_unlock'), new_unlock_path(resource_name)
+    = link_to t('devise.shared.links.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name)
     br
 
   - if devise_mapping.omniauthable?
     - resource_class.omniauth_providers.each do |provider|
-      = link_to t('.sign_in_with', provider: OmniAuth::Utils.camelize(provider)),
+      = link_to t('devise.shared.links.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)),
               omniauth_authorize_path(resource_name, provider), method: :post
       br

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -25,7 +25,7 @@
           = User.human_attribute_name('role')
           | :
         .col.row-value
-          = @user.role
+          = t("users.role.#{@user.role}")
 
 - if policy(@user).manage_accountlinks?
   .show-table
@@ -50,7 +50,7 @@
         .account-link-description.info-box
           span.fa-solid.fa-circle-info
           = t('account_links.show.description_html')
-          = link_to "More Information...", account_link_documentation_home_index_path
+          = link_to t('.account_links.more_information'), account_link_documentation_home_index_path
         - @user.account_links.each do |account_link|
           .table-list
             = account_link.name
@@ -64,7 +64,7 @@
                 =< t('common.button.edit')
               = link_to user_account_link_path(current_user, account_link), method: :delete, data: { confirm: t('common.sure') }, class: 'btn btn-light btn-sm' do
                 i.fa-solid.fa-trash-can
-                =< t('common.button.destroy')
+                =< t('common.button.delete')
     - if @user.shared_account_links.any?
       .row.vertical
         .col.row-label

--- a/app/views/users/unlocks/new.html.slim
+++ b/app/views/users/unlocks/new.html.slim
@@ -1,10 +1,10 @@
 .header.mb-5
   .std-heading
     i.fa-solid.fa-unlock style='color: #444444'
-    =< t('.resend_unlock')
+    =< t('devise.unlocks.new.resend_unlock_instructions')
 
 = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
-  = render('shared/form_errors', object: resource, title: t('.validation_error'))
+  = render('shared/form_errors', object: resource, title: t('users.shared.validation_error'))
 
   .form-group.field-element
     = f.label :email, class: 'form-label'
@@ -19,7 +19,7 @@
     .btn-group[role='group']
       = button_tag type: 'submit', class: 'btn btn-important' do
         i.fa-solid.fa-unlock
-        =< t('.resend_unlock')
+        =< t('devise.unlocks.new.resend_unlock_instructions')
       = link_to :back, class: 'btn btn-important' do
         i.fa-solid.fa-xmark style=('color: gray')
         =< t('common.button.back')

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module CodeHarbor
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}')]
     # config.i18n.default_locale = :de
-    config.i18n.available_locales = %i[en]
+    config.i18n.available_locales = %i[de en]
 
     config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/').to_s
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -134,6 +134,10 @@ search:
 ignore_unused:
   - 'activerecord.{attributes,errors,models}.*'
   - '{devise,simple_form}.*'
+  - '{*}.javascripts.*'
+  # ignore devise errors
+  - 'errors.messages.{already_confirmed,confirmation_period_expired,expired,not_found,not_locked}'
+  - 'errors.messages.not_saved.*'
 
 ## Exclude these keys from the `i18n_tasks eq-base' report:
 # ignore_eq_base:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -5,7 +5,7 @@
 # The "main" locale.
 base_locale: en
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [en] # TODO: revert this line to the default after adding German locales
+# locales: [es, fr]
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 

--- a/config/locales/de/common.yml
+++ b/config/locales/de/common.yml
@@ -8,21 +8,26 @@ de:
       close: Schließen
       confirm: Bestätigen
       delete: Löschen
-      destroy: Zerstören
-      download_zip: Zip herunterladen
+      download_zip: ZIP herunterladen
       duplicate: Duplizieren
       edit: Bearbeiten
       export: Exportieren
       hide: Verstecken
       import: Importieren
       log_in: Anmelden
+      'no': Nein
       remove: Entfernen
       retry: Erneut versuchen
+      save: Speichern
+      save_object: "%{model} speichern"
       show: Anzeigen
       show_less: Weniger anzeigen
       show_more: Mehr anzeigen
       sign_up: Registrieren
+      update: Aktualisieren
       view: Ansehen
+      'yes': Ja
+    created: Erstellt
     created_at: Erstellt am
     created_by: Erstellt von
     edit_colon: 'Bearbeiten:'
@@ -33,7 +38,9 @@ de:
       not_authorized: Sie sind nicht berechtigt, diese Aktion auszuführen.
       not_found_error: Sie haben keinen Zugriff auf dieses Objekt oder es existiert nicht.
       not_signed_in: Sie müssen angemeldet sein, um fortzufahren.
-      something_went_wrong: Etwas ist schiefgelaufen
+      something_went_wrong: Etwas ist schiefgelaufen.
+    javascripts:
+      error: Fehler
     locales:
       de: Deutsch
       en: Englisch

--- a/config/locales/de/common.yml
+++ b/config/locales/de/common.yml
@@ -1,0 +1,46 @@
+---
+de:
+  common:
+    button:
+      abort: Abbrechen
+      back: Zurück
+      cancel: Abbrechen
+      close: Schließen
+      confirm: Bestätigen
+      delete: Löschen
+      destroy: Zerstören
+      download_zip: Zip herunterladen
+      duplicate: Duplizieren
+      edit: Bearbeiten
+      export: Exportieren
+      hide: Verstecken
+      import: Importieren
+      log_in: Anmelden
+      remove: Entfernen
+      retry: Erneut versuchen
+      show: Anzeigen
+      show_less: Weniger anzeigen
+      show_more: Mehr anzeigen
+      sign_up: Registrieren
+      view: Ansehen
+    created_at: Erstellt am
+    created_by: Erstellt von
+    edit_colon: 'Bearbeiten:'
+    errors:
+      changes_not_saved: 'Ihre Änderungen konnten aufgrund von Fehlern nicht gespeichert werden:'
+      generic: Ein Fehler ist aufgetreten.
+      model_not_saved: "%{model} konnte aufgrund von Fehlern nicht gespeichert werden:"
+      not_authorized: Sie sind nicht berechtigt, diese Aktion auszuführen.
+      not_found_error: Sie haben keinen Zugriff auf dieses Objekt oder es existiert nicht.
+      not_signed_in: Sie müssen angemeldet sein, um fortzufahren.
+      something_went_wrong: Etwas ist schiefgelaufen
+    locales:
+      en: Englisch
+    none: Keine
+    notices:
+      object_created: "%{model} wurde erfolgreich erstellt."
+      object_deleted: "%{model} wurde erfolgreich gelöscht."
+      object_duplicated: "%{model} wurde erfolgreich dupliziert."
+      object_removed: "%{model} wurde erfolgreich entfernt."
+      object_updated: "%{model} wurde erfolgreich aktualisiert."
+    sure: Sind Sie sicher?

--- a/config/locales/de/common.yml
+++ b/config/locales/de/common.yml
@@ -35,6 +35,7 @@ de:
       not_signed_in: Sie müssen angemeldet sein, um fortzufahren.
       something_went_wrong: Etwas ist schiefgelaufen
     locales:
+      de: Deutsch
       en: Englisch
     none: Keine
     notices:

--- a/config/locales/de/common.yml
+++ b/config/locales/de/common.yml
@@ -1,6 +1,7 @@
 ---
 de:
   common:
+    app_name: CodeHarbor
     button:
       abort: Abbrechen
       back: Zurück

--- a/config/locales/de/controllers/account_links.yml
+++ b/config/locales/de/controllers/account_links.yml
@@ -1,0 +1,8 @@
+---
+de:
+  account_links:
+    add_shared_user:
+      granted_push: Die Push-Berechtigungen für %{user} wurden gewährt.
+      share_duplicate: Dieses Kontoverbindung ist bereits mit %{user} geteilt.
+    remove_shared_user:
+      removed_push: Die Push-Berechtigungen für %{user} wurden entfernt.

--- a/config/locales/de/controllers/account_links.yml
+++ b/config/locales/de/controllers/account_links.yml
@@ -2,7 +2,7 @@
 de:
   account_links:
     add_shared_user:
-      granted_push: Die Push-Berechtigungen für %{user} wurden gewährt.
-      share_duplicate: Dieses Kontoverbindung ist bereits mit %{user} geteilt.
+      granted_push: Die Push-Berechtigungen für %{user} wurden vergeben.
+      share_duplicate: Dieser Account-Link ist bereits mit %{user} geteilt.
     remove_shared_user:
       removed_push: Die Push-Berechtigungen für %{user} wurden entfernt.

--- a/config/locales/de/controllers/collections.yml
+++ b/config/locales/de/controllers/collections.yml
@@ -1,0 +1,19 @@
+---
+de:
+  collections:
+    leave:
+      left_successfully: Du hast die Sammlung erfolgreich verlassen.
+    push_collection:
+      not_working: Der Link zu deinem Konto %{account_link} scheint nicht zu funktionieren.
+      push_external_notice: Übung wurde zu %{account_link} verschoben
+    remove_all:
+      cannot_remove_alert: Du kannst nicht alle Aufgaben entfernen
+      success_notice: Alle Aufgaben wurden erfolgreich entfernt
+    remove_task:
+      cannot_remove_alert: Du kannst diese Aufgabe nicht entfernen.
+    save_shared:
+      success_notice: Du kannst jetzt an dieser Sammlung zusammenarbeiten.
+    share:
+      success_notice: Deine Sammlung wurde gesendet.
+    share_message:
+      text: "%{user} hat dir ihre Sammlung %{collection} gesendet."

--- a/config/locales/de/controllers/collections.yml
+++ b/config/locales/de/controllers/collections.yml
@@ -2,18 +2,18 @@
 de:
   collections:
     leave:
-      left_successfully: Du hast die Sammlung erfolgreich verlassen.
+      left_successfully: Sie haben die Aufgabensammlung erfolgreich verlassen.
     push_collection:
-      not_working: Der Link zu deinem Konto %{account_link} scheint nicht zu funktionieren.
-      push_external_notice: Übung wurde zu %{account_link} verschoben
+      not_working: Ihr Account-Link %{account_link} scheint nicht zu funktionieren.
+      push_external_notice: Aufgabe wurde zu %{account_link} verschoben.
     remove_all:
-      cannot_remove_alert: Du kannst nicht alle Aufgaben entfernen
-      success_notice: Alle Aufgaben wurden erfolgreich entfernt
+      cannot_remove_alert: Sie können nicht alle Aufgaben entfernen.
+      success_notice: Alle Aufgaben wurden erfolgreich entfernt.
     remove_task:
-      cannot_remove_alert: Du kannst diese Aufgabe nicht entfernen.
+      cannot_remove_alert: Sie können diese Aufgabe nicht entfernen.
     save_shared:
-      success_notice: Du kannst jetzt an dieser Sammlung zusammenarbeiten.
+      success_notice: Sie können jetzt an dieser Aufgabensammlung zusammenarbeiten.
     share:
-      success_notice: Deine Sammlung wurde gesendet.
+      success_notice: Ihre Aufgabensammlung wurde gesendet.
     share_message:
-      text: "%{user} hat dir ihre Sammlung %{collection} gesendet."
+      text: '%{user} hat Ihnen die Aufgabensammlung "%{collection}" gesendet.'

--- a/config/locales/de/controllers/comments.yml
+++ b/config/locales/de/controllers/comments.yml
@@ -1,0 +1,7 @@
+---
+de:
+  comments:
+    create:
+      error: Es ist ein Fehler aufgetreten beim Erstellen Ihres Kommentars.
+    update:
+      error: Es ist ein Fehler aufgetreten beim Aktualisieren Ihres Kommentars.

--- a/config/locales/de/controllers/groups.yml
+++ b/config/locales/de/controllers/groups.yml
@@ -1,0 +1,24 @@
+---
+de:
+  groups:
+    delete_from_group:
+      success_notice: Benutzer aus Gruppe gelöscht.
+    demote_admin:
+      success_notice: Admin zu Benutzer heruntergestuft.
+    deny_access:
+      success_notice: Benutzer abgelehnt.
+    grant_access:
+      success_notice: Zugriff gewährt.
+    leave:
+      cannot_leave_alert: Du musst zuerst jemand anderen zum Admin ernennen
+      success_notice: Du hast erfolgreich die Gruppe verlassen
+    make_admin:
+      success_notice: Benutzer zum Admin gemacht.
+    request_access:
+      success_notice: Deine Zugriffsanfrage wurde gesendet.
+    send_access_request_message:
+      message: "%{user} möchte auf deine Gruppe zugreifen: %{group}."
+    send_deny_access_message:
+      message: "%{user} hat dich nicht in ihre Gruppe aufgenommen: %{group}."
+    send_grant_access_messages:
+      message: "%{user} hat dich in ihre Gruppe aufgenommen: %{group}."

--- a/config/locales/de/controllers/groups.yml
+++ b/config/locales/de/controllers/groups.yml
@@ -2,23 +2,23 @@
 de:
   groups:
     delete_from_group:
-      success_notice: Benutzer aus Gruppe gelöscht.
+      success_notice: Benutzer:in aus Gruppe gelöscht.
     demote_admin:
-      success_notice: Admin zu Benutzer heruntergestuft.
+      success_notice: Administrator:in zu Benutzer:in heruntergestuft.
     deny_access:
-      success_notice: Benutzer abgelehnt.
+      success_notice: Benutzer:in abgelehnt.
     grant_access:
       success_notice: Zugriff gewährt.
     leave:
-      cannot_leave_alert: Du musst zuerst jemand anderen zum Admin ernennen
-      success_notice: Du hast erfolgreich die Gruppe verlassen
+      cannot_leave_alert: Sie müssen zuerst jemand anderen zur Administrator:in ernennen.
+      success_notice: Sie haben erfolgreich die Gruppe verlassen.
     make_admin:
-      success_notice: Benutzer zum Admin gemacht.
+      success_notice: Benutzer:in zur Administrator:in gemacht.
     request_access:
-      success_notice: Deine Zugriffsanfrage wurde gesendet.
+      success_notice: Ihre Zugriffsanfrage wurde gesendet.
     send_access_request_message:
-      message: "%{user} möchte auf deine Gruppe zugreifen: %{group}."
+      message: "%{user} möchte auf Ihre Gruppe zugreifen: %{group}"
     send_deny_access_message:
-      message: "%{user} hat dich nicht in ihre Gruppe aufgenommen: %{group}."
+      message: "%{user} hat Sie nicht in die Gruppe aufgenommen: %{group}"
     send_grant_access_messages:
-      message: "%{user} hat dich in ihre Gruppe aufgenommen: %{group}."
+      message: "%{user} hat Sie in die Gruppe aufgenommen: %{group}"

--- a/config/locales/de/controllers/messages.yml
+++ b/config/locales/de/controllers/messages.yml
@@ -1,0 +1,7 @@
+---
+de:
+  messages:
+    create:
+      sent_successfully: Nachricht wurde erfolgreich gesendet.
+    destroy:
+      error: Beim Löschen der Nachricht ist ein Fehler aufgetreten.

--- a/config/locales/de/controllers/ratings.yml
+++ b/config/locales/de/controllers/ratings.yml
@@ -1,0 +1,5 @@
+---
+de:
+  ratings:
+    handle_own_rating:
+      error: Du kannst deine eigene Aufgabe nicht bewerten

--- a/config/locales/de/controllers/ratings.yml
+++ b/config/locales/de/controllers/ratings.yml
@@ -2,4 +2,4 @@
 de:
   ratings:
     handle_own_rating:
-      error: Du kannst deine eigene Aufgabe nicht bewerten
+      error: Sie können Ihre eigene Aufgabe nicht bewerten.

--- a/config/locales/de/controllers/task_files.yml
+++ b/config/locales/de/controllers/task_files.yml
@@ -2,4 +2,4 @@
 de:
   task_files:
     extract_text_data:
-      no_text: Die Datei enthält keinen Text
+      no_text: Die Datei enthält keinen Text.

--- a/config/locales/de/controllers/task_files.yml
+++ b/config/locales/de/controllers/task_files.yml
@@ -1,0 +1,5 @@
+---
+de:
+  task_files:
+    extract_text_data:
+      no_text: Die Datei enthält keinen Text

--- a/config/locales/de/controllers/tasks.yml
+++ b/config/locales/de/controllers/tasks.yml
@@ -1,0 +1,28 @@
+---
+de:
+  tasks:
+    add_to_collection:
+      error: Aufgabe ist bereits in der Sammlung.
+      success_notice: Aufgabe wurde erfolgreich zur Sammlung hinzugefügt.
+    duplicate:
+      error_alert: Die Aufgabe konnte nicht dupliziert werden.
+    export_external_confirm:
+      error: 'Der Export der Aufgabe (%{title}) ist fehlgeschlagen. <br> Fehler: %{error}'
+      success: Aufgabe (%{title}) erfolgreich exportiert.
+    import_confirm:
+      error: 'Der Import der Aufgabe (%{title}) ist fehlgeschlagen. <br> Fehler: %{error}'
+      success: Aufgabe (%{title}) erfolgreich importiert.
+    import_external:
+      internal_error: Bei der Importierung der Übung ist ein interner Fehler aufgetreten.
+      invalid: Ungültige Übung
+      success: Erfolg
+    import_start:
+      choose_file_error: Sie müssen eine Datei auswählen.
+    proforma_service:
+      convert_zip_to_proforma_tasks:
+        nested_too_deep: Die Zip-Datei ist zu tief verschachtelt.
+    task_service:
+      check_external:
+        no_task: In der externen App wurde keine entsprechende Aufgabe gefunden. Beim Pushen dieser Aufgabe wird eine neue Aufgabe in der externen App erstellt, die mit dieser Aufgabe in CodeHarbor verknüpft ist. Alle Änderungen an einer der Aufgaben können auf die jeweils andere Plattform übertragen werden.
+        task_found: 'In der externen App wurde eine entsprechende Aufgabe gefunden. Sie können: <ul><li><b>Überschreiben</b> Sie die Aufgabe in der externen App. Dadurch werden alle Änderungen, die in CodeHarbor vorgenommen wurden, auf die externe App übertragen.<br>Vorsicht: Dadurch werden alle potenziellen Änderungen in der externen App überschrieben. Dadurch wird die Aufgabe geändert (und möglicherweise zerstört), auch wenn sie derzeit in einem Kurs verwendet wird.</li><li><b>Erstellen Sie eine neue</b> Aufgabe, die den aktuellen Zustand dieser Aufgabe kopiert. Dadurch wird eine Kopie dieser Aufgabe in CodeHarbor erstellt, die dann als völlig neue Übung in der externen App exportiert wird.</li></ul>'
+        task_found_no_right: 'In der externen App wurde eine entsprechende Aufgabe gefunden, aber Sie haben keine Rechte, sie zu bearbeiten. Sie können: <ul><li><b>Erstellen Sie eine neue</b> Aufgabe, die den aktuellen Zustand dieser Aufgabe kopiert. Dadurch wird eine Kopie dieser Aufgabe in CodeHarbor erstellt, die dann als völlig neue Aufgabe in der externen App exportiert wird.</li></ul>'

--- a/config/locales/de/controllers/tasks.yml
+++ b/config/locales/de/controllers/tasks.yml
@@ -13,16 +13,16 @@ de:
       error: 'Der Import der Aufgabe (%{title}) ist fehlgeschlagen. <br> Fehler: %{error}'
       success: Aufgabe (%{title}) erfolgreich importiert.
     import_external:
-      internal_error: Bei der Importierung der Übung ist ein interner Fehler aufgetreten.
-      invalid: Ungültige Übung
+      internal_error: Bei der Importierung der Aufgabe ist ein interner Fehler aufgetreten.
+      invalid: Ungültige Aufgabe
       success: Erfolg
     import_start:
       choose_file_error: Sie müssen eine Datei auswählen.
     proforma_service:
       convert_zip_to_proforma_tasks:
-        nested_too_deep: Die Zip-Datei ist zu tief verschachtelt.
+        nested_too_deep: Die ZIP-Datei ist zu tief verschachtelt.
     task_service:
       check_external:
         no_task: In der externen App wurde keine entsprechende Aufgabe gefunden. Beim Pushen dieser Aufgabe wird eine neue Aufgabe in der externen App erstellt, die mit dieser Aufgabe in CodeHarbor verknüpft ist. Alle Änderungen an einer der Aufgaben können auf die jeweils andere Plattform übertragen werden.
-        task_found: 'In der externen App wurde eine entsprechende Aufgabe gefunden. Sie können: <ul><li><b>Überschreiben</b> Sie die Aufgabe in der externen App. Dadurch werden alle Änderungen, die in CodeHarbor vorgenommen wurden, auf die externe App übertragen.<br>Vorsicht: Dadurch werden alle potenziellen Änderungen in der externen App überschrieben. Dadurch wird die Aufgabe geändert (und möglicherweise zerstört), auch wenn sie derzeit in einem Kurs verwendet wird.</li><li><b>Erstellen Sie eine neue</b> Aufgabe, die den aktuellen Zustand dieser Aufgabe kopiert. Dadurch wird eine Kopie dieser Aufgabe in CodeHarbor erstellt, die dann als völlig neue Übung in der externen App exportiert wird.</li></ul>'
-        task_found_no_right: 'In der externen App wurde eine entsprechende Aufgabe gefunden, aber Sie haben keine Rechte, sie zu bearbeiten. Sie können: <ul><li><b>Erstellen Sie eine neue</b> Aufgabe, die den aktuellen Zustand dieser Aufgabe kopiert. Dadurch wird eine Kopie dieser Aufgabe in CodeHarbor erstellt, die dann als völlig neue Aufgabe in der externen App exportiert wird.</li></ul>'
+        task_found: 'In der externen App wurde eine entsprechende Aufgabe gefunden. Sie können: <ul><li><b>Überschreiben</b> Sie die Aufgabe in der externen App. Dadurch werden alle Änderungen, die in CodeHarbor vorgenommen wurden, auf die externe App übertragen.<br>Vorsicht: Dadurch werden alle potenziellen Änderungen in der externen App überschrieben. Dadurch wird die Aufgabe geändert (und möglicherweise zerstört), auch wenn sie derzeit in einem Kurs verwendet wird.</li><li><b>Erstellen Sie eine neue</b> Aufgabe, die den aktuellen Zustand dieser Aufgabe kopiert. Dadurch wird eine Kopie dieser Aufgabe in CodeHarbor erstellt, die dann als völlig neue Aufgabe in der externen App exportiert wird.</li></ul>'
+        task_found_no_right: 'In der externen App wurde eine entsprechende Aufgabe gefunden, aber Sie haben keine Rechte, sie zu bearbeiten. Sie können: <ul><li><b>Eine neue Aufgabe erstellen</b>, die den aktuellen Zustand dieser Aufgabe kopiert. Dadurch wird eine Kopie dieser Aufgabe in CodeHarbor erstellt, die dann als völlig neue Aufgabe in der externen App exportiert wird.</li></ul>'

--- a/config/locales/de/external/devise.yml
+++ b/config/locales/de/external/devise.yml
@@ -1,0 +1,148 @@
+---
+de:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: Bestätigung gesendet am
+        confirmation_token: Bestätigungs-Token
+        confirmed_at: Bestätigt am
+        created_at: Erstellt am
+        current_password: Bisheriges Passwort
+        current_sign_in_at: Aktuelle Anmeldung am
+        current_sign_in_ip: IP der aktuellen Anmeldung
+        email: E-Mail
+        encrypted_password: Verschlüsseltes Passwort
+        failed_attempts: Fehlversuche
+        last_sign_in_at: Letzte Anmeldung am
+        last_sign_in_ip: IP der letzten Anmeldung
+        locked_at: Gesperrt am
+        password: Passwort
+        password_confirmation: Passwortbestätigung
+        remember_created_at: '"Angemeldet bleiben" erstellt am'
+        remember_me: Angemeldet bleiben
+        reset_password_sent_at: E-Mail zum Zurücksetzen des Passworts gesendet am
+        reset_password_token: Token zum Zurücksetzen des Passworts
+        sign_in_count: Anzahl der Anmeldungen
+        unconfirmed_email: Unbestätigte E-Mail-Adresse
+        unlock_token: Entsperrungs-Token
+        updated_at: Aktualisiert am
+    models:
+      user:
+        one: Benutzer:in
+        other: Benutzer:innen
+  devise:
+    confirmations:
+      confirmed: Ihre E-Mail-Adresse wurde erfolgreich bestätigt.
+      new:
+        resend_confirmation_instructions: Bestätigungsanleitung erneut senden
+      send_instructions: In wenigen Minuten erhalten Sie eine E-Mail zur Bestätigung Ihrer Registrierung.
+      send_paranoid_instructions: Falls Ihre E-Mail-Adresse in unserer Datenbank existiert, erhalten Sie in wenigen Minuten eine E-Mail zur Bestätigung Ihrer Registrierung.
+    failure:
+      already_authenticated: Sie sind bereits angemeldet.
+      inactive: Ihr Account ist noch nicht aktiv.
+      invalid: "%{authentication_keys} oder Passwort ist ungültig."
+      last_attempt: Sie haben noch einen Versuch, bevor Ihr Account gesperrt wird.
+      locked: Ihr Account ist gesperrt.
+      not_found_in_database: "%{authentication_keys} oder Passwort ist ungültig."
+      timeout: Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.
+      unauthenticated: Sie müssen sich anmelden oder registrieren, um fortzufahren.
+      unconfirmed: Sie müssen Ihren Account bestätigen, bevor Sie fortfahren können.
+    mailer:
+      confirmation_instructions:
+        action: Meinen Account bestätigen
+        greeting: Willkommen %{recipient}!
+        instruction: 'Klicken Sie auf den folgenden Link, um Ihren Account zu bestätigen:'
+        subject: Anleitung zur Account-Bestätigung
+      email_changed:
+        greeting: Hallo %{recipient}!
+        message: Wir möchten Sie informieren, dass Ihre E-Mail-Adresse zu %{email} geändert wurde.
+        message_unconfirmed: Wir möchten Sie informieren, dass Ihre E-Mail-Adresse zu %{email} geändert wird.
+        subject: E-Mail-Adresse geändert
+      password_change:
+        greeting: Hallo %{recipient}!
+        message: Wir möchten Sie darüber informieren, dass Ihr Passwort geändert wurde.
+        subject: Passwortänderung
+      reset_password_instructions:
+        action: Passwort ändern
+        greeting: Hallo %{recipient}!
+        instruction: Jemand hat einen Link zum Ändern Ihres Passworts angefordert. Klicken Sie auf den folgenden Link, um Ihr Passwort zu ändern.
+        instruction_2: Ignorieren Sie diese E-Mail, wenn Sie kein neues Passwort angefordert haben.
+        instruction_3: Ihr Passwort wird erst geändert, wenn Sie den obigen Link nutzen und ein neues Passwort festlegen.
+        subject: Anweisungen zum Zurücksetzen Ihres Passworts
+      unlock_instructions:
+        action: Meinen Account entsperren
+        greeting: Hallo %{recipient}!
+        instruction: 'Klicken Sie auf den folgenden Link, um Ihren Account zu entsperren:'
+        message: Aufgrund zahlreicher fehlgeschlagener Anmeldeversuche wurde Ihr Account gesperrt.
+        subject: Anweisungen zur Entsperrung Ihres Accounts
+    omniauth_callbacks:
+      failure: 'Die Anmeldung mit Ihrem %{kind}-Account war aufgrund des folgenden Grundes nicht möglich: "%{reason}".'
+      success: Sie haben sich erfolgreich über Ihren %{kind}-Account angemeldet.
+    passwords:
+      edit:
+        change_my_password: Mein Passwort ändern
+        change_your_password: Ihr Passwort ändern
+        confirm_new_password: Neues Passwort bestätigen
+        new_password: Neues Passwort
+      new:
+        forgot_your_password: Haben Sie Ihr Passwort vergessen?
+        send_me_reset_password_instructions: Anweisungen zum Zurücksetzen meines Passworts senden
+      no_token: Sie können diese Seite nicht nutzen, es sei denn, Sie stammen von einer Passwort-Zurücksetzen-E-Mail. Wenn dies der Fall ist, stellen Sie sicher, dass Sie die vollständige URL verwendet haben.
+      send_instructions: Sie erhalten in Kürze eine E-Mail mit Anweisungen zum Zurücksetzen Ihres Passworts.
+      send_paranoid_instructions: Wenn Ihre E-Mail-Adresse in unserer Datenbank existiert, erhalten Sie in Kürze eine E-Mail mit Anweisungen zum Zurücksetzen Ihres Passworts.
+      updated: Ihr Passwort wurde geändert. Sie sind jetzt angemeldet.
+      updated_not_active: Ihr Passwort wurde erfolgreich geändert.
+    registrations:
+      destroyed: Ihr Account wurde gelöscht. Wir hoffen, Sie bald wiederzusehen.
+      edit:
+        are_you_sure: Sind Sie sicher, dass Sie das tun möchten?
+        cancel_my_account: Account löschen
+        currently_waiting_confirmation_for_email: Bestätigung für %{email} ausstehend.
+        leave_blank_if_you_don_t_want_to_change_it: Leer lassen, wenn Sie es unverändert lassen möchten.
+        title: "%{resource} bearbeiten"
+        unhappy: Nicht zufrieden?
+        update: Änderungen speichern
+        we_need_your_current_password_to_confirm_your_changes: Zur Bestätigung geben Sie bitte Ihr aktuelles Passwort ein.
+      new:
+        sign_up: Registrieren
+      signed_up: Sie haben sich erfolgreich registriert.
+      signed_up_but_inactive: Ihre Registrierung war erfolgreich, Ihr Account ist jedoch noch nicht aktiviert.
+      signed_up_but_locked: Ihre Registierung war erfolgreich, Ihr Account ist jedoch gesperrt.
+      signed_up_but_unconfirmed: Sie erhalten in Kürze eine Bestätigungs-E-Mail. Bitte klicken Sie auf den darin enthaltenen Link, um Ihren Account zu aktivieren.
+      update_needs_confirmation: Sie haben Ihre Daten aktualisiert. Eine Bestätigungs-E-Mail wird Ihnen zugesandt. Bitte klicken Sie auf den Link in der E-Mail, um Ihre Änderungen zu bestätigen.
+      updated: Ihre Einstellungen wurden aktualisiert.
+      updated_but_not_signed_in: Sie haben Ihre Daten aktualisiert, aber Sie müssen sich wegen einer Passwortänderung erneut anmelden.
+    sessions:
+      already_signed_out: Sie sind bereits abgemeldet.
+      new:
+        sign_in: Anmelden
+      signed_in: Sie sind nun angemeldet.
+      signed_out: Sie haben sich erfolgreich abgemeldet.
+    shared:
+      links:
+        back: Zurück
+        didn_t_receive_confirmation_instructions: Keine Bestätigungs-E-Mail erhalten?
+        didn_t_receive_unlock_instructions: Keine Anweisungen zum Entsperren erhalten?
+        forgot_your_password: Passwort vergessen?
+        sign_in: Anmelden
+        sign_in_with_provider: Mit %{provider} anmelden
+        sign_up: Registrieren
+      minimum_password_length:
+        one: "(mindestens %{count} Zeichen)"
+        other: "(mindestens %{count} Zeichen)"
+    unlocks:
+      new:
+        resend_unlock_instructions: Anweisungen zum Entsperren erneut senden
+      send_instructions: Sie erhalten in Kürze eine E-Mail mit Anweisungen, wie Sie Ihren Account entsperren können.
+      send_paranoid_instructions: Wenn Ihre E-Mail-Adresse in unserer Datenbank verzeichnet ist, erhalten Sie Anweisungen zur Entsperrung Ihres Accounts.
+      unlocked: Ihr Account wurde entsperrt. Bitte melden Sie sich jetzt an.
+  errors:
+    messages:
+      already_confirmed: Bereits bestätigt. Versuchen Sie, sich anzumelden.
+      confirmation_period_expired: Die Bestätigungsfrist von %{period} ist abgelaufen. Bitte erneut anfordern.
+      expired: Der Link ist abgelaufen. Bitte erneut anfordern.
+      not_found: Nicht gefunden.
+      not_locked: Nicht gesperrt.
+      not_saved:
+        one: "%{resource} konnte wegen eines Fehlers nicht gespeichert werden:"
+        other: "%{count} Fehler verhinderten das Speichern von %{resource}:"

--- a/config/locales/de/external/simple_form.yml
+++ b/config/locales/de/external/simple_form.yml
@@ -1,0 +1,10 @@
+---
+de:
+  simple_form:
+    error_notification:
+      default_message: 'Bitte prüfen Sie die folgenden Probleme:'
+    'no': Nein
+    required:
+      mark: "*"
+      text: erforderlich
+    'yes': Ja

--- a/config/locales/de/models.yml
+++ b/config/locales/de/models.yml
@@ -1,0 +1,179 @@
+---
+de:
+  activerecord:
+    attributes:
+      account_link:
+        api_key: API-Schlüssel
+        check_uuid_url: UUID-URL überprüfen
+        name: Name
+        push_url: Push-URL
+      account_link_user:
+        user: Benutzer
+      collection:
+        description: Beschreibung
+        title: Titel
+        users: Benutzer
+      comment:
+        text: Text
+      group:
+        admins: Admins
+        description: Beschreibung
+        name: Name
+      group_membership:
+        role: Rolle
+        user_id: Benutzer-ID
+      group_task:
+        task_id: Aufgaben-ID
+      label:
+        color: Farbe
+        name: Name
+      license:
+        name: Name
+      message:
+        recipient: Empfänger
+        text: Text
+      model_solution:
+        xml_id: XML-ID
+      rating:
+        rating: Bewertung
+      task:
+        access_level: Sichtbarkeit
+        description: Beschreibung
+        external_resources: Externe Ressourcen
+        files: Dateien
+        grading_hints: Bewertungshinweise
+        internal_description: Interne Beschreibung
+        language: Sprache
+        license: Lizenz
+        meta_data: Metadaten
+        parent_uuid: Übergeordnete UUID
+        programming_language: Programmiersprache
+        submission_restrictions: Abgabe-Einschränkungen
+        tests: Tests
+        title: Titel
+        uuid: UUID
+      task_file:
+        attachment: Anhang
+        content: Inhalt
+        internal_description: Interne Beschreibung
+        name: Name
+        path: Pfad
+        usage_by_lms: Verwendung durch LMS
+        used_by_grader: Verwendet durch Grader
+        visible: Sichtbar
+        xml_id: XML-ID
+      test:
+        configuration: Konfiguration
+        description: Beschreibung
+        internal_description: Interne Beschreibung
+        test_type: Testtyp
+        testing_framework: Testframework
+        timeout: Timeout
+        title: Titel
+        validity: Gültigkeit
+        xml_id: XML-ID
+      user:
+        email: E-Mail
+        first_name: Vorname
+        last_name: Nachname
+        role: Rolle
+      user_identity:
+        omniauth_provider: OmniAuth-Anbieter
+        provider_uid: Anbieter-UID
+    errors:
+      models:
+        collection:
+          attributes:
+            description:
+              too_long: ist %{excess} Zeichen länger als die maximale Länge von %{max_length} Zeichen
+        group:
+          attributes:
+            base:
+              no_admin: Kein Administrator in der Gruppe
+        task:
+          attributes:
+            language:
+              not_de_or_us: 'ist nicht im richtigen Format. Bitte verwenden Sie eines der folgenden Formate: de / en-US'
+              not_iso639: ist kein zweistelliger ISO-639-1- oder dreistelliger ISO-639-2-Sprachcode
+        task_file:
+          attributes:
+            xml_id:
+              not_unique: ist nicht eindeutig
+        user:
+          attributes:
+            avatar:
+              not_an_image: muss ein Bild sein
+              size_over_10_mb: Größe muss kleiner als 10MB sein
+    models:
+      account_link:
+        one: Konto-Link
+        other: Konto-Links
+      account_link_user:
+        one: Konto-Link
+        other: Konto-Link-Benutzer
+      collection:
+        one: Sammlung
+        other: Sammlungen
+      collection_task:
+        one: Sammlungsaufgabe
+        other: Sammlungsaufgaben
+      collection_user:
+        one: Sammlungsbenutzer
+        other: Sammlungsbenutzer
+      comment:
+        one: Kommentar
+        other: Kommentare
+      group:
+        one: Gruppe
+        other: Gruppen
+      group_membership:
+        one: Gruppenmitgliedschaft
+        other: Gruppenmitgliedschaften
+      group_task:
+        one: Gruppenaufgabe
+        other: Gruppenaufgaben
+      label:
+        one: Label
+        other: Labels
+      license:
+        one: Lizenz
+        other: Lizenzen
+      message:
+        one: Nachricht
+        other: Nachrichten
+      model_solution:
+        one: Musterlösung
+        other: Musterlösungen
+      programming_language:
+        one: Programmiersprache
+        other: Programmiersprachen
+      rating:
+        one: Bewertung
+        other: Bewertungen
+      report:
+        one: Bericht
+        other: Berichte
+      task:
+        one: Aufgabe
+        other: Aufgaben
+      task_file:
+        one: Aufgabendatei
+        other: Aufgabendateien
+      task_label:
+        one: Aufgabenlabel
+        other: Aufgabenlabels
+      test:
+        one: Test
+        other: Tests
+      testing_framework:
+        one: Test-Framework
+        other: Test-Frameworks
+      user:
+        one: Benutzer
+        other: Benutzer
+      user_identity:
+        one: Benutzeridentität
+        other: Benutzeridentitäten
+  tasks:
+    model:
+      copy_of_task: Kopie der Aufgabe

--- a/config/locales/de/models.yml
+++ b/config/locales/de/models.yml
@@ -4,24 +4,24 @@ de:
     attributes:
       account_link:
         api_key: API-Schlüssel
-        check_uuid_url: UUID-URL überprüfen
+        check_uuid_url: URL zum Überprüfen der UUID
         name: Name
         push_url: Push-URL
       account_link_user:
-        user: Benutzer
+        user: Benutzer:in
       collection:
         description: Beschreibung
         title: Titel
-        users: Benutzer
+        users: Benutzer:innen
       comment:
         text: Text
       group:
-        admins: Admins
+        admins: Administratorinnen und Administratoren
         description: Beschreibung
         name: Name
       group_membership:
         role: Rolle
-        user_id: Benutzer-ID
+        user_id: Benutzer:innen-ID
       group_task:
         task_id: Aufgaben-ID
       label:
@@ -30,7 +30,7 @@ de:
       license:
         name: Name
       message:
-        recipient: Empfänger
+        recipient: Empfänger:in
         text: Text
       model_solution:
         xml_id: XML-ID
@@ -52,6 +52,19 @@ de:
         tests: Tests
         title: Titel
         uuid: UUID
+      task/files:
+        attachment: Anhang einer Datei
+        name: Name einer Datei
+        xml_id: XML-ID einer Datei
+      task/model_solutions:
+        xml_id: XML-ID einer Musterlösung
+      task/model_solutions/files:
+        attachment: Anhang einer Datei in einer Musterlösung
+        name: Name einer Datei in einer Musterlösung
+        xml_id: XML_ID einer Datei in einer Musterlösung
+      task/tests:
+        title: Titel eines Tests
+        xml_id: XML-ID eines Tests
       task_file:
         attachment: Anhang
         content: Inhalt
@@ -59,7 +72,7 @@ de:
         name: Name
         path: Pfad
         usage_by_lms: Verwendung durch LMS
-        used_by_grader: Verwendet durch Grader
+        used_by_grader: Verwendung durch Autograder
         visible: Sichtbar
         xml_id: XML-ID
       test:
@@ -73,7 +86,6 @@ de:
         validity: Gültigkeit
         xml_id: XML-ID
       user:
-        email: E-Mail
         first_name: Vorname
         last_name: Nachname
         role: Rolle
@@ -89,7 +101,7 @@ de:
         group:
           attributes:
             base:
-              no_admin: Kein Administrator in der Gruppe
+              no_admin: Kein/e Administrator:in in der Gruppe
         task:
           attributes:
             language:
@@ -106,20 +118,20 @@ de:
               size_over_10_mb: Größe muss kleiner als 10MB sein
     models:
       account_link:
-        one: Konto-Link
-        other: Konto-Links
+        one: Account-Link
+        other: Account-Links
       account_link_user:
-        one: Konto-Link
-        other: Konto-Link-Benutzer
+        one: Account-Link-Benutzer:in
+        other: Account-Link-Benutzer:innen
       collection:
-        one: Sammlung
-        other: Sammlungen
+        one: Aufgabensammlung
+        other: Aufgabensammlungen
       collection_task:
         one: Sammlungsaufgabe
         other: Sammlungsaufgaben
       collection_user:
-        one: Sammlungsbenutzer
-        other: Sammlungsbenutzer
+        one: Sammlungsbenutzer:in
+        other: Sammlungsbenutzer:innen
       comment:
         one: Kommentar
         other: Kommentare
@@ -168,12 +180,13 @@ de:
       testing_framework:
         one: Test-Framework
         other: Test-Frameworks
-      user:
-        one: Benutzer
-        other: Benutzer
       user_identity:
-        one: Benutzeridentität
-        other: Benutzeridentitäten
+        one: Benutzer:innenidentität
+        other: Benutzer:innenidentitäten
   tasks:
     model:
       copy_of_task: Kopie der Aufgabe
+  users:
+    role:
+      admin: Administrator:in
+      user: Benutzer:in

--- a/config/locales/de/views/account_links.yml
+++ b/config/locales/de/views/account_links.yml
@@ -1,0 +1,24 @@
+---
+de:
+  account_links:
+    edit:
+      header: Bearbeiten des Kontolinks
+    form:
+      button:
+        save: Kontolink speichern
+      info:
+        check_uuid_url: Die Adresse auf der Autograder-Seite, die abgefragt werden kann, um festzustellen, ob die Übung bereits existiert.
+        name: Kann beliebig sein, um Ihren Kontolink zu identifizieren.
+        push_url: Die Adresse auf der Autograder-Seite, zu der Ihre Übung exportiert werden kann. Wenn Sie nicht wissen, was Sie hier schreiben sollen, fragen Sie die Autograder-Administratoren.
+        token: Wird zur Authentifizierung Ihrer Exportanfrage verwendet. Muss auf beiden Seiten identisch sein.
+    new:
+      header: Neuer Kontolink
+    show:
+      description_html: |
+        Account-Links definieren eine Verbindung zu einem Autograder. <br/>
+        Wenn Sie einen Account-Link haben, können Sie einfach Übungen in den Autograder exportieren, die für Sie verfügbar sind. <br/>
+        Sie können Ihren eigenen Account-Link erstellen, wenn Sie die push_url eines Autograders haben, der OAuth2 POST-Anfragen verarbeiten kann.</br>
+        Weitere Informationen zur Herstellung einer Verbindung zu einem Autograder finden Sie unter folgendem Link:</br>
+      shared: geteilt
+      shared_users: Benutzer, mit denen Sie den Zugriff geteilt haben
+      shared_with_users: Mit %{count} anderen Benutzern geteilt.

--- a/config/locales/de/views/account_links.yml
+++ b/config/locales/de/views/account_links.yml
@@ -2,23 +2,24 @@
 de:
   account_links:
     edit:
-      header: Bearbeiten des Kontolinks
+      header: Bearbeiten des Account-Links
     form:
       button:
-        save: Kontolink speichern
+        generate: Generieren
+        save: Account-Link speichern
       info:
-        check_uuid_url: Die Adresse auf der Autograder-Seite, die abgefragt werden kann, um festzustellen, ob die Übung bereits existiert.
-        name: Kann beliebig sein, um Ihren Kontolink zu identifizieren.
-        push_url: Die Adresse auf der Autograder-Seite, zu der Ihre Übung exportiert werden kann. Wenn Sie nicht wissen, was Sie hier schreiben sollen, fragen Sie die Autograder-Administratoren.
+        check_uuid_url: Die Adresse auf der Autograder-Seite, die abgefragt werden kann, um festzustellen, ob die Aufgabe bereits existiert.
+        name: Kann beliebig sein, um Ihren Account-Link zu identifizieren.
+        push_url: Die Adresse auf der Autograder-Seite, zu der Ihre Aufgabe exportiert werden kann. Wenn Sie nicht wissen, was Sie hier schreiben sollen, fragen Sie die Autograder-Administratoren.
         token: Wird zur Authentifizierung Ihrer Exportanfrage verwendet. Muss auf beiden Seiten identisch sein.
     new:
-      header: Neuer Kontolink
+      header: Neuer Account-Link
     show:
       description_html: |
         Account-Links definieren eine Verbindung zu einem Autograder. <br/>
-        Wenn Sie einen Account-Link haben, können Sie einfach Übungen in den Autograder exportieren, die für Sie verfügbar sind. <br/>
+        Wenn Sie einen Account-Link haben, können Sie einfach Aufgaben zu den Autogradern exportieren, die für Sie verfügbar sind. <br/>
         Sie können Ihren eigenen Account-Link erstellen, wenn Sie die push_url eines Autograders haben, der OAuth2 POST-Anfragen verarbeiten kann.</br>
-        Weitere Informationen zur Herstellung einer Verbindung zu einem Autograder finden Sie unter folgendem Link:</br>
+        Weitere Informationen zur Herstellung einer Verbindung mit einem Autograder finden Sie unter folgendem Link:</br>
       shared: geteilt
-      shared_users: Benutzer, mit denen Sie den Zugriff geteilt haben
-      shared_with_users: Mit %{count} anderen Benutzern geteilt.
+      shared_users: Benutzer:innen, mit denen Sie den Zugriff geteilt haben
+      shared_with_users: Mit %{count} anderen Benutzer:innen geteilt.

--- a/config/locales/de/views/application.yml
+++ b/config/locales/de/views/application.yml
@@ -1,0 +1,19 @@
+---
+de:
+  application:
+    footer:
+      about:
+        header: Über CodeHarbor
+        paragraph: CodeHarbor ermöglicht das Teilen, Bewerten und Diskutieren von automatisch bewertbaren Programmieraufgaben mit Kollegen. Wiederverwenden Sie vorhandene Aufgaben, klonen Sie Aufgaben und passen Sie sie an Ihre Bedürfnisse an. Übersetzen Sie sie in eine andere menschliche Sprache oder portieren Sie sie in eine andere Programmiersprache. Behalten Sie immer die volle Kontrolle darüber, mit wem Sie teilen.
+      hasso_plattner_institute: Hasso-Plattner-Institut
+      imprint: Impressum
+      more:
+        header: Weitere Informationen
+        link: Über CodeHarbor
+      privacy_policy: Datenschutzerklärung
+    navigation:
+      rails_admin: Rails-Administrator
+    session:
+      button:
+        log_out: Abmelden
+      profile: Profil

--- a/config/locales/de/views/application.yml
+++ b/config/locales/de/views/application.yml
@@ -4,7 +4,7 @@ de:
     footer:
       about:
         header: Über CodeHarbor
-        paragraph: CodeHarbor ermöglicht das Teilen, Bewerten und Diskutieren von automatisch bewertbaren Programmieraufgaben mit Kollegen. Wiederverwenden Sie vorhandene Aufgaben, klonen Sie Aufgaben und passen Sie sie an Ihre Bedürfnisse an. Übersetzen Sie sie in eine andere menschliche Sprache oder portieren Sie sie in eine andere Programmiersprache. Behalten Sie immer die volle Kontrolle darüber, mit wem Sie teilen.
+        paragraph: CodeHarbor ermöglicht das Teilen, Bewerten und Diskutieren von automatisch-bewertbaren Programmieraufgaben mit Kollegen und Kolleginnen. Verwenden Sie vorhandene Aufgaben wieder, klonen Sie Aufgaben und passen Sie sie an Ihre Bedürfnisse an. Übersetzen Sie sie in eine andere Sprache oder portieren Sie sie in eine andere Programmiersprache. Behalten Sie immer die volle Kontrolle darüber, mit wem Sie Aufgaben teilen.
       hasso_plattner_institute: Hasso-Plattner-Institut
       imprint: Impressum
       more:
@@ -12,7 +12,7 @@ de:
         link: Über CodeHarbor
       privacy_policy: Datenschutzerklärung
     navigation:
-      rails_admin: Rails-Administrator
+      rails_admin: Rails Admin
     session:
       button:
         log_out: Abmelden

--- a/config/locales/de/views/breadcrumbs.yml
+++ b/config/locales/de/views/breadcrumbs.yml
@@ -1,0 +1,36 @@
+---
+de:
+  breadcrumbs:
+    confirmations:
+      create: Konto bestätigen
+      new: Konto bestätigen
+      show: Konto bestätigen
+    home:
+      about: Über
+      account_link_documentation: Über Kontoverknüpfungen
+      index: Titelseite
+    passwords:
+      create: Passwort vergessen
+      edit: Passwort ändern
+      new: Passwort vergessen
+      update: Passwort ändern
+    registrations:
+      create: Registrieren
+      edit: Profil aktualisieren
+      new: Registrieren
+      update: Profil aktualisieren
+    sessions:
+      create: Anmelden
+      new: Anmelden
+    unlocks:
+      create: Konto entsperren
+      new: Konto entsperren
+      show: Konto entsperren
+  shared:
+    create: Erstellen
+    delete: Löschen
+    edit: Bearbeiten
+    index: Index
+    new: Neu
+    show: Anzeigen
+    update: Aktualisieren

--- a/config/locales/de/views/breadcrumbs.yml
+++ b/config/locales/de/views/breadcrumbs.yml
@@ -2,13 +2,13 @@
 de:
   breadcrumbs:
     confirmations:
-      create: Konto bestätigen
-      new: Konto bestätigen
-      show: Konto bestätigen
+      create: Account bestätigen
+      new: Account bestätigen
+      show: Account bestätigen
     home:
       about: Über
-      account_link_documentation: Über Kontoverknüpfungen
-      index: Titelseite
+      account_link_documentation: Über Account-Links
+      index: Startseite
     passwords:
       create: Passwort vergessen
       edit: Passwort ändern
@@ -23,9 +23,9 @@ de:
       create: Anmelden
       new: Anmelden
     unlocks:
-      create: Konto entsperren
-      new: Konto entsperren
-      show: Konto entsperren
+      create: Account entsperren
+      new: Account entsperren
+      show: Account entsperren
   shared:
     create: Erstellen
     delete: Löschen

--- a/config/locales/de/views/collections.yml
+++ b/config/locales/de/views/collections.yml
@@ -1,0 +1,34 @@
+---
+de:
+  collections:
+    collections:
+      empty_state:
+        heading: Sie haben noch keine Aufgabensammlungen
+        hint: Sie können Aufgabensammlungen erstellen und Aufgaben hinzufügen.
+    form:
+      button:
+        remove_all: Alle entfernen
+        save: Aufgabensammlung speichern
+    index:
+      new_collection: Neue Aufgabensammlung
+      view_shared: Geteilte Aufgabensammlung anzeigen
+    new:
+      header: Neue Aufgabensammlung
+    shared:
+      no_description: Keine Beschreibung
+      no_tasks_added: Keine Aufgaben hinzugefügt
+    show:
+      button:
+        collaborate: Zusammenarbeiten
+        leave: Verlassen
+        share: Aufgabensammlung teilen
+      define_account_link: Bitte erstellen Sie zuerst einen Account-Link
+      download_no_exercises: Download nicht möglich ohne Aufgaben
+      export_to: Exportieren nach
+      leave:
+        deletion_warning: Sie sind der/die letzte Benutzer:in in dieser Aufgabensammlung. Wenn Sie gehen, wird diese Aufgabensammlung dauerhaft gelöscht! Sind Sie sicher?
+      locked_exercise_hint: 'Hinweis: Für Aufgaben mit einem Schloss-Symbol müssen Sie zuerst Zugriff beantragen, um sie anzeigen zu können.'
+      noExercisesAdded: Keine Aufgabe hinzugefügt
+      shared_by: Geteilt von
+      temporarily_disabled: Vorübergehend deaktiviert
+      type_hint: Geben Sie die E-Mail-Adresse des/der Benutzer:in ein

--- a/config/locales/de/views/comments.yml
+++ b/config/locales/de/views/comments.yml
@@ -1,0 +1,9 @@
+---
+de:
+  comments:
+    task_comments:
+      button:
+        refresh_comments: Kommentare aktualisieren
+      info:
+        no_comments: Diese Aufgabe hat noch keine Kommentare
+      time_ago: Vor %{time}

--- a/config/locales/de/views/groups.yml
+++ b/config/locales/de/views/groups.yml
@@ -5,29 +5,39 @@ de:
       button:
         save: Gruppe speichern
     groups:
-      admin_label: Admin
+      admin_label: Administrator:in
+      create_groups_tip: Sie können Gruppen erstellen, um mit anderen zusammenzuarbeiten und Zugriffsrechte für Aufgaben zu verwalten.
       member_label: Mitglied
+      no_groups_yet: Sie haben noch keine Gruppen
       pending_label: Ausstehend
+      wait_to_get_accepted: Warten Sie darauf, angenommen zu werden
+    index:
+      button:
+        all_groups: Alle Gruppen
+        my_groups: Meine Gruppen
+        new_group: Neue Gruppe
     new:
       header: Neue Gruppe
     share_account_link_button:
-      share_tooltip: Teilen Sie den Kontolink für %{account_link} mit %{user}
-      unshare_tooltip: Teilen des Kontolinks für %{account_link} mit %{user} beenden
+      share_tooltip: Teilen Sie den Account-Link für %{account_link} mit %{user}
+      unshare_tooltip: Teilen des Account-Links für %{account_link} mit %{user} beenden
+    shared:
+      button:
+        request_membership: Mitgliedschaft beantragen
     show:
       button:
         delete_group: Gruppe löschen
-        demote_admin: Admin degradieren
-        demote_yourself: Dich selbst degradieren
+        demote_admin: Administrator:in degradieren
+        demote_yourself: Selbst degradieren
         deny_access: Zugriff verweigern
         grant_access: Zugriff gewähren
         leave: Gruppe verlassen
-        make_admin: Admin machen
-        request_membership: Mitgliedschaft beantragen
+        make_admin: Zum/Zur Administrator:in befördern
       demote_admin:
-        confirm: Bist du sicher, dass du den Admin degradieren möchtest?
+        confirm: Sind Sie sicher, dass Sie den/die Administrator:in degradieren möchten?
       demote_yourself:
-        confirm: Bist du sicher, dass du dich selbst degradieren möchtest?
+        confirm: Sind Sie sicher, dass Sie sich selbst degradieren möchten?
       has_no_tasks: Die Gruppe hat noch keine Aufgaben
-      has_no_users: Die Gruppe hat keine Benutzer
-      no_pending_users: Die Gruppe hat keine ausstehenden Benutzer
-      pending_users: Ausstehende Benutzer
+      has_no_users: Die Gruppe hat keine Benutzer:innen
+      no_pending_users: Die Gruppe hat keine ausstehenden Benutzer:innen
+      pending_users: Ausstehende Benutzer:innen

--- a/config/locales/de/views/groups.yml
+++ b/config/locales/de/views/groups.yml
@@ -1,0 +1,33 @@
+---
+de:
+  groups:
+    form:
+      button:
+        save: Gruppe speichern
+    groups:
+      admin_label: Admin
+      member_label: Mitglied
+      pending_label: Ausstehend
+    new:
+      header: Neue Gruppe
+    share_account_link_button:
+      share_tooltip: Teilen Sie den Kontolink für %{account_link} mit %{user}
+      unshare_tooltip: Teilen des Kontolinks für %{account_link} mit %{user} beenden
+    show:
+      button:
+        delete_group: Gruppe löschen
+        demote_admin: Admin degradieren
+        demote_yourself: Dich selbst degradieren
+        deny_access: Zugriff verweigern
+        grant_access: Zugriff gewähren
+        leave: Gruppe verlassen
+        make_admin: Admin machen
+        request_membership: Mitgliedschaft beantragen
+      demote_admin:
+        confirm: Bist du sicher, dass du den Admin degradieren möchtest?
+      demote_yourself:
+        confirm: Bist du sicher, dass du dich selbst degradieren möchtest?
+      has_no_tasks: Die Gruppe hat noch keine Aufgaben
+      has_no_users: Die Gruppe hat keine Benutzer
+      no_pending_users: Die Gruppe hat keine ausstehenden Benutzer
+      pending_users: Ausstehende Benutzer

--- a/config/locales/de/views/groups.yml
+++ b/config/locales/de/views/groups.yml
@@ -1,6 +1,13 @@
 ---
 de:
   groups:
+    access_request_mailer:
+      confirm_request: Anfrage annehmen
+      greeting: Hallo %{user}
+      message_line1: '%{user} möchte Ihrer Gruppe "%{group}" beitreten.'
+      message_line2: Sie können sie/ihn beitreten lassen, indem Sie auf den Link unten klicken.
+      message_line3: Ansonsten können Sie diese E-Mail ignorieren.
+      subject: '%{user} möchte Ihrer Grupper "%{group}" beitreten'
     form:
       button:
         save: Gruppe speichern

--- a/config/locales/de/views/home.yml
+++ b/config/locales/de/views/home.yml
@@ -7,29 +7,29 @@ de:
     account_link_documentation:
       header: Über Autograder und Account-Links
       paragraph_html: |
-        <h3>Über Kontolinks:</h3>
+        <h3>Über Account-Links:</h3>
         <p>
-          Kontolinks definieren eine Verbindung zu einem Autograder. <br/>
-          Wenn Sie einen Kontolink haben, können Sie einfach Übungen in den Autograder exportieren, die für Sie verfügbar sind. <br/>
-          Sie können Ihren eigenen Kontolink erstellen, wenn Sie die push_url eines Autograders haben, der OAuth2-POST-Anfragen verarbeiten kann.</br>
+          Account-Links definieren eine Verbindung zu einem Autograder. <br/>
+          Wenn Sie einen Account-Link haben, können Sie einfach Aufgaben zu den Autogradern exportieren, die für Sie verfügbar sind. <br/>
+          Sie können Ihren eigenen Account-Link erstellen, wenn Sie die push_url eines Autograders haben, der OAuth2-POST-Anfragen verarbeiten kann.</br>
         </p>
         <h3>Sie möchten einen Autograder verbinden, der bereits OAuth2- und ProFormA-XML-Unterstützung hat:</h3>
         <p>
-          Wenn der Autograder Übungen, die über OAuth2-Anfragen im ProFormA-XML-Format gesendet werden, importieren kann, benötigen Sie folgende Dinge: <br/>
-          1. Push-URL: Der Autograder benötigt einen URL-Code, an den CodeHarbor die Übung senden kann. <br/>
-          2. OAuth2-Token: Der Autograder muss in der Lage sein, einen Token mit Ihrem Konto zu verknüpfen, um Übungen zu autorisieren, die dort geschoben werden. <br/>
-             Wenn Sie keinen spezifischen Token benötigen, können Sie einen Token generieren, wenn Sie einen Kontolink auf der CodeHarbor-Seite erstellen, oder einen beliebigen Token verwenden, <br/>
-             solange es derselbe Token auf der CodeHarbor- und der Autograder-Seite ist.<br>
-          Sie müssen auch eine Client-ID und ein Client-Secret für einen Kontolink auf der CodeHarbor-Seite erstellen. <br/>
+          Wenn der Autograder Aufgaben, die über OAuth2-Anfragen im ProFormA-XML-Format gesendet werden, importieren kann, benötigen Sie folgende Konfigurationsparameter: <br/>
+          1. Push-URL: Der Autograder benötigt eine URL, an die CodeHarbor die Aufgabe senden kann. <br/>
+          2. OAuth2-Token: Der Autograder muss in der Lage sein, ein Token mit Ihrem Account zu verknüpfen, um Aufgaben zu autorisieren, die zum Autograder gesendet werden. <br/>
+             Wenn Sie kein spezifisches Token benötigen, können Sie ein Token generieren, wenn Sie einen Account-Link auf der CodeHarbor-Seite erstellen, oder ein beliebiges Token verwenden, <br/>
+             solange es sich um dasselbe Token auf der CodeHarbor- und der Autograder-Seite handelt.<br>
+          Sie müssen auch eine Client-ID und ein Client-Secret für einen Account-Link auf der CodeHarbor-Seite erstellen. <br/>
           Wenn der Autograder keine spezifische Anforderung hat, können Sie sie automatisch generieren lassen.<br/>
         </p>
         <h3>Wie Sie Ihren eigenen Autograder vorbereiten können:</h3>
         <p>
-          CodeHarbor verwendet das OAuth 2.0-Protokoll, um Übungen über eine POST-Anfrage zu senden. <a href="https://oauth.net/2/">https://oauth.net/2/</a><br/>
+          CodeHarbor verwendet das OAuth 2.0-Protokoll, um Aufgaben über eine POST-Anfrage zu senden. <a href="https://oauth.net/2/">https://oauth.net/2/</a><br/>
           CodeHarbor ist in diesem Fall der Client, Ihr Autograder der Ressourcenserver und Sie sind der Ressourcenbesitzer.
-          Wenn Sie eine Übung exportieren, generiert CodeHarbor zunächst eine XML-Datei, die dem ProFormA-XML-Standard für den Austausch von Übungen entspricht. <a href="https://github.com/ProFormA/taskxml">https://github.com/ProFormA/taskxml</a>
+          Wenn Sie eine Aufgabe exportieren, generiert CodeHarbor zunächst eine XML-Datei, die dem ProFormA-XML-Standard für den Austausch von Aufgaben entspricht. <a href="https://github.com/ProFormA/taskxml">https://github.com/ProFormA/taskxml</a>
           Anschließend wird eine POST-Anfrage an die von Ihnen gewählte push_url gesendet. Die XML-Datei befindet sich im Anfragekörper und der OAuth2-Token in den Anforderungsheadern ("request.headers['Authorization']"). <br/>
-          In Ihrem Autograder müssen Sie sicherstellen, dass der OAuth2-Token validiert wird und der entsprechende Benutzer gefunden wird. Wir empfehlen, eine Schnittstelle hinzuzufügen, damit Benutzer einen OAuth2-Token hinzufügen können. <br/>
+          In Ihrem Autograder müssen Sie sicherstellen, dass der OAuth2-Token validiert wird und der entsprechende Benutzer gefunden wird. Wir empfehlen, eine Schnittstelle hinzuzufügen, damit Benutzer:innen ein OAuth2-Token hinzufügen können. <br/>
           Die XML-Datei im Anfragekörper muss in die Datenbank geparst werden. Da wir das ProFormA-XML-Format verwenden, können Sie das XML mit XPath parsen. <br/>
           Schließlich antworten Sie bitte mit einem Statuscode 200, wenn alles in Ordnung war, oder mit einem Statuscode 400, wenn dies nicht der Fall war. <br/>
         </p>
@@ -37,19 +37,19 @@ de:
       feature:
         collections:
           alt_text: Bild eines geöffneten Dokumentenordners auf einem Laptop
-          header: Übungs-Sammlungen erstellen
-          paragraph: Erstellen Sie Sammlungen Ihrer Lieblingsübungen für zukünftigen Bedarf. Teilen Sie Sammlungen mit Kollegen und Peers. Exportieren Sie sie an Ihren bevorzugten Autograder oder laden Sie sie als XML herunter.
+          header: Erstellen Sie Aufgabensammlungen
+          paragraph: Legen Sie Sammlungen Ihrer Lieblingsaufgaben an, um sie später wiederzuverwenden. Teilen Sie Sammlungen mit Kolleginnen und Kollegen, exportieren Sie sie zu Ihrem bevorzugten Autograder oder laden Sie sie als XML herunter.
         exercises:
           alt_text: Bild eines Computers mit einer Lupe, der nach einem Text sucht
-          header: Suchen, diskutieren und erstellen Sie Übungen
-          paragraph: Mit CodeHarbor können Sie auto-bewertbare Programmierübungen mit Kollegen und Peers teilen, bewerten und diskutieren. Verwenden Sie vorhandene Übungen erneut, klonen Sie Übungen und passen Sie sie an Ihre Bedürfnisse an. Übersetzen Sie Übungen in andere menschliche Sprachen oder portieren Sie sie in andere Programmiersprachen. Sie behalten immer die volle Kontrolle darüber, mit wem Sie teilen.
+          header: Suchen, diskutieren und erstellen Sie Aufgaben
+          paragraph: Mit CodeHarbor können Sie automatisch-bewertbare Programmieraufgaben mit Kolleginnen und Kollegen teilen, bewerten und diskutieren. Verwenden Sie vorhandene Aufgaben erneut, klonen Sie Aufgaben und passen Sie sie an Ihre Bedürfnisse an. Übersetzen Sie Aufgaben in andere Sprachen oder portieren Sie sie in andere Programmiersprachen. Sie behalten immer die volle Kontrolle darüber, mit wem Sie Aufgaben teilen.
         groups:
-          alt_text: Bild von verbundenen Benutzern, die verschiedene Geräte verwenden
-          header: Benutzergruppen erstellen und Übungen mit Ihrer Gruppe teilen.
-          paragraph: Wenn Sie sich entscheiden, Ihre Übungen nicht mit allen zu teilen, geben Sie sie als privat an und ermöglichen Sie nur ausgewählten Gruppen oder Benutzern den Zugriff.
+          alt_text: Bild von verbundenen Benutzer:innen, die verschiedene Geräte verwenden
+          header: Bilden Sie Gruppen von Benutzer:innen und teilen Sie Aufgaben mit Ihrer Gruppe
+          paragraph: Wenn Sie sich entscheiden, Ihre Aufgaben nicht öffentlich zu teilen, kennzeichnen Sie sie als privat an und ermöglichen Sie nur ausgewählten Gruppen oder Benutzer:innen den Zugriff.
         header: Funktionen
       hero:
-        alt_text: CodeHarbor-Held mit einem Computer auf einem Schreibtisch und einem Segelboot daneben
+        alt_text: CodeHarbor-Symbolbild mit einem Computer auf einem Schreibtisch und einem Segelboot daneben
         subtitle: Kollaboratives Autograder-Repository
         title1: Code
         title2: Harbor
@@ -57,11 +57,11 @@ de:
         mooc:
           alt_text: Bild repräsentiert MOOCs in der Cloud
           header_html: "CodeHarbor für \n MOOCs"
-          paragraph: Entwickeln und ausführen Sie MOOCs, die auto-bewertbare Programmierübungen enthalten?
+          paragraph: Entwickeln und veröffentlichen Sie MOOCs, die automatisch-bewertbare Programmieraufgaben enthalten?
         schools:
           alt_text: Bild eines Schulgebäudes
           header_html: "CodeHarbor für \n Schulen"
-          paragraph: Unterrichten Sie Programmierung in der Schule und benötigen Sie auto-bewertbare Programmierübungen?
+          paragraph: Unterrichten Sie Informatik in der Schule und benötigen Sie automatisch-bewertbare Programmieraufgaben?
         title: Anwendungsfälle
         universities:
           alt_text: Bild eines Universitätsgebäudes

--- a/config/locales/de/views/home.yml
+++ b/config/locales/de/views/home.yml
@@ -1,6 +1,77 @@
 ---
 de:
   home:
+    about:
+      header: Über CodeHarbor
+      paragraph: ''
+    account_link_documentation:
+      header: Über Autograder und Account-Links
+      paragraph_html: |
+        <h3>Über Kontolinks:</h3>
+        <p>
+          Kontolinks definieren eine Verbindung zu einem Autograder. <br/>
+          Wenn Sie einen Kontolink haben, können Sie einfach Übungen in den Autograder exportieren, die für Sie verfügbar sind. <br/>
+          Sie können Ihren eigenen Kontolink erstellen, wenn Sie die push_url eines Autograders haben, der OAuth2-POST-Anfragen verarbeiten kann.</br>
+        </p>
+        <h3>Sie möchten einen Autograder verbinden, der bereits OAuth2- und ProFormA-XML-Unterstützung hat:</h3>
+        <p>
+          Wenn der Autograder Übungen, die über OAuth2-Anfragen im ProFormA-XML-Format gesendet werden, importieren kann, benötigen Sie folgende Dinge: <br/>
+          1. Push-URL: Der Autograder benötigt einen URL-Code, an den CodeHarbor die Übung senden kann. <br/>
+          2. OAuth2-Token: Der Autograder muss in der Lage sein, einen Token mit Ihrem Konto zu verknüpfen, um Übungen zu autorisieren, die dort geschoben werden. <br/>
+             Wenn Sie keinen spezifischen Token benötigen, können Sie einen Token generieren, wenn Sie einen Kontolink auf der CodeHarbor-Seite erstellen, oder einen beliebigen Token verwenden, <br/>
+             solange es derselbe Token auf der CodeHarbor- und der Autograder-Seite ist.<br>
+          Sie müssen auch eine Client-ID und ein Client-Secret für einen Kontolink auf der CodeHarbor-Seite erstellen. <br/>
+          Wenn der Autograder keine spezifische Anforderung hat, können Sie sie automatisch generieren lassen.<br/>
+        </p>
+        <h3>Wie Sie Ihren eigenen Autograder vorbereiten können:</h3>
+        <p>
+          CodeHarbor verwendet das OAuth 2.0-Protokoll, um Übungen über eine POST-Anfrage zu senden. <a href="https://oauth.net/2/">https://oauth.net/2/</a><br/>
+          CodeHarbor ist in diesem Fall der Client, Ihr Autograder der Ressourcenserver und Sie sind der Ressourcenbesitzer.
+          Wenn Sie eine Übung exportieren, generiert CodeHarbor zunächst eine XML-Datei, die dem ProFormA-XML-Standard für den Austausch von Übungen entspricht. <a href="https://github.com/ProFormA/taskxml">https://github.com/ProFormA/taskxml</a>
+          Anschließend wird eine POST-Anfrage an die von Ihnen gewählte push_url gesendet. Die XML-Datei befindet sich im Anfragekörper und der OAuth2-Token in den Anforderungsheadern ("request.headers['Authorization']"). <br/>
+          In Ihrem Autograder müssen Sie sicherstellen, dass der OAuth2-Token validiert wird und der entsprechende Benutzer gefunden wird. Wir empfehlen, eine Schnittstelle hinzuzufügen, damit Benutzer einen OAuth2-Token hinzufügen können. <br/>
+          Die XML-Datei im Anfragekörper muss in die Datenbank geparst werden. Da wir das ProFormA-XML-Format verwenden, können Sie das XML mit XPath parsen. <br/>
+          Schließlich antworten Sie bitte mit einem Statuscode 200, wenn alles in Ordnung war, oder mit einem Statuscode 400, wenn dies nicht der Fall war. <br/>
+        </p>
+    index:
+      feature:
+        collections:
+          alt_text: Bild eines geöffneten Dokumentenordners auf einem Laptop
+          header: Übungs-Sammlungen erstellen
+          paragraph: Erstellen Sie Sammlungen Ihrer Lieblingsübungen für zukünftigen Bedarf. Teilen Sie Sammlungen mit Kollegen und Peers. Exportieren Sie sie an Ihren bevorzugten Autograder oder laden Sie sie als XML herunter.
+        exercises:
+          alt_text: Bild eines Computers mit einer Lupe, der nach einem Text sucht
+          header: Suchen, diskutieren und erstellen Sie Übungen
+          paragraph: Mit CodeHarbor können Sie auto-bewertbare Programmierübungen mit Kollegen und Peers teilen, bewerten und diskutieren. Verwenden Sie vorhandene Übungen erneut, klonen Sie Übungen und passen Sie sie an Ihre Bedürfnisse an. Übersetzen Sie Übungen in andere menschliche Sprachen oder portieren Sie sie in andere Programmiersprachen. Sie behalten immer die volle Kontrolle darüber, mit wem Sie teilen.
+        groups:
+          alt_text: Bild von verbundenen Benutzern, die verschiedene Geräte verwenden
+          header: Benutzergruppen erstellen und Übungen mit Ihrer Gruppe teilen.
+          paragraph: Wenn Sie sich entscheiden, Ihre Übungen nicht mit allen zu teilen, geben Sie sie als privat an und ermöglichen Sie nur ausgewählten Gruppen oder Benutzern den Zugriff.
+        header: Funktionen
+      hero:
+        alt_text: CodeHarbor-Held mit einem Computer auf einem Schreibtisch und einem Segelboot daneben
+        subtitle: Kollaboratives Autograder-Repository
+        title1: Code
+        title2: Harbor
+      marketing:
+        mooc:
+          alt_text: Bild repräsentiert MOOCs in der Cloud
+          header_html: "CodeHarbor für \n MOOCs"
+          paragraph: Entwickeln und ausführen Sie MOOCs, die auto-bewertbare Programmierübungen enthalten?
+        schools:
+          alt_text: Bild eines Schulgebäudes
+          header_html: "CodeHarbor für \n Schulen"
+          paragraph: Unterrichten Sie Programmierung in der Schule und benötigen Sie auto-bewertbare Programmierübungen?
+        title: Anwendungsfälle
+        universities:
+          alt_text: Bild eines Universitätsgebäudes
+          header_html: "CodeHarbor für \n Universitäten"
+          paragraph: Unterrichten Sie große Programmierkurse an der Universität und verwenden Sie Autograder zur Bewertung?
+      sign_in:
+        header: Mitglied werden
+        link1: Registrieren
+        link2: Anmelden
+        paragraph_html: Wenn Sie unserer Community beitreten möchten, klicken Sie jetzt auf %{href1} oder auf %{href2}, wenn Sie bereits Mitglied sind.
     partners:
       bmbf:
         alt_text: Gefördert vom Bundesministerium für Bildung und Forschung

--- a/config/locales/de/views/labels.yml
+++ b/config/locales/de/views/labels.yml
@@ -1,0 +1,15 @@
+---
+de:
+  labels:
+    index:
+      change_color_to: Farbe ändern in
+      merge: Zusammenführen und umbenennen in
+    javascripts:
+      can_only_create_5: Sie können nur 5 Labels hinzufügen
+      cannot_be_empty: Der eingegebene Label-Name ist leer
+      change_color_confirmation: Dies wird die Farbe der ausgewählten %{selected_labels_count} Label(s) ändern.
+      delete_confirmation: Dies wird die ausgewählten %{selected_labels_count} Label(s) löschen.
+      merge_confirmation: Dies wird die ausgewählten %{selected_labels_count} Label(s) zusammenführen und in "%{new_merged_name}" umbenennen
+      new:
+        selection_suffix: " (neu)"
+      too_long: Der eingegebene Label-Name ist zu lang

--- a/config/locales/de/views/labels.yml
+++ b/config/locales/de/views/labels.yml
@@ -3,13 +3,18 @@ de:
   labels:
     index:
       change_color_to: Farbe ändern in
+      filter_by_name: Nach Namen filtern
+      id: ID
       merge: Zusammenführen und umbenennen in
+      new_name: Neuer Name
+      used_by_tasks: Gehört zu Aufgaben
     javascripts:
-      can_only_create_5: Sie können nur 5 Labels hinzufügen
       cannot_be_empty: Der eingegebene Label-Name ist leer
-      change_color_confirmation: Dies wird die Farbe der ausgewählten %{selected_labels_count} Label(s) ändern.
-      delete_confirmation: Dies wird die ausgewählten %{selected_labels_count} Label(s) löschen.
-      merge_confirmation: Dies wird die ausgewählten %{selected_labels_count} Label(s) zusammenführen und in "%{new_merged_name}" umbenennen
+      change_color_confirmation: Die Farbe der ausgewählten %{selected_labels_count} Label(s) wird geändert.
+      delete_confirmation: Die ausgewählten %{selected_labels_count} Label(s) werden gelöscht.
+      max_limit_reached: Sie können nur %{limit} Labels hinzufügen
+      merge_confirmation: Die ausgewählten %{selected_labels_count} Label(s) werden zusammengeführt und in "%{new_merged_name}" umbenannt.
       new:
         selection_suffix: " (neu)"
+      ok: OK
       too_long: Der eingegebene Label-Name ist zu lang

--- a/config/locales/de/views/messages.yml
+++ b/config/locales/de/views/messages.yml
@@ -1,0 +1,23 @@
+---
+de:
+  messages:
+    index:
+      button:
+        deny_access: Zugriff verweigern
+        grant_access: Zugriff gewähren
+        inbox: Posteingang
+        make_co_author: Als Co-Autor festlegen
+        reply: Antworten
+        save_collection: Sammlung speichern
+        view: Ansehen
+      from: Von
+      no_messages: Sie haben keine Nachrichten.
+      reply: Antworten
+      sent: Gesendet
+      to: An
+      unknown: unbekannt
+    reply:
+      message_to: Nachricht senden an
+    shared:
+      new: Neue Nachricht
+      send_message: Nachricht senden

--- a/config/locales/de/views/messages.yml
+++ b/config/locales/de/views/messages.yml
@@ -6,9 +6,9 @@ de:
         deny_access: Zugriff verweigern
         grant_access: Zugriff gewähren
         inbox: Posteingang
-        make_co_author: Als Co-Autor festlegen
+        make_co_author: Als Co-Autor:in festlegen
         reply: Antworten
-        save_collection: Sammlung speichern
+        save_collection: Aufgabensammlung speichern
         view: Ansehen
       from: Von
       no_messages: Sie haben keine Nachrichten.

--- a/config/locales/de/views/tasks.yml
+++ b/config/locales/de/views/tasks.yml
@@ -1,0 +1,106 @@
+---
+de:
+  tasks:
+    editor:
+      button:
+        extract_text: Text extrahieren
+        toggle_file: Datei-Upload/Editor umschalten
+        upload_a_new_file: Eine neue Datei hochladen
+    export_actions:
+      create_new: Neu erstellen
+      overwrite: Überschreiben
+    file_config:
+      configuration: Konfiguration
+    form:
+      button:
+        add_model_solution: Modellösung hinzufügen
+        add_test: Test hinzufügen
+        remove_model_solution: Modellösung entfernen
+        remove_test: Test entfernen
+        save_task: Aufgabe speichern
+      errors:
+        not_public_without_prog_lang: Kann nicht öffentlich sein, solange die Programmiersprache nicht festgelegt ist
+        prog_lang_not_empty_while_public: Darf nicht leer sein, wenn die Sichtbarkeit auf öffentlich eingestellt ist
+      no_license: Keine Lizenz
+      unchangeable_groups: Nicht änderbare Gruppen
+      visibility_warning: Diese Aufgabe befindet sich derzeit in einer Sammlung. Andere Benutzer können Ihre Aufgabe nicht anzeigen oder bearbeiten. Der Titel bleibt jedoch für diese Benutzer sichtbar.
+    import_actions:
+      button:
+        import_copy: Als Kopie importieren
+        overwrite: Überschreiben
+        show_task: Aufgabe anzeigen
+    import_dialog_content:
+      path: 'Pfad: %{path}'
+      task_with_uuid: 'Aufgaben-UUID: %{task_uuid}'
+    index:
+      button:
+        choose_file: Datei auswählen
+        import_tasks: Aufgaben importieren
+        import_zip: ZIP-Datei importieren
+        new_task: Neue Aufgabe
+      menu_button:
+        group: Gruppenaufgaben
+        mine: Meine Aufgaben
+        public: Öffentlich
+      search:
+        advanced: Erweitert
+        all_access_levels: Alle Sichtbarkeiten
+        all_time: Alle Zeiten
+        created: Erstellt
+        has_all_labels: Hat alle Labels
+        label: Suche
+        last_month: Letzter Monat
+        last_week: Letzte Woche
+        min_stars: Mindestanzahl an Sternen
+        order: Sortieren nach
+        placeholder: Nach Aufgabe oder Label suchen
+        reset: Zurücksetzen
+        today: Heute
+    javascripts:
+      all_languages: Alle Sprachen
+      checking_external_app: Überprüfen, ob die Aufgabe in der externen App vorhanden ist.
+      select_groups: Gruppen auswählen
+    nested_file_form:
+      add_file: Datei hinzufügen
+      remove_file: Datei entfernen
+    new:
+      new_task: Neue Aufgabe
+    shared:
+      additional_info: Zusätzliche Informationen
+      basic_information: Grundinformationen
+    show:
+      add_to_collection_hint: Speichern Sie Aufgaben für später, indem Sie sie zu einer Sammlung hinzufügen.
+      button:
+        add_collection: Sammlung hinzufügen
+        add_to_collection: Zur Sammlung hinzufügen
+        download_as_zip: Diese Aufgabe als ZIP-Datei herunterladen.
+        export: Exportieren
+        export_tasks: Aufgaben exportieren
+        rate: Bewerten
+        show_comments: Kommentare anzeigen
+      define_account_link: Bitte definieren Sie zuerst eine Kontoverknüpfung
+      export_to: Exportieren nach
+      guest:
+        disabled:
+          tooltip: Sie müssen eingeloggt sein, um dies zu verwenden.
+      no_files: Keine Dateien enthalten
+      no_license: Keine
+      no_model_solution_present: Keine Model Solutions vorhanden
+      no_tests: Keine Tests enthalten
+      undefined: Benutzer undefiniert
+      yourself: sich selbst
+    tasks:
+      button:
+        new_comment: Neuer Kommentar
+        related_exercises: Verwandte Übungen anzeigen
+        show_comments: Kommentare anzeigen
+      no_description: Keine Beschreibung
+      no_programming_language_selected: Keine Programmiersprache ausgewählt
+      search:
+        no_results: Keine Ergebnisse
+        no_results_description: Versuchen Sie verschiedene Optionen aus, indem Sie auf 'Erweitert' klicken.
+        no_tasks: Sie haben noch keine Aufgaben
+    visibility:
+      label: Sichtbarkeit
+      private: Privat
+      public: Öffentlich

--- a/config/locales/de/views/tasks.yml
+++ b/config/locales/de/views/tasks.yml
@@ -4,26 +4,29 @@ de:
     editor:
       button:
         extract_text: Text extrahieren
-        toggle_file: Datei-Upload/Editor umschalten
+        toggle_file: Datei-Upload / Editor umschalten
         upload_a_new_file: Eine neue Datei hochladen
     export_actions:
       create_new: Neu erstellen
       overwrite: Überschreiben
     file_config:
       configuration: Konfiguration
+      delayed: Verzögert
+      display: Anzeigen
+      download: Herunterladen
     form:
       button:
-        add_model_solution: Modellösung hinzufügen
+        add_model_solution: Musterlösung hinzufügen
         add_test: Test hinzufügen
-        remove_model_solution: Modellösung entfernen
+        remove_model_solution: Musterlösung entfernen
         remove_test: Test entfernen
         save_task: Aufgabe speichern
       errors:
-        not_public_without_prog_lang: Kann nicht öffentlich sein, solange die Programmiersprache nicht festgelegt ist
-        prog_lang_not_empty_while_public: Darf nicht leer sein, wenn die Sichtbarkeit auf öffentlich eingestellt ist
+        not_public_without_prog_lang: kann nicht öffentlich sein, solange die Programmiersprache nicht festgelegt ist
+        prog_lang_not_empty_while_public: darf nicht leer sein, wenn die Sichtbarkeit auf öffentlich eingestellt ist
       no_license: Keine Lizenz
       unchangeable_groups: Nicht änderbare Gruppen
-      visibility_warning: Diese Aufgabe befindet sich derzeit in einer Sammlung. Andere Benutzer können Ihre Aufgabe nicht anzeigen oder bearbeiten. Der Titel bleibt jedoch für diese Benutzer sichtbar.
+      visibility_warning: Diese Aufgabe befindet sich derzeit in einer Sammlung. Andere Benutzer:innen können Ihre Aufgabe nicht anzeigen oder bearbeiten. Der Titel bleibt jedoch für diese Benutzer:innen sichtbar.
     import_actions:
       button:
         import_copy: Als Kopie importieren
@@ -39,15 +42,16 @@ de:
         import_zip: ZIP-Datei importieren
         new_task: Neue Aufgabe
       menu_button:
-        group: Gruppenaufgaben
+        group: Aufgaben aus Gruppen
         mine: Meine Aufgaben
         public: Öffentlich
       search:
         advanced: Erweitert
-        all_access_levels: Alle Sichtbarkeiten
-        all_time: Alle Zeiten
-        created: Erstellt
-        has_all_labels: Hat alle Labels
+        all_access_levels: egal
+        all_time: egal
+        average_rating: Bewertung
+        creation_date: Erstellungsdatum
+        has_all_labels: Hat Labels
         label: Suche
         last_month: Letzter Monat
         last_week: Letzte Woche
@@ -57,8 +61,8 @@ de:
         reset: Zurücksetzen
         today: Heute
     javascripts:
-      all_languages: Alle Sprachen
-      checking_external_app: Überprüfen, ob die Aufgabe in der externen App vorhanden ist.
+      all_languages: egal
+      checking_external_app: Überprüfen, ob die Aufgabe im Autograder vorhanden ist.
       select_groups: Gruppen auswählen
     nested_file_form:
       add_file: Datei hinzufügen
@@ -67,38 +71,38 @@ de:
       new_task: Neue Aufgabe
     shared:
       additional_info: Zusätzliche Informationen
-      basic_information: Grundinformationen
+      basic_information: Basisinformationen
+      new_comment: Neuer Kommentar
     show:
       add_to_collection_hint: Speichern Sie Aufgaben für später, indem Sie sie zu einer Sammlung hinzufügen.
       button:
-        add_collection: Sammlung hinzufügen
-        add_to_collection: Zur Sammlung hinzufügen
+        add_collection: Aufgabensammlung hinzufügen
+        add_to_collection: Zu Sammlung hinzufügen
         download_as_zip: Diese Aufgabe als ZIP-Datei herunterladen.
         export: Exportieren
         export_tasks: Aufgaben exportieren
         rate: Bewerten
         show_comments: Kommentare anzeigen
-      define_account_link: Bitte definieren Sie zuerst eine Kontoverknüpfung
+      define_account_link: Bitte definieren Sie zuerst einen Account-Link
       export_to: Exportieren nach
       guest:
         disabled:
-          tooltip: Sie müssen eingeloggt sein, um dies zu verwenden.
+          tooltip: Sie müssen eingeloggt sein, um diese Funktion zu verwenden.
       no_files: Keine Dateien enthalten
       no_license: Keine
-      no_model_solution_present: Keine Model Solutions vorhanden
+      no_model_solution_present: Keine Musterlösungen vorhanden
       no_tests: Keine Tests enthalten
-      undefined: Benutzer undefiniert
-      yourself: sich selbst
+      undefined: Benutzer:in undefiniert
+      yourself: Ihnen selbst
     tasks:
       button:
-        new_comment: Neuer Kommentar
-        related_exercises: Verwandte Übungen anzeigen
+        related_exercises: Verwandte Aufgaben anzeigen
         show_comments: Kommentare anzeigen
       no_description: Keine Beschreibung
       no_programming_language_selected: Keine Programmiersprache ausgewählt
       search:
         no_results: Keine Ergebnisse
-        no_results_description: Versuchen Sie verschiedene Optionen aus, indem Sie auf 'Erweitert' klicken.
+        no_results_description: Probieren Sie verschiedene Optionen aus, indem Sie auf 'Erweitert' klicken und die Suche wiederholen.
         no_tasks: Sie haben noch keine Aufgaben
     visibility:
       label: Sichtbarkeit

--- a/config/locales/de/views/tasks.yml
+++ b/config/locales/de/views/tasks.yml
@@ -1,6 +1,12 @@
 ---
 de:
   tasks:
+    access_request_mailer:
+      greeting: Hallo %{user}
+      message_line1: '%{user} möchte an Ihrer Aufgabe "%{task}" mitarbeiten.'
+      message_line2: Wenn Sie den/die Benutzer:in zum/zur Co-Autor:in ernennen oder in eine Gruppe einladen möchten, klicken Sie auf den Link unten.
+      message_line3: Ansonsten können Sie diese E-Mail ignorieren.
+      subject: '%{user} möchte an Ihrer Aufgabe "%{task}" mitarbeiten.'
     editor:
       button:
         extract_text: Text extrahieren

--- a/config/locales/de/views/users.yml
+++ b/config/locales/de/views/users.yml
@@ -1,0 +1,71 @@
+---
+de:
+  users:
+    confirmations:
+      new:
+        resend_confirmation: Bestätigungsinstruktionen erneut senden
+        validation_error: 'Aufgrund von Fehlern konnten die Instruktionen nicht gesendet werden:'
+    passwords:
+      edit:
+        change_my_pwd: Passwort ändern
+        change_pwd: Passwort ändern
+      new:
+        forgot_pwd: Passwort vergessen?
+        send_reset_pwd: Senden Sie mir Reset-Passwort-Instruktionen
+        validation_error: 'Aufgrund von Fehlern konnte die E-Mail nicht gesendet werden:'
+    registrations:
+      avatar_form:
+        remove_avatar: Avatar entfernen
+      edit:
+        confirm_w_pwd: Wir benötigen Ihr aktuelles Passwort, um Ihre Änderungen zu bestätigen.
+        header: Benutzer bearbeiten
+        leave_blank: Lassen Sie es leer, wenn Sie es nicht ändern möchten.
+        password_current: Aktuelles Passwort
+        update_user: Aktualisieren
+        waiting_confirmation: 'Aktuell in Wartestellung für Bestätigung: %{email}'
+      new:
+        header: Registrieren
+        password: Passwort
+    sessions:
+      new:
+        email:
+          label: E-Mail
+          placeholder: E-Mail
+        header: Einloggen
+        password:
+          label: Passwort
+          placeholder: Passwort
+    shared:
+      links:
+        forgot_pwd: Passwort vergessen?
+        no_confirmation: Keine Bestätigungsinstruktionen erhalten?
+        no_unlock: Keine Entsperrungsinstruktionen erhalten?
+        sign_in_with: Mit %{provider} anmelden
+      minimum_password_length: Mindestens %{count} Zeichen
+      notification_modal:
+        delete_modal:
+          content:
+            groups_1: Gruppen, in denen Sie der einzige Benutzer sind, werden gelöscht
+            groups_2: 'Gruppen, in denen Sie der Administrator und andere Benutzer sind: Ein anderer Benutzer wird zufällig zum Administrator erklärt'
+            groups_3: 'Gruppen mit anderen Administratoren: keine Änderungen'
+            groups_header: 'Gruppen:'
+            intro: 'Die Löschung Ihres Kontos hat folgende Auswirkungen:'
+            tasks_content: Ihre Aufgaben bleiben bestehen, aber Ihr Name wird anonymisiert
+            tasks_header: 'Aufgaben:'
+      password_new: Neues Passwort
+      password_new_confirmation: Bestätigen Sie Ihr neues Passwort
+    show:
+      account_links:
+        add: Account-Link hinzufügen
+        created: Erstellte Account-Links
+        other: Andere Account-Links
+      delete_modal:
+        title: Warnung
+      full_name: Vollständiger Name
+      private_information: Private Informationen
+      public_information: Öffentliche Informationen
+      send_message: Nachricht senden
+    unlocks:
+      new:
+        resend_unlock: Entsperrungsinstruktionen erneut senden
+        validation_error: 'Aufgrund von Fehlern konnten die Instruktionen nicht gesendet werden:'

--- a/config/locales/de/views/users.yml
+++ b/config/locales/de/views/users.yml
@@ -1,63 +1,30 @@
 ---
 de:
   users:
-    confirmations:
-      new:
-        resend_confirmation: Bestätigungsinstruktionen erneut senden
-        validation_error: 'Aufgrund von Fehlern konnten die Instruktionen nicht gesendet werden:'
-    passwords:
-      edit:
-        change_my_pwd: Passwort ändern
-        change_pwd: Passwort ändern
-      new:
-        forgot_pwd: Passwort vergessen?
-        send_reset_pwd: Senden Sie mir Reset-Passwort-Instruktionen
-        validation_error: 'Aufgrund von Fehlern konnte die E-Mail nicht gesendet werden:'
+    mailer:
+      confirmation_instructions:
+        p1: 'Vielen Dank für Ihre Registrierung bei CodeHarbor! Klicken Sie auf den folgenden Link, um Ihren Account zu bestätigen:'
     registrations:
       avatar_form:
-        remove_avatar: Avatar entfernen
-      edit:
-        confirm_w_pwd: Wir benötigen Ihr aktuelles Passwort, um Ihre Änderungen zu bestätigen.
-        header: Benutzer bearbeiten
-        leave_blank: Lassen Sie es leer, wenn Sie es nicht ändern möchten.
-        password_current: Aktuelles Passwort
-        update_user: Aktualisieren
-        waiting_confirmation: 'Aktuell in Wartestellung für Bestätigung: %{email}'
-      new:
-        header: Registrieren
-        password: Passwort
-    sessions:
-      new:
-        email:
-          label: E-Mail
-          placeholder: E-Mail
-        header: Einloggen
-        password:
-          label: Passwort
-          placeholder: Passwort
+        remove_avatar: Profilbild entfernen
     shared:
-      links:
-        forgot_pwd: Passwort vergessen?
-        no_confirmation: Keine Bestätigungsinstruktionen erhalten?
-        no_unlock: Keine Entsperrungsinstruktionen erhalten?
-        sign_in_with: Mit %{provider} anmelden
-      minimum_password_length: Mindestens %{count} Zeichen
       notification_modal:
         delete_modal:
           content:
-            groups_1: Gruppen, in denen Sie der einzige Benutzer sind, werden gelöscht
-            groups_2: 'Gruppen, in denen Sie der Administrator und andere Benutzer sind: Ein anderer Benutzer wird zufällig zum Administrator erklärt'
-            groups_3: 'Gruppen mit anderen Administratoren: keine Änderungen'
+            groups_1: Gruppen, in denen Sie der/die einzige Benutzer:in sind, werden gelöscht
+            groups_2: 'Gruppen, in denen Sie der/die Administrator:in und andere Benutzer:innen sind: Ein/e andere/r Benutzer:in wird zufällig zum/zur Administrator:in erklärt'
+            groups_3: 'Gruppen mit anderen Administratorinnen oder Administratoren: keine Änderungen'
             groups_header: 'Gruppen:'
-            intro: 'Die Löschung Ihres Kontos hat folgende Auswirkungen:'
+            intro: 'Die Löschung Ihres Accounts hat folgende Auswirkungen:'
             tasks_content: Ihre Aufgaben bleiben bestehen, aber Ihr Name wird anonymisiert
             tasks_header: 'Aufgaben:'
-      password_new: Neues Passwort
       password_new_confirmation: Bestätigen Sie Ihr neues Passwort
+      validation_error: 'Aufgrund von Fehlern konnte die Anleitung nicht gesendet werden:'
     show:
       account_links:
         add: Account-Link hinzufügen
         created: Erstellte Account-Links
+        more_information: Mehr dazu...
         other: Andere Account-Links
       delete_modal:
         title: Warnung
@@ -65,7 +32,3 @@ de:
       private_information: Private Informationen
       public_information: Öffentliche Informationen
       send_message: Nachricht senden
-    unlocks:
-      new:
-        resend_unlock: Entsperrungsinstruktionen erneut senden
-        validation_error: 'Aufgrund von Fehlern konnten die Instruktionen nicht gesendet werden:'

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -1,6 +1,7 @@
 ---
 en:
   common:
+    app_name: CodeHarbor
     button:
       abort: Abort
       back: Back

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -35,6 +35,7 @@ en:
       not_signed_in: You must be signed in to continue.
       something_went_wrong: Something went wrong
     locales:
+      de: German
       en: English
     none: None
     notices:

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -8,21 +8,26 @@ en:
       close: Close
       confirm: Confirm
       delete: Delete
-      destroy: Destroy
-      download_zip: Download Zip
+      download_zip: Download ZIP
       duplicate: Duplicate
       edit: Edit
       export: Export
       hide: Hide
       import: Import
       log_in: Log in
+      'no': 'no'
       remove: Remove
       retry: Retry
+      save: Save
+      save_object: Save %{model}
       show: Show
       show_less: Show less
       show_more: Show more
       sign_up: Sign up
+      update: Update
       view: View
+      'yes': 'yes'
+    created: Created
     created_at: Created at
     created_by: Created by
     edit_colon: 'Edit:'
@@ -34,6 +39,8 @@ en:
       not_found_error: You are not able to access this object or it doesn't exist
       not_signed_in: You must be signed in to continue.
       something_went_wrong: Something went wrong
+    javascripts:
+      error: Error
     locales:
       de: German
       en: English

--- a/config/locales/en/controllers/collections.yml
+++ b/config/locales/en/controllers/collections.yml
@@ -16,4 +16,4 @@ en:
     share:
       success_notice: Your collection has been sent.
     share_message:
-      text: "%{user} sent you their Collection %{collection}."
+      text: '%{user} sent you their collection "%{collection}"'

--- a/config/locales/en/controllers/groups.yml
+++ b/config/locales/en/controllers/groups.yml
@@ -17,8 +17,8 @@ en:
     request_access:
       success_notice: Your Access request has been sent.
     send_access_request_message:
-      message: "%{user} wants to access your group: %{group}."
+      message: "%{user} wants to access your group: %{group}"
     send_deny_access_message:
-      message: "%{user} did not accept you to their group: %{group}."
+      message: "%{user} did not accept you to their group: %{group}"
     send_grant_access_messages:
-      message: "%{user} accepted you to their group: %{group}."
+      message: "%{user} accepted you to their group: %{group}"

--- a/config/locales/en/controllers/tasks.yml
+++ b/config/locales/en/controllers/tasks.yml
@@ -20,7 +20,7 @@ en:
       choose_file_error: You need to choose a file.
     proforma_service:
       convert_zip_to_proforma_tasks:
-        nested_too_deep: Zip is nested too deep.
+        nested_too_deep: ZIP is nested too deep.
     task_service:
       check_external:
         no_task: No corresponding task found on external app. Pushing this task will create a new task on external app, which will be linked to this one on CodeHarbor. Any changes to either one can be pushed to the respective other platform.

--- a/config/locales/en/external/devise.yml
+++ b/config/locales/en/external/devise.yml
@@ -1,8 +1,40 @@
 ---
 en:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: Confirmation sent at
+        confirmation_token: Confirmation token
+        confirmed_at: Confirmed at
+        created_at: Created at
+        current_password: Current password
+        current_sign_in_at: Current sign in at
+        current_sign_in_ip: Current sign in IP
+        email: Email
+        encrypted_password: Encrypted password
+        failed_attempts: Failed attempts
+        last_sign_in_at: Last sign in at
+        last_sign_in_ip: Last sign in IP
+        locked_at: Locked at
+        password: Password
+        password_confirmation: Password confirmation
+        remember_created_at: Remember created at
+        remember_me: Remember me
+        reset_password_sent_at: Reset password sent at
+        reset_password_token: Reset password token
+        sign_in_count: Sign in count
+        unconfirmed_email: Unconfirmed email
+        unlock_token: Unlock token
+        updated_at: Updated at
+    models:
+      user:
+        one: User
+        other: Users
   devise:
     confirmations:
       confirmed: Your email address has been successfully confirmed.
+      new:
+        resend_confirmation_instructions: Resend confirmation instructions
       send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
@@ -18,35 +50,43 @@ en:
     mailer:
       confirmation_instructions:
         action: Confirm my account
-        greeting: Welcome %{name},
-        p1: 'Thanks for registering to CodeHarbor! You can confirm your account email through the link below:'
+        greeting: Welcome %{recipient}!
+        instruction: 'You can confirm your account email through the link below:'
         subject: Confirmation instructions
       email_changed:
-        greeting: Hello %{name},
-        p1: We're contacting you to notify you that your email for CodeHarbor is being changed to %{unconfirmed_email}.
-        p2: We're contacting you to notify you that your email for CodeHarbor has been changed to %{email}.
-        subject: Email changed
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your email has been changed to %{email}.
+        message_unconfirmed: We're contacting you to notify you that your email is being changed to %{email}.
+        subject: Email Changed
       password_change:
-        greeting: Hello %{name},
-        p1: We're contacting you to notify you that your password for CodeHarbor has been changed.
-        subject: Password changed
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your password has been changed.
+        subject: Password Changed
       reset_password_instructions:
         action: Change my password
-        greeting: Hello %{name},
-        p1: Someone has requested a link to change your password for CodeHarbor. You can do this through the link below.
-        p2: If you didn't request this, please ignore this email.
-        p3: Your password won't change until you access the link above and create a new one.
+        greeting: Hello %{recipient}!
+        instruction: Someone has requested a link to change your password. You can do this through the link below.
+        instruction_2: If you didn't request this, please ignore this email.
+        instruction_3: Your password won't change until you access the link above and create a new one.
         subject: Reset password instructions
       unlock_instructions:
         action: Unlock my account
-        greeting: Hello %{name},
-        p1: Your CodeHarbor account has been locked due to an excessive number of unsuccessful sign in attempts.
-        p2: 'Click the link below to unlock your account:'
+        greeting: Hello %{recipient}!
+        instruction: 'Click the link below to unlock your account:'
+        message: Your account has been locked due to an excessive number of unsuccessful sign in attempts.
         subject: Unlock instructions
     omniauth_callbacks:
       failure: Could not authenticate you from %{kind} because "%{reason}".
       success: Successfully authenticated from %{kind} account.
     passwords:
+      edit:
+        change_my_password: Change my password
+        change_your_password: Change your password
+        confirm_new_password: Confirm new password
+        new_password: New password
+      new:
+        forgot_your_password: Forgot your password?
+        send_me_reset_password_instructions: Send me reset password instructions
       no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
       send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
@@ -54,6 +94,17 @@ en:
       updated_not_active: Your password has been changed successfully.
     registrations:
       destroyed: Bye! Your account has been successfully cancelled. We hope to see you again soon.
+      edit:
+        are_you_sure: Are you sure?
+        cancel_my_account: Cancel my account
+        currently_waiting_confirmation_for_email: 'Currently waiting confirmation for: %{email}'
+        leave_blank_if_you_don_t_want_to_change_it: leave blank if you don't want to change it
+        title: Edit %{resource}
+        unhappy: Unhappy?
+        update: Update
+        we_need_your_current_password_to_confirm_your_changes: we need your current password to confirm your changes
+      new:
+        sign_up: Sign up
       signed_up: Welcome! You have signed up successfully.
       signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
       signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
@@ -63,9 +114,35 @@ en:
       updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again.
     sessions:
       already_signed_out: Signed out successfully.
+      new:
+        sign_in: Log in
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
+    shared:
+      links:
+        back: Back
+        didn_t_receive_confirmation_instructions: Didn't receive confirmation instructions?
+        didn_t_receive_unlock_instructions: Didn't receive unlock instructions?
+        forgot_your_password: Forgot your password?
+        sign_in: Log in
+        sign_in_with_provider: Sign in with %{provider}
+        sign_up: Sign up
+      minimum_password_length:
+        one: "(%{count} character minimum)"
+        other: "(%{count} characters minimum)"
     unlocks:
+      new:
+        resend_unlock_instructions: Resend unlock instructions
       send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
       send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.
+  errors:
+    messages:
+      already_confirmed: was already confirmed, please try signing in
+      confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
+      expired: has expired, please request a new one
+      not_found: not found
+      not_locked: was not locked
+      not_saved:
+        one: '1 error prohibited this %{resource} from being saved:'
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -52,6 +52,19 @@ en:
         tests: Tests
         title: Title
         uuid: UUID
+      task/files:
+        attachment: File attachment
+        name: File name
+        xml_id: File XML ID
+      task/model_solutions:
+        xml_id: Model solution XML ID
+      task/model_solutions/files:
+        attachment: Attachment of a file in a model solution
+        name: Name of a file in a model solution
+        xml_id: XML ID of a file in a model solution
+      task/tests:
+        title: Test title
+        xml_id: Test XML ID
       task_file:
         attachment: Attachment
         content: Content
@@ -73,7 +86,6 @@ en:
         validity: Validity
         xml_id: XML ID
       user:
-        email: Email
         first_name: First name
         last_name: Last name
         role: Role
@@ -168,12 +180,13 @@ en:
       testing_framework:
         one: Testing framework
         other: Testing frameworks
-      user:
-        one: User
-        other: Users
       user_identity:
         one: User identity
         other: User identities
   tasks:
     model:
       copy_of_task: Copy of task
+  users:
+    role:
+      admin: Admin
+      user: User

--- a/config/locales/en/views/account_links.yml
+++ b/config/locales/en/views/account_links.yml
@@ -5,6 +5,7 @@ en:
       header: Editing Account Link
     form:
       button:
+        generate: Generate
         save: Save Account Link
       info:
         check_uuid_url: The address on the auto-grader side that can be queried to determine if the exercise already exists.

--- a/config/locales/en/views/groups.yml
+++ b/config/locales/en/views/groups.yml
@@ -1,6 +1,13 @@
 ---
 en:
   groups:
+    access_request_mailer:
+      confirm_request: Confirm Request
+      greeting: Hello %{user}
+      message_line1: '%{user} asked to join your group "%{group}".'
+      message_line2: If you want to give your permission click on the link below.
+      message_line3: Otherwise ignore this Email.
+      subject: '%{user} wants to access your Group "%{group}"'
     form:
       button:
         save: Save Group

--- a/config/locales/en/views/groups.yml
+++ b/config/locales/en/views/groups.yml
@@ -6,13 +6,24 @@ en:
         save: Save Group
     groups:
       admin_label: Admin
+      create_groups_tip: You can create groups to connect with other users and handle exercise access.
       member_label: Member
+      no_groups_yet: You do not have groups yet
       pending_label: Pending
+      wait_to_get_accepted: Wait to get accepted
+    index:
+      button:
+        all_groups: All Groups
+        my_groups: My Groups
+        new_group: New Group
     new:
       header: New Group
     share_account_link_button:
       share_tooltip: Share account link for %{account_link} with %{user}
       unshare_tooltip: Stop sharing account link for %{account_link} with %{user}
+    shared:
+      button:
+        request_membership: Request Membership
     show:
       button:
         delete_group: Delete group
@@ -22,7 +33,6 @@ en:
         grant_access: Grant Access
         leave: Leave Group
         make_admin: Make Admin
-        request_membership: Request Membership
       demote_admin:
         confirm: Are you sure you want to demote the admin?
       demote_yourself:

--- a/config/locales/en/views/home.yml
+++ b/config/locales/en/views/home.yml
@@ -16,7 +16,7 @@ en:
         <h3>You want to connect an auto-grader that already has OAuth2 and ProFormA-XML support:</h3>
         <p>
           If the auto-grader can import exercises sent via OAuth2 request in the ProFormA-XML format you will need the following things: <br/>
-          1. Push-url: The auto-grader needs to have an ULR CodeHarbor can post the exercise to. <br/>
+          1. Push-url: The auto-grader needs to have a URL CodeHarbor can post the exercise to. <br/>
           2. OAuth2-token: The auto-grader must be able to link a token to your account to authorize exercises that will be pushed there. <br/>
              If you do not need a specific token you can generate a token when creating an account link on CodeHarbor side or use whatever you want <br/>
              as long as it is the same token on CodeHarbor and the auto-graders side.<br>

--- a/config/locales/en/views/labels.yml
+++ b/config/locales/en/views/labels.yml
@@ -3,13 +3,18 @@ en:
   labels:
     index:
       change_color_to: Change Color to
+      filter_by_name: Filter By Name
+      id: ID
       merge: Merge and Rename to
+      new_name: New Name
+      used_by_tasks: Used By Tasks
     javascripts:
-      can_only_create_5: You can only add 5 labels
       cannot_be_empty: The label name entered is empty
       change_color_confirmation: This will change the color of the %{selected_labels_count} label(s) selected.
       delete_confirmation: This will delete the %{selected_labels_count} label(s) selected.
+      max_limit_reached: You can only add %{limit} labels
       merge_confirmation: This will merge the %{selected_labels_count} label(s) selected and rename them to "%{new_merged_name}"
       new:
         selection_suffix: " (new)"
+      ok: OK
       too_long: The label name entered is too long

--- a/config/locales/en/views/tasks.yml
+++ b/config/locales/en/views/tasks.yml
@@ -11,6 +11,9 @@ en:
       overwrite: Overwrite
     file_config:
       configuration: Configuration
+      delayed: delayed
+      display: display
+      download: download
     form:
       button:
         add_model_solution: Add Model Solution
@@ -46,7 +49,8 @@ en:
         advanced: Advanced
         all_access_levels: All Visibilities
         all_time: All Time
-        created: Created
+        average_rating: Average Rating
+        creation_date: Creation Date
         has_all_labels: Has All Labels
         label: Search
         last_month: Last Month
@@ -58,7 +62,7 @@ en:
         today: Today
     javascripts:
       all_languages: All Languages
-      checking_external_app: Checking if the task exists on the external app.
+      checking_external_app: Checking if the task exists on the autograder.
       select_groups: Select groups
     nested_file_form:
       add_file: Add file
@@ -68,12 +72,13 @@ en:
     shared:
       additional_info: Additional Information
       basic_information: Basic Information
+      new_comment: New Comment
     show:
       add_to_collection_hint: Save Tasks for later by adding them to a collection.
       button:
         add_collection: Add Collection
         add_to_collection: Add to collection
-        download_as_zip: Download this Task as a zip file.
+        download_as_zip: Download this Task as a ZIP file.
         export: Export
         export_tasks: Export Tasks
         rate: Rate
@@ -91,14 +96,13 @@ en:
       yourself: yourself
     tasks:
       button:
-        new_comment: New Comment
         related_exercises: Show Related Exercises
         show_comments: Show Comments
       no_description: No Description
       no_programming_language_selected: No programming language selected
       search:
         no_results: No results
-        no_results_description: Try different options by clicking on 'Advanced'.
+        no_results_description: Try different options by clicking on 'Advanced' and repeating the search.
         no_tasks: You do not have tasks yet
     visibility:
       label: Visibility

--- a/config/locales/en/views/tasks.yml
+++ b/config/locales/en/views/tasks.yml
@@ -1,6 +1,12 @@
 ---
 en:
   tasks:
+    access_request_mailer:
+      greeting: Hello %{user}
+      message_line1: '%{user} asked to contribute to your task "%{task}".'
+      message_line2: If you want to make them a co-author or suggest Membership to a group click the link below.
+      message_line3: Otherwise ignore this Email.
+      subject: '%{user} wants to contribute to your task "%{task}"'
     editor:
       button:
         extract_text: Extract text

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -1,47 +1,13 @@
 ---
 en:
   users:
-    confirmations:
-      new:
-        resend_confirmation: Resend confirmation instructions
-        validation_error: 'Could not send instructions due to errors:'
-    passwords:
-      edit:
-        change_my_pwd: Change my password
-        change_pwd: Change your password
-      new:
-        forgot_pwd: Forgot your password?
-        send_reset_pwd: Send me reset password instructions
-        validation_error: 'Could not send email due to errors:'
+    mailer:
+      confirmation_instructions:
+        p1: 'Thanks for registering to CodeHarbor! You can confirm your account email through the link below:'
     registrations:
       avatar_form:
         remove_avatar: Remove Avatar
-      edit:
-        confirm_w_pwd: We need your current password to confirm your changes.
-        header: Edit User
-        leave_blank: Leave it blank if you don't want to change it.
-        password_current: Current password
-        update_user: Update
-        waiting_confirmation: 'Currently waiting confirmation for: %{email}'
-      new:
-        header: Sign Up
-        password: Password
-    sessions:
-      new:
-        email:
-          label: Email
-          placeholder: Email
-        header: Log In
-        password:
-          label: Password
-          placeholder: Password
     shared:
-      links:
-        forgot_pwd: Forgot your password?
-        no_confirmation: Didn't receive confirmation instructions?
-        no_unlock: Didn't receive unlock instructions?
-        sign_in_with: Sign in with %{provider}
-      minimum_password_length: "%{count} characters minimum"
       notification_modal:
         delete_modal:
           content:
@@ -52,12 +18,13 @@ en:
             intro: 'Deletion of your account will have the following effects:'
             tasks_content: Your tasks will remain, but your name will be anonymized
             tasks_header: 'Tasks:'
-      password_new: New password
       password_new_confirmation: Confirm your new password
+      validation_error: 'Could not send instructions due to errors:'
     show:
       account_links:
         add: Add Account Link
         created: Created Account Links
+        more_information: More Information...
         other: Other Account Links
       delete_modal:
         title: Warning
@@ -65,7 +32,3 @@ en:
       private_information: Private Information
       public_information: Public Information
       send_message: Send Message
-    unlocks:
-      new:
-        resend_unlock: Resend unlock instructions
-        validation_error: 'Could not send instructions due to errors:'

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -24,7 +24,15 @@ const envConfig = module.exports = {
     },
     module: {
         rules: [
-            erb
+            erb,
+            {
+                // Exclude non-JS file from select2-i18n, otherwise breaking our dynamic language lookup.
+                test: /select2\/dist\/js\/i18n\/build\.txt$/,
+                type: 'asset/resource',
+                generator: {
+                    emit: false,
+                },
+            },
         ]
     },
     optimization: {

--- a/db/migrate/20240221163906_add_preferred_locale_to_users.rb
+++ b/db/migrate/20240221163906_add_preferred_locale_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreferredLocaleToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :preferred_locale, :string
+  end
+end

--- a/db/migrate/20240312165451_rename_group_param_type.rb
+++ b/db/migrate/20240312165451_rename_group_param_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RenameGroupParamType < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        Message.where(param_type: :group).find_each {|message| message.update!(param_type: :group_requested) }
+      end
+
+      dir.down do
+        Message.where(param_type: :group_requested).find_each {|message| message.update!(param_type: :group) }
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_21_163906) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_12_165451) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_11_200306) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_21_163906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -315,6 +315,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_11_200306) do
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at"
+    t.string "preferred_locale"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'Authentication' do
     context 'with valid credentials' do
       it 'allows to sign in' do
         click_link(I18n.t('common.button.log_in'))
-        fill_in(I18n.t('users.sessions.new.email.label'), with: user.email)
-        fill_in(I18n.t('users.sessions.new.password.label'), with: password)
+        fill_in(:user_email, with: user.email)
+        fill_in(:user_password, with: password)
         click_button(I18n.t('common.button.log_in'))
         expect(page).to have_content(I18n.t('devise.sessions.signed_in'))
       end
@@ -47,8 +47,8 @@ RSpec.describe 'Authentication' do
       end
 
       it 'redirects to the desired page immediately after sign-in' do
-        fill_in(I18n.t('users.sessions.new.email.label'), with: user.email)
-        fill_in(I18n.t('users.sessions.new.password.label'), with: password)
+        fill_in(:user_email, with: user.email)
+        fill_in(:user_password, with: password)
         click_button(I18n.t('common.button.log_in'))
         expect(page).to have_content(task.title)
       end
@@ -57,8 +57,8 @@ RSpec.describe 'Authentication' do
         let(:task) { create(:task, access_level: :private) }
 
         it 'informs the user about missing permissions' do
-          fill_in(I18n.t('users.sessions.new.email.label'), with: user.email)
-          fill_in(I18n.t('users.sessions.new.password.label'), with: password)
+          fill_in(:user_email, with: user.email)
+          fill_in(:user_password, with: password)
           click_button(I18n.t('common.button.log_in'))
           expect(page).to have_content(I18n.t('common.errors.not_authorized'))
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe User do
 
       context 'when message has type exercise', pending: 'messages and sharing permissions need to be reworked' do
         before do
-          create(:message, sender: user, param_type: 'exercise')
-          create(:message, sender: user, param_type: 'group')
-          create(:message, sender: user, param_type: 'collection')
+          create(:message, sender: user, param_type: 'exercise', param_id: create(:task).id)
+          create(:message, sender: user, param_type: 'group_requested', param_id: create(:group).id)
+          create(:message, sender: user, param_type: 'collection', param_id: create(:collection).id)
         end
 
         it 'deletes message' do

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -7,8 +7,8 @@ module Authentication
 
   def sign_in_with_js_driver(user, password)
     visit(new_user_session_path)
-    fill_in(I18n.t('users.sessions.new.email.label'), with: user.email)
-    fill_in(I18n.t('users.sessions.new.password.label'), with: password)
+    fill_in(:user_email, with: user.email)
+    fill_in(:user_password, with: password)
     click_button(I18n.t('common.button.log_in'))
     expect(page).to have_content(I18n.t('devise.sessions.signed_in'))
   end


### PR DESCRIPTION
This PR adds the current status of the translation of CodeHarbor to German.

As specified in the first commit, the translations provided here were not checked manually yet and therefore contain some inconsistencies, such as the salutation ("Du" vs "Sie") or the gender form. Before merging, we should unify those (probably "Sie" and gendered nouns with `:` [e.g., "Empfänger:in"]). Further, I omitted the "external" translations, since we can probably borrow them from some other location without the need to review them.

The other changes beside the locale files are probably enough to enable an additional language for CodeHarbor and allow users to switch. These parts of the code originate from CodeOcean and are only adjusted where necessary.