### PR TITLE
Update webpack-dev-server default port to 3045

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant.configure(2) do |config|
   # Webpack Dev Server
   config.vm.network 'forwarded_port',
     host_ip: ENV.fetch('LISTEN_ADDRESS', '127.0.0.1'),
-    host: 3035,
-    guest: 3035
+    host: 3045,
+    guest: 3045
 
   config.vm.synced_folder '.', '/home/vagrant/codeharbor'
   config.vm.provision 'shell', path: 'provision/provision.vagrant.sh', privileged: false

--- a/config/content_security_policy.yml.ci
+++ b/config/content_security_policy.yml.ci
@@ -8,8 +8,8 @@ development:
   <<: *default
   # Allow the webpack-dev-server in development
   connect_src:
-    - http://localhost:3035
-    - ws://localhost:3035
+    - http://localhost:3045
+    - ws://localhost:3045
 
 
 production:

--- a/config/content_security_policy.yml.example
+++ b/config/content_security_policy.yml.example
@@ -16,8 +16,8 @@ development:
   <<: *default
   # Allow the webpack-dev-server in development
   connect_src:
-    - http://localhost:3035
-    - ws://localhost:3035
+    - http://localhost:3045
+    - ws://localhost:3045
 
 
 production:

--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -53,7 +53,7 @@ development:
   dev_server:
     https: false
     host: localhost
-    port: 3035
+    port: 3045
     # Hot Module Replacement updates modules while the application is running without a full reload
     # Used instead of the `hot` key in https://webpack.js.org/configuration/dev-server/#devserverhot
     hmr: false

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -191,7 +191,7 @@ This project uses [shakapacker](https://github.com/shakacode/shakapacker) to int
   yarn run webpack-dev-server
   ```
 
-This will launch a dedicated server on port 3035 (default setting) and allow incoming WebSocket connections from your browser.
+This will launch a dedicated server on port 3045 (default setting) and allow incoming WebSocket connections from your browser.
 
 2. Rails application:
 

--- a/docs/LOCAL_SETUP_VAGRANT.md
+++ b/docs/LOCAL_SETUP_VAGRANT.md
@@ -85,7 +85,7 @@ This project uses [shakapacker](https://github.com/shakacode/shakapacker) to int
   yarn run webpack-dev-server
   ```
 
-This will launch a dedicated server on port 3035 (default setting) and allow incoming WebSocket connections from your browser.
+This will launch a dedicated server on port 3045 (default setting) and allow incoming WebSocket connections from your browser.
 
 2. Rails application:
 


### PR DESCRIPTION
Previously, CodeOcean and CodeHarbor both used the same port 3035 for the webpack-dev-server. When running both projects side-by-side with dedicated webpack-dev-servers, this configuration clashed. Hence, these changes allow for a better alignment of both projects.

Important: A local copy of the `config/content_security_policy.yml` needs to be updated accordingly.