### PR TITLE
Issue #1142: Moving methods from task model to policy

### DIFF
--- a/app/assets/stylesheets/groups.css.scss
+++ b/app/assets/stylesheets/groups.css.scss
@@ -41,3 +41,9 @@ $group-color: #660000;
 .dropdown-item:hover {
   background-color: #f0f0f0;
 }
+
+.table-list.group-tasks {
+  .btn-group.btn:not(:last-child) {
+    border-right: none;
+  }
+}

--- a/app/controllers/bridges/lom/tasks_controller.rb
+++ b/app/controllers/bridges/lom/tasks_controller.rb
@@ -8,7 +8,7 @@ module Bridges
       def show
         task = Task.find(params[:id])
 
-        if task.lom_showable_by?(current_user)
+        if Pundit.policy(current_user, task).show?
           render xml: Nokogiri::XML::Builder.new(encoding: 'UTF-8') {|xml| LomService::ExportLom.call(task:, xml:) }
         else
           render xml: Nokogiri::XML::Builder.new(encoding: 'UTF-8') {|xml| xml.error 'Access Denied' }, status: :forbidden

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -122,7 +122,7 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
   def import_uuid_check
     task = Task.find_by(uuid: params[:uuid])
     return render json: {uuid_found: false} if task.nil?
-    return render json: {uuid_found: true, update_right: false} unless task.can_access(current_user)
+    return render json: {uuid_found: true, update_right: false} unless Pundit.policy(current_user, task).manage?
 
     render json: {uuid_found: true, update_right: true}
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -102,43 +102,6 @@ class Task < ApplicationRecord
     %w[labels]
   end
 
-  def can_access(user)
-    showable_by?(user) && updateable_by?(user) && destroyable_by?(user)
-  end
-
-  def author?(user)
-    self.user == user
-  end
-
-  def showable_by?(user)
-    user.nil? ? false : Pundit.policy(user, self).show?
-  end
-
-  def updateable_by?(user)
-    user.nil? ? false : Pundit.policy(user, self).update?
-  end
-
-  def destroyable_by?(user)
-    user.nil? ? false : Pundit.policy(user, self).destroy?
-  end
-
-  def lom_showable_by?(user)
-    access_level_public? || showable_by?(user)
-  end
-
-  # TODO: Find a better name for the methods
-  def in_same_group?(user)
-    in_same_group_member?(user) || in_same_group_admin?(user)
-  end
-
-  def in_same_group_member?(user)
-    groups.any? {|group| group.confirmed_member?(user) }
-  end
-
-  def in_same_group_admin?(user)
-    groups.any? {|group| group.admin?(user) }
-  end
-
   # This method creates a duplicate while leaving permissions and ownership unchanged
   def duplicate
     dup.tap do |task|

--- a/app/policies/task_file_policy.rb
+++ b/app/policies/task_file_policy.rb
@@ -11,7 +11,7 @@ class TaskFilePolicy < ApplicationPolicy
   end
 
   def download_attachment?
-    corresponding_task.showable_by?(@user)
+    Pundit.policy(@user, corresponding_task).show?
   end
 
   def extract_text_data?

--- a/app/services/proforma_service/cache_import_file.rb
+++ b/app/services/proforma_service/cache_import_file.rb
@@ -27,7 +27,7 @@ module ProformaService
     def file_data_hash(task, import_file, proforma_task)
       {path: proforma_task[:path].tr(' ', '_'),
        exists: task.present?,
-       updatable: task&.can_access(@user) || false,
+       updatable: task.present? && Pundit.policy(@user, task).manage?,
        import_id: import_file.id,
        task_uuid: proforma_task[:uuid]}
     end

--- a/app/services/proforma_service/import_task.rb
+++ b/app/services/proforma_service/import_task.rb
@@ -20,7 +20,7 @@ module ProformaService
     def base_task
       task = Task.find_by(uuid: @proforma_task.uuid)
       if task
-        return task if task.can_access(@user)
+        return task if Pundit.policy(@user, task).manage?
 
         return Task.new(uuid: SecureRandom.uuid)
       end

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -62,14 +62,12 @@
     .row-value
       - if @group.tasks.present?
         - @group.tasks.each do |task|
-          .table-list
+          .table-list.group-tasks
             .btn-group
+              = link_to task.title, task_path(task), class: 'btn btn-light'
               - if policy(@group).remove_task?
-                = link_to task.title, task_path(task), class: 'btn btn-light', style: "border-right: none"
-                = link_to remove_task_group_path(task: task), method: :patch, class: 'btn btn-light', style: "border-left: none; margin-right: 5px;"  do
+                = link_to remove_task_group_path(task: task), method: :patch, class: 'btn btn-light' do
                   i.fa-solid.fa-xmark style=("color:gray;")
-              - else
-                = link_to task.title, task_path(task), class: 'btn btn-light'
       - else
         = t('.has_no_tasks')
 

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -64,9 +64,12 @@
         - @group.tasks.each do |task|
           .table-list
             .btn-group
-              = link_to task.title, task_path(task), class: 'btn btn-light', style: "border-right: none"
-              = link_to remove_task_group_path(task: task), method: :patch, class: 'btn btn-light', style: "border-left: none; margin-right: 5px;"  do
-                i.fa-solid.fa-xmark style=("color:gray;")
+              - if policy(@group).remove_task?
+                = link_to task.title, task_path(task), class: 'btn btn-light', style: "border-right: none"
+                = link_to remove_task_group_path(task: task), method: :patch, class: 'btn btn-light', style: "border-left: none; margin-right: 5px;"  do
+                  i.fa-solid.fa-xmark style=("color:gray;")
+              - else
+                = link_to task.title, task_path(task), class: 'btn btn-light'
       - else
         = t('.has_no_tasks')
 

--- a/app/views/tasks/_tasks.html.slim
+++ b/app/views/tasks/_tasks.html.slim
@@ -62,9 +62,8 @@
           = link_to t('common.button.view'), task_path(task), class: 'btn btn-light'
         - if policy(task).edit?
           = link_to t('common.button.edit'), edit_task_path(task), class: 'btn btn-light'
+        - if policy(task).destroy?
           = link_to t('common.button.delete'), task_path(task), class: 'btn btn-light', method: :delete, data: { confirm: t('common.sure') }
-        / - if cannot? :edit, task
-          = link_to 'Contribute', contribute_task_path(task), method: :post, class: 'btn btn-light'
     .card-footer
       = button_tag type: 'button', class: 'btn no-border index-comment-button', data: {task: task.id} do
         => t('.button.show_comments')

--- a/spec/controllers/bridges/lom/tasks_controller_spec.rb
+++ b/spec/controllers/bridges/lom/tasks_controller_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Bridges::Lom::TasksController do
   let(:programming_language) { create(:programming_language, :ruby) }
   let(:license) { create(:license) }
   let(:parent_uuid) { create(:task).uuid }
-  let(:task) { create(:task, :with_content, :with_labels, user:, parent_uuid:, programming_language:, license:) }
+  let(:access_level) { :public }
+  let(:task) { create(:task, :with_content, :with_labels, user:, parent_uuid:, programming_language:, license:, access_level:) }
 
   describe 'GET #show' do
     subject(:get_request) { get :show, params: {id: task.to_param} }
@@ -29,13 +30,11 @@ RSpec.describe Bridges::Lom::TasksController do
     before { allow(Task).to receive(:find).with(task.id.to_s).and_return(task) }
 
     context 'when allowed to access the LOM' do
-      before { allow(task).to receive(:lom_showable_by?).and_return(true) }
-
       include_examples 'is a valid LOM response'
     end
 
     context 'when not allowed to access the LOM' do
-      before { allow(task).to receive(:lom_showable_by?).and_return(false) }
+      let(:access_level) { :private }
 
       it 'returns HTTP forbidden' do
         get_request
@@ -44,8 +43,6 @@ RSpec.describe Bridges::Lom::TasksController do
     end
 
     context 'with additional details' do
-      before { allow(task).to receive(:lom_showable_by?).and_return(true) }
-
       context 'when no license is specified' do
         let(:license) { nil }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -178,31 +178,6 @@ RSpec.describe User do
     end
   end
 
-  describe 'exercise visible for user', pending: 'group sharing is currently broken' do
-    let!(:user) { create(:user) }
-    let!(:user2) { create(:user) }
-    let!(:group) { create(:group, users: [user]) }
-    let!(:exercise) { create(:only_meta_data, :with_primary_description, private: false, authors: [user]) }
-    let!(:exercise2) { create(:only_meta_data, :with_primary_description, private: true, authors: [user]) }
-    let!(:exercise3) { create(:only_meta_data, :with_primary_description, private: true, authors: [user2], groups: [group]) }
-
-    it 'allows access to a public exercise to all users' do
-      expect(exercise.can_access(user2)).to be true
-    end
-
-    it 'does not allow access for any user to a private exercise' do
-      expect(exercise2.can_access(user2)).to be false
-    end
-
-    it 'allows access to a private exercise to the the author of the exercise' do
-      expect(exercise2.can_access(user)).to be true
-    end
-
-    it 'allows access to a private exercise to the member of a group which was granted access' do
-      expect(exercise3.can_access(user)).to be true
-    end
-  end
-
   describe '#available_account_links' do
     subject(:available_account_links) { user.available_account_links }
 

--- a/spec/policies/task_policy_spec.rb
+++ b/spec/policies/task_policy_spec.rb
@@ -16,14 +16,12 @@ RSpec.describe TaskPolicy do
     context 'when task is private' do
       let(:access_level) { :private }
 
-      it { expect(task.lom_showable_by?(user)).to be false }
       it { is_expected.to forbid_all_actions }
     end
 
     context 'when task is public' do
       let(:access_level) { :public }
 
-      it { expect(task.lom_showable_by?(user)).to be true }
       it { is_expected.to permit_only_actions(%i[show download]) }
     end
   end
@@ -33,20 +31,17 @@ RSpec.describe TaskPolicy do
     let(:generic_user_permissions) { %i[index new import_start import_confirm import_uuid_check import_external] }
 
     it { is_expected.to permit_only_actions(generic_user_permissions) }
-    it { expect(task.lom_showable_by?(user)).to be false }
 
     context 'when user is admin' do
       let(:user) { create(:admin) }
 
       it { is_expected.to permit_all_actions }
-      it { expect(task.lom_showable_by?(user)).to be true }
     end
 
     context 'when task is from user' do
       let(:task_user) { user }
 
       it { is_expected.to permit_all_actions }
-      it { expect(task.lom_showable_by?(user)).to be true }
     end
 
     context 'when task has access_level "public"' do
@@ -54,7 +49,6 @@ RSpec.describe TaskPolicy do
       let(:access_level) { :public }
 
       it { is_expected.to permit_only_actions(generic_user_permissions + %i[show export_external_start export_external_check export_external_confirm download add_to_collection duplicate]) }
-      it { expect(task.lom_showable_by?(user)).to be true }
     end
 
     context 'when task is "private" and in same group' do
@@ -68,12 +62,11 @@ RSpec.describe TaskPolicy do
       let(:group_member_permissions) { generic_user_permissions + %i[edit update duplicate show export_external_start export_external_check export_external_confirm download add_to_collection duplicate] }
 
       it { is_expected.to permit_only_actions(group_member_permissions) }
-      it { expect(task.lom_showable_by?(user)).to be true }
 
       context 'when user is group-admin' do
         let(:role) { :admin }
 
-        it { is_expected.to permit_only_actions(group_member_permissions + %i[destroy]) }
+        it { is_expected.to permit_only_actions(group_member_permissions + %i[destroy manage]) }
       end
     end
   end


### PR DESCRIPTION
Closes #1142

I also moved/refactored some other methods because they were only used in the task policy
- replaced showable_by?, updateable_by?, destroyable_by?, lom_showable_by? with their pundit equivalents
- replaced can_access with a new pundit manage? 
(I am not sure if we could just replace it with update? because previously can_access implied that a user can also destroy the task. Replacing can_access with destroy? did not seem very readable though because we actually want to test if a user has full control over the task and not if he/she can destroy it. Because destroy? is the highest permission possible can_access and destroy? are equivalent but for users that dont know that this might be confusing to read. This is why I thought a manage? permission could be used in these cases where we want to test for full control over the task)
- removed/replaced author? because it was only used in the task policy
- moved and renamed in_same_group?, in_same_group_member? and in_same_group_admin? to the policy because they are only used there. However I could also see why it would make sense to have these in the model instead.

I hope you agree that these changes make sense.