### PR TITLE
Disallowing group admins to destroy tasks they do not own

### DIFF
--- a/app/policies/task_policy.rb
+++ b/app/policies/task_policy.rb
@@ -46,9 +46,7 @@ class TaskPolicy < ApplicationPolicy
   end
 
   def destroy?
-    return false if @user.blank?
-
-    record_owner? || task_in_group_with_admin?(@user) || admin?
+    record_owner? || admin?
   end
 
   def manage?

--- a/spec/policies/task_policy_spec.rb
+++ b/spec/policies/task_policy_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe TaskPolicy do
       context 'when user is group-admin' do
         let(:role) { :admin }
 
-        it { is_expected.to permit_only_actions(group_member_permissions + %i[destroy manage]) }
+        it { is_expected.to permit_only_actions(group_member_permissions) }
       end
     end
   end


### PR DESCRIPTION
Closes #1213

I thought about whether we would need a button like "Remove from my groups" for group admins that removes the task from all groups the current user is an admin in or if we wanted the destroy button to behave like that instead of actually destroying the task. I decided against that because I think a "Remove from my groups" button might be a bit confusing given that "my groups" in this case only means groups the current user is admin in and also includes groups the current user did not originally create. Also this button would not add functionality because group admins can already remove tasks from their groups.
The second option of changing the behavior of the destroy button might also be a bit confusing because the button would not actually do what it says.