### PR TITLE
Fixing #1186: Viewing tasks is no longer possible as anonymous user

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,7 +10,7 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
   before_action :set_search, only: [:index]
   prepend_before_action :set_user_for_api_request, only: %i[import_uuid_check import_external]
   skip_before_action :verify_authenticity_token, only: %i[import_uuid_check import_external]
-  skip_before_action :require_user!, only: %i[show]
+  skip_before_action :require_user!, only: %i[show download]
 
   def index
     page = params[:page]

--- a/app/policies/task_policy.rb
+++ b/app/policies/task_policy.rb
@@ -5,11 +5,13 @@ class TaskPolicy < ApplicationPolicy
     @record
   end
 
-  def show?
-    if @user.present?
-      admin? || task.access_level_public? || task.in_same_group?(@user) || task.author?(@user)
-    else
-      task.access_level_public?
+  %i[show? download?].each do |action|
+    define_method(action) do
+      if @user.present?
+        admin? || task.access_level_public? || task.in_same_group?(@user) || task.author?(@user)
+      else
+        task.access_level_public?
+      end
     end
   end
 
@@ -25,7 +27,7 @@ class TaskPolicy < ApplicationPolicy
     record_owner? || admin?
   end
 
-  %i[download? add_to_collection? duplicate? export_external_start? export_external_check? export_external_confirm?].each do |action|
+  %i[add_to_collection? duplicate? export_external_start? export_external_check? export_external_confirm?].each do |action|
     define_method(action) do
       return false if @user.blank?
 

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -14,7 +14,7 @@
             span.fa-regular.fa-star.overall-rating data-rating=i
         small
           .rating-dropdown
-            - if policy(Rating).new?
+            - if current_user && policy(Rating).new?
               .btn.btn-sm#rate
                 => t('.button.rate')
                 span.fa-solid.fa-caret-down
@@ -99,7 +99,7 @@
             = t('.yourself')
           - elsif @task.user.first_name.nil?
             = "User#{@task.user.id}"
-          - elsif policy(@task.user).show?
+          - elsif current_user && policy(@task.user).show?
             = link_to @task.user.name, user_path(@task.user)
           - else
             = @task.user.name
@@ -140,7 +140,7 @@
           - @task.groups.each_with_index do |group, index|
             - if index > 0
               = ', '
-            - if policy(group).show?
+            - if current_user && policy(group).show?
               = link_to group.name, group_path(group)
             - else
               = group.name

--- a/spec/policies/task_policy_spec.rb
+++ b/spec/policies/task_policy_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TaskPolicy do
       let(:access_level) { :public }
 
       it { expect(task.lom_showable_by?(user)).to be true }
-      it { is_expected.to permit_only_actions(%i[show]) }
+      it { is_expected.to permit_only_actions(%i[show download]) }
     end
   end
 


### PR DESCRIPTION
Closes #1186

The problem was that the RatingPolicy and UserPolicy cannot be created without a current_user. I avoided that by introducing the extra check for current_user. Another possibility would be to set user_required? to false in the RatingPolicy and UserPolicy but I did not want to touch the policies just for this single view.