### PR TITLE
781 - collections consume invitation

### DIFF
--- a/app/assets/stylesheets/collections.css.scss
+++ b/app/assets/stylesheets/collections.css.scss
@@ -37,11 +37,9 @@ $collection-color: #000080;
   flex-direction: column;
   span {
     i {
-      &:first-child {
-        width: 20px;
-      }
+      width: 20px;
+      text-align: center;
     }
-
     padding: 5px;
   }
 }

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -14,7 +14,9 @@ class CollectionsController < ApplicationController
     authorize @collections
   end
 
-  def show; end
+  def show
+    @num_of_invites = Message.where(param_type: 'collection', param_id: @collection.id).count
+  end
 
   def new
     @collection = Collection.new

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,6 +2,7 @@
 
 class Message < ApplicationRecord
   validates :text, presence: true, unless: -> { %w[group_requested group_accepted group_declined collection].include?(param_type) }
+  validates :param_id, uniqueness: {scope: %i[recipient_id param_type]}, unless: -> { param_type == 'collection' }
 
   belongs_to :sender, class_name: 'User', inverse_of: :sent_messages
   belongs_to :recipient, class_name: 'User', inverse_of: :received_messages

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,7 @@
 
 class Message < ApplicationRecord
   validates :text, presence: true, unless: -> { %w[group_requested group_accepted group_declined collection].include?(param_type) }
-  validates :param_id, uniqueness: {scope: %i[recipient_id param_type]}, unless: -> { param_type == 'collection' }
+  validates :param_id, uniqueness: {scope: %i[recipient_id param_type]}, if: -> { param_type == 'collection' }
 
   belongs_to :sender, class_name: 'User', inverse_of: :sent_messages
   belongs_to :recipient, class_name: 'User', inverse_of: :received_messages

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -13,18 +13,19 @@
         - else
           i.fa-solid.fa-lock.lock-icon
           =< t('.visibility.private')
-      span
-        i.fa-solid.fa-users
-        - if @collection.users.size == 1
-          =< t('.no_other_user')
-        - else
-          =< t('.num_of_other_users', count: @collection.users.size - 1)
-      span
-        i.fa-regular.fa-envelope
-        - if @num_of_invites == 0
-          =< t('.no_invites')
-        - else
-          =< t('.num_of_invites', count: @num_of_invites)
+      - if action_name != 'view_shared'
+        span
+          i.fa-solid.fa-users
+          - if @collection.users.size == 1
+            =< t('.no_other_user')
+          - else
+            =< t('.num_of_other_users', count: @collection.users.size - 1)
+        span
+          i.fa-regular.fa-envelope
+          - if @num_of_invites == 0
+            =< t('.no_invites')
+          - else
+            =< t('.num_of_invites', count: @num_of_invites)
 
     .collection-content.mt-2.pt-2
       .description.collapsable.w-100

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -14,11 +14,18 @@
           i.fa-solid.fa-lock.lock-icon
           =< t('.visibility.private')
       span
+        span
         i.fa-solid.fa-users
         - if @collection.users.size == 1
           =< t('.no_other_user')
         - else
           =< t('.num_of_other_users', count: @collection.users.size - 1)
+      span
+        i.fa-solid.fa-message
+        - if @num_of_invites == 0
+          =< t('.no_invites')
+        - else
+          =< t('.num_of_invites', count: @num_of_invites)
 
     .collection-content.mt-2.pt-2
       .description.collapsable.w-100

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -22,7 +22,7 @@
             =< t('.num_of_other_users', count: @collection.users.size - 1)
         span
           i.fa-regular.fa-envelope
-          - if @num_of_invites == 0
+          - if @num_of_invites.zero?
             =< t('.no_invites')
           - else
             =< t('.num_of_invites', count: @num_of_invites)

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -14,14 +14,13 @@
           i.fa-solid.fa-lock.lock-icon
           =< t('.visibility.private')
       span
-        span
         i.fa-solid.fa-users
         - if @collection.users.size == 1
           =< t('.no_other_user')
         - else
           =< t('.num_of_other_users', count: @collection.users.size - 1)
       span
-        i.fa-solid.fa-message
+        i.fa-regular.fa-envelope
         - if @num_of_invites == 0
           =< t('.no_invites')
         - else

--- a/config/locales/de/views/collections.yml
+++ b/config/locales/de/views/collections.yml
@@ -30,7 +30,11 @@ de:
         deletion_warning: Sie sind der/die letzte Benutzer:in in dieser Aufgabensammlung. Wenn Sie gehen, wird diese Aufgabensammlung dauerhaft gelöscht! Sind Sie sicher?
       locked_exercise_hint: 'Hinweis: Für Aufgaben mit einem Schloss-Symbol müssen Sie zuerst Zugriff beantragen, um sie anzeigen zu können.'
       noExercisesAdded: Keine Aufgabe hinzugefügt
+      no_invites: Es stehen keine Einladungen aus
       no_other_user: Kein/Keine anderer/andere Benutzer:in hat Zugriff auf diese Aufgabensammlung
+      num_of_invites:
+        one: Eine Einladung steht aus
+        other: Es stehen %{count} Einladungen aus
       num_of_other_users:
         one: Ein/Eine anderer/andere Benutzer:in hat Zugriff auf diese Aufgabensammlung
         other: "%{count} andere Benutzer:innen haben Zugriff auf diese Aufgabensammlung"

--- a/config/locales/en/views/collections.yml
+++ b/config/locales/en/views/collections.yml
@@ -30,7 +30,11 @@ en:
         deletion_warning: You are the last user in this collection. If you leave, this collection will be permanently deleted! Are you sure?
       locked_exercise_hint: 'Hint: For exercises marked with a lock you have to request access first before you can view them.'
       noExercisesAdded: No Exercise Added
+      no_invites: There are no pending invitations
       no_other_user: No other user has access to this collection
+      num_of_invites:
+        one: There is one pending invitation
+        other: There are %{count} pending invitations
       num_of_other_users:
         one: One other user has access to this collection
         other: "%{count} other users have access to this collection"

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -4,6 +4,17 @@ require 'rails_helper'
 require 'nokogiri'
 
 RSpec.describe Message do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.not_to validate_uniqueness_of(:param_id).scoped_to(%i[recipient_id param_type]) }
+
+    context 'with param_type: collection' do
+      subject { create(:message, param_type: 'collection', param_id: create(:collection).id) }
+
+      it { is_expected.to validate_uniqueness_of(:param_id).scoped_to(%i[recipient_id param_type]) }
+    end
+  end
+
   describe 'destroy_hook' do
     let!(:message) { create(:message) }
 


### PR DESCRIPTION
Currently a user can use an invitation as many times as they want, which does not feel intuitive.
This PR also adds an overview of how many open invitations a collection has

depends on #1130 