### PR TITLE
Fix Kramdown issues for task descriptions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,7 +46,12 @@ module ApplicationHelper
   end
 
   def render_markdown(markdown)
-    ActionController::Base.helpers.sanitize Kramdown::Document.new(markdown, input: 'GFM', hard_wrap: false).to_html.strip
+    ActionController::Base.helpers.sanitize Kramdown::Document.new(
+      markdown,
+      input: 'GFM',
+      hard_wrap: false,
+      smart_quotes: 'apos,apos,quot,quot'
+    ).to_html.strip
   end
 
   def row(options = {}, &block)

--- a/app/services/proforma_service/convert_proforma_task_to_task.rb
+++ b/app/services/proforma_service/convert_proforma_task_to_task.rb
@@ -43,7 +43,7 @@ module ProformaService
     end
 
     def description
-      Kramdown::Document.new(@proforma_task.description || '', html_to_native: true).to_kramdown.strip
+      Kramdown::Document.new(@proforma_task.description || '', html_to_native: true, line_width: -1).to_kramdown.strip
     end
 
     def files

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -17,3 +17,24 @@ module WillPaginate
     end
   end
 end
+
+# rubocop:disable all
+# To avoid Kramdown escaping symbols
+module Kramdown
+  module Converter
+    class Kramdown
+      def convert_text(el, opts)
+        if opts[:raw_text]
+          el.value
+        else
+          el.value.gsub(/\A\n/) do
+            opts[:prev] && opts[:prev].type == :br ? '' : "\n"
+          end.gsub(/\s+/, ' ').gsub(ESCAPED_CHAR_RE) do
+            $1 || !opts[:prev] || opts[:prev].type == :br ? "#{$1 || $2}" : $&
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable all

--- a/db/migrate/20240312201146_migrate_task_descriptions_fix_kramdown_quotes.rb
+++ b/db/migrate/20240312201146_migrate_task_descriptions_fix_kramdown_quotes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class MigrateTaskDescriptionsFixKramdownQuotes < ActiveRecord::Migration[7.1]
+  def up
+    Task.find_each do |task|
+      task.description = fix_kramdown_descriptions(task.description)
+      task.save!(touch: false)
+    end
+  end
+
+  def fix_kramdown_descriptions(string)
+    # removes double escapes of symbols and unnecessary newlines
+    Kramdown::Document.new(string, line_width: -1).to_kramdown.gsub(/\\([\\*_`\[\]\{"'|])/, '\1').strip
+  end
+end
+
+class Task < ApplicationRecord
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_12_165451) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_12_201146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -199,6 +199,17 @@ RSpec.describe TasksController do
           end
         end
       end
+
+      context 'when description contains quotes' do
+        # the quotes should render as normal quotes instead of ldquo and rdquo (see app/helpers/application_helper.rb:53)
+        let(:task) { create(:task, valid_attributes.merge(description:)) }
+        let(:description) { 'foo "bar" bla' }
+
+        it 'renders the quotes correctly' do
+          get_request
+          expect(response.body).to include(description)
+        end
+      end
     end
   end
 

--- a/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
@@ -90,6 +90,27 @@ RSpec.describe ProformaService::ConvertProformaTaskToTask do
           )
         end
       end
+
+      context 'with a p containing quotes' do
+        let(:description) { '<p>foo "bar" bla</p>' }
+
+        # quotes should not be escaped to easy copyability (see config/initializers/monkey_patches.rb:27)
+        it 'creates a task with a correct description' do
+          expect(convert_to_task_service).to have_attributes(
+            description: 'foo "bar" bla'
+          )
+        end
+      end
+
+      context 'with a long description' do
+        let(:description) { 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut' }
+
+        it 'creates a task with a correct description' do
+          expect(convert_to_task_service).to have_attributes(
+            description:
+          )
+        end
+      end
     end
 
     context 'with meta_data' do


### PR DESCRIPTION
fixed kramdown issues:
- escaping quotes while importing tasks (and converting descriptions to markdown)
- adding linebreaks to long descriptions

fixes #1095