### PR TITLE
Use Webpack to deliver newest ACE editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'ace-rails-ap'
 gem 'acts-as-taggable-on'
 gem 'bcrypt'
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ace-rails-ap (4.5)
     actioncable (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -558,7 +557,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ace-rails-ap
   acts-as-taggable-on
   bcrypt
   better_errors

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,9 +11,6 @@
 // about supported directives.
 //
 //= require turbolinks
-//= require ace-rails-ap
-//= require ace/theme-monokai
-//= require ace/ext-options
 //= require nested_form_fields
 //
 // app/assets

--- a/app/assets/javascripts/editor.coffee
+++ b/app/assets/javascripts/editor.coffee
@@ -3,7 +3,6 @@ ready = ->
   initializeEditors()
 
 initializeAce = ->
-  ace.config.set 'basePath', '/assets/ace/'
   $(document).on 'fields_added.nested_form_fields', ->
     $ initializeEditors()
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -69,3 +69,10 @@ window.I18n = i18n;
 // Routes
 import * as Routes from 'routes.js.erb';
 window.Routes = Routes;
+
+// ACE editor
+import ace from 'ace-builds';
+import "ace-builds/esm-resolver";
+import "ace-builds/src-noconflict/ext-language_tools";
+import "ace-builds/src-noconflict/ext-modelist";
+window.ace = ace; // Publish ace in global namespace

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@sentry/browser": "^7.107.0",
     "@sentry/integrations": "^7.107.0",
     "@webpack-cli/serve": "^2.0.5",
+    "ace-builds": "^1.32.6",
     "babel-loader": "9.1.3",
     "bootstrap": "^5.3.3",
     "compression-webpack-plugin": "11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,6 +2310,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ace-builds@npm:^1.32.6":
+  version: 1.32.6
+  resolution: "ace-builds@npm:1.32.6"
+  checksum: 9b3ac9a500ab5ce779aed75bc0d799b57ddc24229f458a4c3541c35d2b23b51eec1cbb681335de42cac731883d52073540c52e93e2754d302ed9ed718e28cac4
+  languageName: node
+  linkType: hard
+
 "acorn-import-assertions@npm:^1.9.0":
   version: 1.9.0
   resolution: "acorn-import-assertions@npm:1.9.0"
@@ -2901,6 +2908,7 @@ __metadata:
     "@sentry/browser": "npm:^7.107.0"
     "@sentry/integrations": "npm:^7.107.0"
     "@webpack-cli/serve": "npm:^2.0.5"
+    ace-builds: "npm:^1.32.6"
     babel-loader: "npm:9.1.3"
     bootstrap: "npm:^5.3.3"
     compression-webpack-plugin: "npm:11.1.0"


### PR DESCRIPTION
With this commit, we change the delivery method for the ACE editor from the `ace-rails-ap` gem to using yarn and webpack. As a side-change, we also modify how the mode is selected through JavaScript instead of Ruby.

Through webpack, the `basePath` is automatically determined and working as expected without any manual intervention.

Besides refactoring the integration of ACE, this commit further resolves an issue where some files could not be fetched correctly in our production environment.

<hr>

This PR aligns with openHPI/codeocean#2144.