### PR TITLE
Resolve fixture_path deprecation warning in Rails 7.1

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures')
+  config.fixture_paths = [Rails.root.join('spec/fixtures')]
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
This PR resolves an open deprecation warnings:

- `Rails 7.1 has deprecated the singular fixture_path in favour of an array.You should migrate to plural` is resolved in the second commit aa575117a62dd8f23b9cf1cd582ab9347e45b6ae.