### PR TITLE
Rebrush Advanced Search Elements

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -25,6 +25,15 @@
 }
 
 /* BUTTONS */
+.btn-light {
+  background-color: #ffffff;
+  border-color: #cccccc;
+  border-radius: 2px;
+  &:hover {
+    background-color: #dddddd;
+  }
+}
+
 .btn-main {
   color: #444444;
   background-color: #f5f5f5;
@@ -91,4 +100,16 @@ a.no-border:visited {
 
 .margin-right-5px {
   margin-right: 5px;
+}
+
+.input-group {
+  .custom-input {
+    border-radius: 2px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-color: #cccccc;
+    &::placeholder {
+      color: #d3d3d3;
+    }
+  }
 }

--- a/app/assets/stylesheets/buttons-and-controls.css.scss
+++ b/app/assets/stylesheets/buttons-and-controls.css.scss
@@ -64,8 +64,7 @@ input[type='radio']:checked + label {
   padding: 5px 15px;
 }
 
-.pagination .page-item,
-.btn-light {
+.pagination .page-item {
   background-color: #ffffff;
   border-color: #cccccc;
 }

--- a/app/assets/stylesheets/exercises.css.scss
+++ b/app/assets/stylesheets/exercises.css.scss
@@ -233,17 +233,15 @@ $exercise-color: #006600;
 .dropdown-content {
   display: none;
   width: 100%;
-  background-color: #f9f9f9;
+  background-color: #f8f9fa;
   border: 1px #cccccc solid;
   margin-top: -1px;
   padding: 6px 12px 6px 12px;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
-  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
-}
-
-.proglanguages {
-  width: 32%;
+  border-bottom-right-radius: 2px;
+  border-bottom-left-radius: 2px;
+  p {
+    margin-bottom: 5px;
+  }
 }
 
 .select2-search_field {
@@ -251,8 +249,18 @@ $exercise-color: #006600;
   font-size: 0.5em !important;
 }
 
-.select2-container .select2-selection--single {
-  height: 32px !important;
+.select2-selection {
+  border-radius: 2px;
+}
+
+.select2-container {
+  .select2-selection--single {
+    height: 32px !important;
+  }
+
+  [class^='select2-selection'] {
+    border-radius: 2px;
+  }
 }
 
 .toggle-next {

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -29,18 +29,18 @@
     .col-md-12.my-4
       .search-container
         .input-group
-          = f.search_field 'fulltext_search', class: 'form-control ransack-filter input-field-tag', placeholder: t('.search.placeholder')
+          = f.search_field 'fulltext_search', class: 'form-control ransack-filter input-field-tag custom-input', placeholder: t('.search.placeholder')
           = f.submit t('.search.label'), class: 'btn btn-light search-submit-button-tag'
           = submit_tag t('.search.reset'), id: 'reset-btn', type: 'button', name: nil, class: 'btn btn-light'
           = button_tag type: 'button', id: 'advanced', class: 'btn btn-light' do
             span
               => t('.search.advanced')
             span.fa-solid.fa-caret-down#drop style="color:#333333"
-        .dropdown-content.p-3
+        .dropdown-content.shadow-sm.p-4
           = hidden_field_tag 'advancedFilterActive', @advanced_filter_active.to_s
           = fields_for 'settings' do |advanced|
-            span.row.p-2
-              .order.col-4
+            span.row
+              .order.col-md-4.pt-3
                 p
                   b = t('.search.order')
                 .btn-group.btn-group-vertical[role="group"]
@@ -48,29 +48,29 @@
                     = sort_link(@search, :created_at, t('.search.creation_date'))
                   div
                     = sort_link(@search, :average_rating, t('.search.average_rating'))
-              .stars.col-4
+              .stars.col-md-4.pt-3
                 p
                   b = t('.search.min_stars')
                 div.form-group
                   = f.select 'min_stars', options_for_select(%w[0 1 2 3 4 5], selected: @min_stars), {}, class: 'form-control defaultSelect2 ransack-filter'
-              .proglanguages.col-4
+              .proglanguages.col-md-4.pt-3
                 p
                   b = ProgrammingLanguage.model_name.human(count: :many)
                 span.form-group
                   = f.collection_select :programming_language_id_in, ProgrammingLanguage.all, :id, :language_with_version, {}, {multiple: true, class: 'form-control language-box ransack-filter'}
-            span.row.p-2
-              .other.col-4
+            span.row.pb-2
+              .other.col-md-4.pt-3
                 p
                   b = t('common.created')
                 span.form-group
                   = f.select 'created_before_days', options_for_select({t('.search.all_time') => 0, t('.search.today') => 1, t('.search.last_week') => 7, t('.search.last_month') => 30}, selected: @created_before_days), {}, class: 'form-control defaultSelect2 ransack-filter'
-              .labels.col-4
+              .labels.col-md-4.pt-3
                 p
                   b = t('.search.has_all_labels')
                 span.form-group
                   = f.select 'has_all_labels', options_for_select(@req_labels.map { |l| [l.name, l.name, { label_color: l.color, label_font_color: l.font_color }] }, @req_labels.pluck(:name)), {}, { class: "labels-select2-tag form-control ransack-filter", multiple: true, "data-tags": false, style: "width: 100px;" }
               - if @visibility == :owner
-                .other.col-4
+                .other.col-md-4.pt-3
                   p
                     b = Task.human_attribute_name("access_level")
                   span.form-group


### PR DESCRIPTION
Rebrush the input group elements, including the advanced search container:
- Make the color and look unify with the new look
- Make adjustment for smaller screen

Before:
<img width="1349" alt="Screenshot 2024-03-25 at 21 08 20" src="https://github.com/openHPI/codeharbor/assets/4398374/92a3267a-f907-4c40-85ba-bd5b425ad017">

<img width="551" alt="Screenshot 2024-03-25 at 21 08 32" src="https://github.com/openHPI/codeharbor/assets/4398374/de3a01ee-b94d-4873-852f-53dfb6e5cb38">

After:
<img width="1359" alt="Screenshot 2024-03-25 at 21 07 38" src="https://github.com/openHPI/codeharbor/assets/4398374/c6a69e9a-5bbd-42e0-89b3-0d09d0e7ba25">
<img width="547" alt="Screenshot 2024-03-25 at 21 08 02" src="https://github.com/openHPI/codeharbor/assets/4398374/333b9e29-0958-468c-8252-ec909d0f50c4">
