### PR TITLE
Rebrush frontend elements

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -185,19 +185,12 @@ table.vertical-table {
   width: 100%;
 
   .selected {
-    border-color: #7c7c7c;
-    z-index: 5;
-  }
-
-  .selected:hover {
-    border-color: #7c7c7c;
     background-color: #eeeeee;
   }
 
   a {
-    padding: 10px 70px 10px 70px;
+    padding: 10px 60px;
     background-color: #f5f5f5;
-    border: 2px #dddddd solid;
     display: inline-block;
   }
   a:hover,
@@ -208,7 +201,7 @@ table.vertical-table {
   }
 
   .nav-btn {
-    padding: 9px 15px;
+    padding: 10px 15px;
     border-color: #888888;
   }
   .nav-btn:hover,

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -30,11 +30,13 @@
   background-color: #f5f5f5;
   border: 1px #dddddd solid;
   border-radius: 2px;
-}
-.btn-main:hover {
-  color: #444444;
-  background-color: #e5e5e5;
-  border: 1px #dddddd solid;
+  &:hover,
+  &:active,
+  &.selected {
+    color: #444444;
+    background-color: #dddddd !important;
+    border: 1px #dddddd solid;
+  }
 }
 
 .btn-important {

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -18,7 +18,8 @@
 }
 
 .navbar-brand {
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     background-color: #f8f9fa;
   }
 }
@@ -28,7 +29,7 @@
   color: #444444;
   background-color: #f5f5f5;
   border: 1px #dddddd solid;
-  border-radius: 0px;
+  border-radius: 2px;
 }
 .btn-main:hover {
   color: #444444;

--- a/app/assets/stylesheets/collections.css.scss
+++ b/app/assets/stylesheets/collections.css.scss
@@ -11,8 +11,7 @@ $collection-color: #000080;
   margin-bottom: 40px;
 }
 .nav-container .nav-btn-collection {
-  padding: 9px 15px;
-  border-color: $collection-color;
+  padding: 10px 15px;
 }
 
 #share-menu {
@@ -47,11 +46,13 @@ $collection-color: #000080;
 
   // ui-sortable-helper is the class of the element being dragged in sortablejs
   // we are removing the border, background and the red X from tasks that are being dragged
-  .ui-sortable-helper{
+  .ui-sortable-helper {
     .row {
       border-bottom: none;
-      background: rgba(0,0,0,0);
+      background: rgba(0, 0, 0, 0);
     }
-    .fa-xmark{ display: none; }
+    .fa-xmark {
+      display: none;
+    }
   }
 }

--- a/app/assets/stylesheets/exercises.css.scss
+++ b/app/assets/stylesheets/exercises.css.scss
@@ -45,17 +45,14 @@ $exercise-color: #006600;
 
 .nav-container {
   button {
-    padding: 10px 70px 10px 70px;
+    padding: 10px 60px;
     background-color: #f5f5f5;
-    border: 2px #dddddd solid;
   }
   button:hover {
     background-color: #eeeeee;
-    border-width: 2px;
   }
   .nav-btn-exercise {
-    padding: 9px 15px;
-    border-color: $exercise-color;
+    padding: 10px 15px;
   }
 }
 

--- a/app/assets/stylesheets/groups.css.scss
+++ b/app/assets/stylesheets/groups.css.scss
@@ -6,9 +6,9 @@ $group-color: #660000;
 
 .nav-container {
   a {
-    padding: 10px 70px 10px 70px;
+    padding: 10px 60px;
     background-color: #f5f5f5;
-    border: 2px #dddddd solid;
+    border: 1px #dddddd solid;
     display: inline-block;
   }
   a:hover,
@@ -16,12 +16,10 @@ $group-color: #660000;
     background-color: #f0f0f0;
     color: black;
     text-decoration: none;
-    border-width: 2px;
   }
 
   .nav-btn-group {
-    padding: 9px 15px;
-    border-color: $group-color;
+    padding: 10px 15px;
   }
 }
 

--- a/app/assets/stylesheets/scaffolds.css.scss
+++ b/app/assets/stylesheets/scaffolds.css.scss
@@ -41,8 +41,9 @@ div {
   color: green;
 }
 
-.field_with_errors{
-  input,textarea {
+.field_with_errors {
+  input,
+  textarea {
     border-color: red;
   }
 }

--- a/app/assets/stylesheets/tasks.css.scss
+++ b/app/assets/stylesheets/tasks.css.scss
@@ -40,11 +40,7 @@
 }
 
 #import-task-button {
-  background-color: #d3d3d3;
-}
-
-#import-task-button:hover {
-  background-color: #d0d0d0;
+  background-color: #dddddd;
 }
 
 .inputfile {

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -16,14 +16,14 @@
               =< t('.button.new_task')
             = button_tag type: 'button', 'data-bs-toggle': 'dropdown', aria: {haspopup: "true", expanded: "false"}, class: 'btn btn-main nav-btn-exercise dropdown-toggle split' do
               span.caret
-            ul.dropdown-menu#xml-import
+            ul.dropdown-menu.rounded-0.shadow-sm#xml-import
               li.dropdown-header style="padding-left: 2px;"
                 = t('.button.import_zip')
               li
                 = file_field_tag 'task_import', accept: '.zip', class: 'inputfile'
-                .btn-group style="display:inline-flex"
-                  = label_tag 'task_import', t('.button.choose_file'), id: 'file-label', class: 'btn btn-light'
-                  = submit_tag t('common.button.import'), id: 'import-task-button', class: 'btn btn-light'
+                .btn-group.pb-2 style="display:inline-flex"
+                  = label_tag 'task_import', t('.button.choose_file'), id: 'file-label', class: 'btn btn-main'
+                  = submit_tag t('common.button.import'), id: 'import-task-button', class: 'btn btn-main'
 
   .row
     .col-md-12.my-4


### PR DESCRIPTION
This PR will be the base PR for all web frontend component makeover.


1. Simplify the look for tab-navbar in tasks, collections, and groups pages.

Before:
<img width="1341" alt="Screenshot 2024-03-08 at 09 58 16" src="https://github.com/openHPI/codeharbor/assets/4398374/06bad7e5-a606-4e5a-b8a4-0b01c5008619">

After:
<img width="1321" alt="Screenshot 2024-03-08 at 09 58 25" src="https://github.com/openHPI/codeharbor/assets/4398374/c84fde9c-df6c-4765-b95c-95414dd9b219">
