### PR TITLE
Add ToastUi editor for markdown elements

### DIFF
--- a/app/assets/javascripts/markdown_editor.js
+++ b/app/assets/javascripts/markdown_editor.js
@@ -1,0 +1,58 @@
+/**
+ * ToastUi editor initializer
+ *
+ * This script transforms form textareas created with
+ * "MarkdownFormBuilder" into ToastUi markdown editors.
+ *
+ */
+
+const initializeMarkdownEditors = () => {
+  const editors = document.querySelectorAll(
+    '[data-behavior="markdown-editor-widget"]'
+  );
+
+  editors.forEach((editor) => {
+    const formInput = document.querySelector(`#${editor.dataset.id}`);
+    if (!editor || !formInput) return;
+
+    const toastEditor = new ToastUi({
+      el: editor,
+      initialValue: formInput.value,
+      placeholder: formInput.placeholder,
+      extendedAutolinks: true,
+      linkAttributes: {
+        target: "_blank",
+      },
+      previewHighlight: false,
+      height: "400px",
+      autofocus: false,
+      usageStatistics: false,
+      language: I18n.locale,
+      toolbarItems: [
+        ["heading", "bold", "italic"],
+        ["link", "quote", "code", "codeblock"],
+        ["ul", "ol"],
+      ],
+      initialEditType: "markdown",
+      events: {
+        change: () => {
+          // Keep real form <textarea> in sync
+          const content = toastEditor.getMarkdown();
+          formInput.value = content;
+        },
+      },
+    });
+
+    // Prevent user from drag'n'dropping images in the editor
+    toastEditor.removeHook("addImageBlobHook");
+
+    // Delegate focus from form input to toast ui editor
+    formInput.addEventListener("focus", () => {
+      toastEditor.focus();
+    });
+  });
+};
+
+$(document).on("turbolinks:load", function () {
+  initializeMarkdownEditors();
+});

--- a/app/assets/javascripts/markdown_editor.js
+++ b/app/assets/javascripts/markdown_editor.js
@@ -31,6 +31,7 @@ const initializeMarkdownEditors = () => {
       toolbarItems: [
         ["heading", "bold", "italic"],
         ["link", "quote", "code", "codeblock"],
+        ["image"],
         ["ul", "ol"],
       ],
       initialEditType: "markdown",
@@ -53,6 +54,21 @@ const initializeMarkdownEditors = () => {
   });
 };
 
+const disableImageUpload = () => {
+  const target = document.querySelector(".toastui-editor-popup");
+  if (!target) {
+    return;
+  }
+  // Reference:https://github.com/nhn/tui.editor/issues/1204#issuecomment-1068364431
+  const observer = new MutationObserver(() => {
+    target.querySelector('[aria-label="URL"]').click();
+    target.querySelector(".toastui-editor-tabs").style.display = "none";
+  });
+
+  observer.observe(target, {attributes: true, attributeFilter: ["style"]});
+};
+
 $(document).on("turbolinks:load", function () {
   initializeMarkdownEditors();
+  disableImageUpload();
 });

--- a/app/assets/javascripts/markdown_editor.js
+++ b/app/assets/javascripts/markdown_editor.js
@@ -6,6 +6,39 @@
  *
  */
 
+const BACKTICK = 192;
+// These counters can be global. Scoping them to each editor becomes redundant
+// since they are reset to this state when switching editors.
+// Read more: https://github.com/openHPI/codeocean/pull/2242#discussion_r1576617432
+let backtickPressedCount = 0;
+let justInsertedCodeBlock = false;
+
+const deleteSelection = (editor, count) => {
+  // The backtick is a so-called dead key, which is waiting for further input to be combined with.
+  // For example a backtick and the letter a are combined to à.
+  // When we remove a selection ending with a backtick, we want to clear the keyboard buffer, too.
+  // This ensures that typing a regular character a after this operation is not combined into à, but just inserted as a.
+  // This solution is taken from https://stackoverflow.com/a/72634132.
+  editor.blur();
+  setTimeout(() => editor.focus());
+  // Get current position
+  const selectionRange = editor.getSelection();
+  // Replace the previous `count` characters with an empty string.
+  // We use a replace function (rather than delete) to avoid issues with line breaks in ToastUi.
+  // Otherwise, a line break following the cursor position might still be displayed normally,
+  // but could be removed erroneously from the internal editor state.
+  // If this happens, code blocks ending with \n``` are not recognized correctly.
+  editor.replaceSelection(
+    "",
+    [selectionRange[0][0], selectionRange[0][1] - count],
+    [selectionRange[1][0], selectionRange[1][1]]
+  );
+};
+const resetCount = (withBlock = false) => {
+  backtickPressedCount = 0;
+  justInsertedCodeBlock = withBlock;
+};
+
 const initializeMarkdownEditors = () => {
   const editors = document.querySelectorAll(
     '[data-behavior="markdown-editor-widget"]'
@@ -40,6 +73,39 @@ const initializeMarkdownEditors = () => {
           // Keep real form <textarea> in sync
           const content = toastEditor.getMarkdown();
           formInput.value = content;
+        },
+        // Fix ToastUI editor bug preventing manual codeblock insertion:
+        // Manually inserting a codeblock adding three backticks and hitting enter
+        // is not functioning in the ToastUI editor due to an existing bug in the library.
+        // Therefore, this `keyup` handler implements a workaround to address the issue.
+        keyup: (_, event) => {
+          // Although the use of keyCode seems to be deprecated, the suggested alternatives (key or code)
+          // work inconsistently across browsers. Using keyCode works flawless for now.
+          // Read more: https://github.com/openHPI/codeocean/pull/2242#discussion_r1576675620
+          if (event.keyCode === BACKTICK) {
+            backtickPressedCount++;
+            if (backtickPressedCount === 2) {
+              // Remove the last two backticks and insert a code block
+              // The order of operations is important here: Inserting the code block first and then removing
+              // some backticks won't work, since this would infer with the internal ToastUi editor state.
+              // With the current solution, we don't mingle with the code block inserted by ToastUi at all.
+              deleteSelection(toastEditor, 2);
+              toastEditor.exec("codeBlock");
+              resetCount(true);
+            }
+          } else if (backtickPressedCount === 1 && justInsertedCodeBlock) {
+            // We want to improve the usage of our code block fix with the following mechanism.
+            // Usually, three backticks are required to start a code block.
+            // However, with our workaround only two backticks are required.
+            // Out of habit, however, users might still enter three backticks at once,
+            // not noticing that the code block was already inserted after the second one.
+            // Thus, we remove one additional backtick entered after starting a code block through our fix.
+            deleteSelection(toastEditor, 1);
+            resetCount();
+          } else {
+            // If any other key is pressed, reset the count
+            resetCount();
+          }
         },
       },
     });

--- a/app/assets/javascripts/markdown_editor.js
+++ b/app/assets/javascripts/markdown_editor.js
@@ -24,7 +24,7 @@ const initializeMarkdownEditors = () => {
         target: "_blank",
       },
       previewHighlight: false,
-      height: "400px",
+      height: "300px",
       autofocus: false,
       usageStatistics: false,
       language: I18n.locale,
@@ -43,6 +43,8 @@ const initializeMarkdownEditors = () => {
         },
       },
     });
+
+    setResizeBtn(formInput, toastEditor);
 
     // Prevent user from drag'n'dropping images in the editor
     toastEditor.removeHook("addImageBlobHook");
@@ -66,6 +68,48 @@ const disableImageUpload = () => {
   });
 
   observer.observe(target, {attributes: true, attributeFilter: ["style"]});
+};
+
+const hasScrollBar = (el) => el.scrollHeight > el.clientHeight;
+const toggleScrollbarModifier = (btn, el) => {
+  if (el.clientHeight === 0) return;
+  btn.classList.toggle(
+    "markdown-editor__resize-btn--with-scrollbar",
+    hasScrollBar(el)
+  );
+};
+const setResizeBtn = (formInput, editor) => {
+  const resizeBtn = document.querySelector(`#${formInput.id}-resize`);
+  if (!resizeBtn) return;
+
+  const editorTextArea = editor
+    .getEditorElements()
+    .mdEditor.querySelector('[contenteditable="true"]');
+
+  toggleScrollbarModifier(resizeBtn, editorTextArea);
+  new MutationObserver(() => {
+    toggleScrollbarModifier(resizeBtn, editorTextArea);
+  }).observe(editorTextArea, {
+    attributes: true,
+  });
+
+  resizeBtn.addEventListener("click", () => {
+    const height = editor.getHeight();
+
+    if (height && height === "300px") {
+      editor.setHeight("auto");
+      editor.setMinHeight("400px");
+      resizeBtn.classList.add("markdown-editor__resize-btn--collapse");
+      resizeBtn.title = I18n.t("application.markdown_editor.collapse");
+      resizeBtn.ariaLabel = I18n.t("application.markdown_editor.collapse");
+    } else {
+      editor.setHeight("300px");
+      editor.setMinHeight("300px");
+      resizeBtn.classList.remove("markdown-editor__resize-btn--collapse");
+      resizeBtn.title = I18n.t("application.markdown_editor.expand");
+      resizeBtn.ariaLabel = I18n.t("application.markdown_editor.expand");
+    }
+  });
 };
 
 $(document).on("turbolinks:load", function () {

--- a/app/assets/stylesheets/scaffolds.css.scss
+++ b/app/assets/stylesheets/scaffolds.css.scss
@@ -21,6 +21,13 @@ pre {
   font-size: 12px;
 }
 
+blockquote {
+  border-left: 4px solid var(--bs-secondary-bg);
+  color: var(--bs-secondary-text-emphasis);
+  margin: 14px 0;
+  padding: 0 16px;
+}
+
 a {
   color: #000000;
 

--- a/app/helpers/markdown_form_builder.rb
+++ b/app/helpers/markdown_form_builder.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/HelperInstanceVariable
+class MarkdownFormBuilder < SimpleForm::FormBuilder
+  def markdown(method, args = {})
+    # Adopt simple form builder
+    @attribute_name = method
+    @input_html_options = args[:input_html]
+
+    @template.capture do
+      @template.concat form_textarea
+      @template.concat @template.tag.div(class: 'markdown-editor', data: {behavior: 'markdown-editor-widget', id: label_target})
+    end
+  end
+
+  private
+
+  def form_textarea
+    @template.text_area @object_name, @attribute_name,
+      **(@input_html_options || {}),
+      id: label_target,
+      class: 'd-none'
+  end
+
+  def base_id
+    options[:markdown_id_suffix] || @attribute_name
+  end
+
+  def label_target
+    "markdown-input-#{base_id}"
+  end
+end
+# rubocop:enable Rails/HelperInstanceVariable

--- a/app/helpers/markdown_form_builder.rb
+++ b/app/helpers/markdown_form_builder.rb
@@ -9,7 +9,7 @@ class MarkdownFormBuilder < SimpleForm::FormBuilder
 
     @template.capture do
       @template.concat form_textarea
-      @template.concat @template.tag.div(class: 'markdown-editor', data: {behavior: 'markdown-editor-widget', id: label_target})
+      @template.concat toast_ui_editor
     end
   end
 
@@ -20,6 +20,18 @@ class MarkdownFormBuilder < SimpleForm::FormBuilder
       **(@input_html_options || {}),
       id: label_target,
       class: 'd-none'
+  end
+
+  def toast_ui_editor
+    @template.tag.div(class: 'markdown-editor__wrapper') do
+      @template.concat @template.tag.div(class: 'markdown-editor', data: {behavior: 'markdown-editor-widget', id: label_target})
+      @template.concat resize_btn
+    end
+  end
+
+  def resize_btn
+    @template.tag.button(class: 'markdown-editor__resize-btn fa-solid', type: 'button', id: "#{label_target}-resize",
+      title: I18n.t(:'application.markdown_editor.expand'), aria_label: I18n.t(:'application.markdown_editor.expand'))
   end
 
   def base_id

--- a/app/javascript/toast-ui.js
+++ b/app/javascript/toast-ui.js
@@ -1,0 +1,7 @@
+/* eslint no-console:0 */
+
+// JS
+import ToastUi from "@toast-ui/editor";
+// Import German locales (english ones are included by default)
+import "@toast-ui/editor/dist/i18n/de-de";
+window.ToastUi = ToastUi

--- a/app/javascript/toast-ui.scss
+++ b/app/javascript/toast-ui.scss
@@ -1,0 +1,71 @@
+@import "@toast-ui/editor/dist/toastui-editor.css";
+@import "@toast-ui/editor/dist/theme/toastui-editor-dark.css";
+
+.markdown-editor {
+  * {
+    box-sizing: content-box;
+  }
+}
+
+// /*------------------------------------*\
+//     $ToastUI overrides
+// \*------------------------------------*/
+
+// Overrides for the preview section to match real output styles
+.toastui-editor-contents {
+  font-size: 14px;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0.5em 0 0.5em 0;
+    padding: 0;
+    border-bottom: 0;
+    font-weight: normal;
+  }
+
+  blockquote {
+    border-left: 4px solid var(--bs-secondary-bg);
+    p {
+      color: var(--bs-secondary-text-emphasis);
+    }
+  }
+
+  ul > li::before {
+    content: none;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ul ul {
+    list-style-type: circle;
+  }
+
+  ol > li::before {
+    color: black;
+  }
+
+  code {
+    color: var(--bs-code-color);
+    background-color: transparent !important;
+  }
+
+  pre {
+    border: 1px solid var(--bs-border-color-translucent);
+  }
+
+  del {
+    color: var(--bs-secondary-color);
+  }
+}
+
+// Ensure multiline backquotes have same text color in "write" mode
+.toastui-editor-md-marked-text,
+.toastui-editor-md-block-quote {
+  color: var(--bs-secondary-text-emphasis);
+}

--- a/app/javascript/toast-ui.scss
+++ b/app/javascript/toast-ui.scss
@@ -5,6 +5,36 @@
   * {
     box-sizing: content-box;
   }
+
+  &__wrapper {
+    position: relative;
+  }
+
+  &__resize-btn {
+    box-sizing: border-box;
+    position: absolute;
+    bottom: 30px;
+    right: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--bs-secondary-text-emphasis);
+    z-index: 100;
+    &::after {
+      content: "\f065";
+    }
+    &--with-scrollbar {
+      right: 18px;
+    }
+    &--collapse {
+      right: 0;
+      &::after {
+        content: "\f066";
+      }
+    }
+    &:hover {
+      background: var(--bs-secondary-bg);
+    }
+  }
 }
 
 // /*------------------------------------*\

--- a/app/views/collections/_form.html.slim
+++ b/app/views/collections/_form.html.slim
@@ -1,4 +1,11 @@
-= form_for @collection do |f|
+- content_for :head do
+  // Force a full page reload, see https://github.com/turbolinks/turbolinks/issues/326.
+     Otherwise, code might not be highlighted correctly (race condition)
+  meta name='turbolinks-visit-control' content='reload'
+  - append_javascript_pack_tag('toast-ui')
+  - append_stylesheet_pack_tag('toast-ui')
+
+= form_for @collection, builder: MarkdownFormBuilder do |f|
   .mt-5
     = render('shared/form_errors', object: @collection)
     .form-group
@@ -7,7 +14,7 @@
         = f.text_field :title, class: 'form-control'
       .field-element
         = f.label :description, Collection.human_attribute_name('description'), class: 'form-label'
-        = f.text_area :description, class: 'form-control', rows: 10
+        = f.markdown :description
       .field-element
         = f.label :visibility_level, Collection.human_attribute_name('visibility_level'), class: 'form-label collection-edit-visibility'
         .radio-switch

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -2,10 +2,12 @@
   // Force a full page reload, see https://github.com/turbolinks/turbolinks/issues/326.
      Otherwise, code might not be highlighted correctly (race condition)
   meta name='turbolinks-visit-control' content='reload'
+  - append_javascript_pack_tag('toast-ui')
+  - append_stylesheet_pack_tag('toast-ui')
 
 .row
   .col-md-12.my-4
-    = simple_form_for @task, html: {class: 'project exercise-validation', multipart: true} do |f|
+    = simple_form_for @task, html: {class: 'project exercise-validation', multipart: true}, builder: MarkdownFormBuilder do |f|
       = render('shared/form_errors', object: @task)
       fieldset.form-group
         legend.toggle-next
@@ -25,7 +27,7 @@
 
           .field-element
             = f.label :description, Task.human_attribute_name('description'), class: 'form-label'
-            = f.text_area :description, class: 'form-control'
+            = f.markdown :description
 
       fieldset.form-group
         legend.toggle-next

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
     # Some dependencies add new styles to the DOM dynamically, requiring :unsafe-inline.
     # Currently, these include turbolinks, and vis.js.
     policy.style_src_elem       :self, :unsafe_inline, :report_sample
-    # We still use some inline styles within the application, and indirectly through d3.js.
+    # We still use some inline styles within the application, and through the ToastUi markdown editor.
     policy.style_src_attr       :unsafe_inline, :report_sample
     # The `style_src` directive is only a fallback for browsers not supporting `style_src_elem` and `style_src_attr`.
     policy.style_src            :self, :unsafe_inline, :report_sample

--- a/config/locales/de/views/application.yml
+++ b/config/locales/de/views/application.yml
@@ -11,6 +11,9 @@ de:
         header: Weitere Informationen
         link: Über CodeHarbor
       privacy_policy: Datenschutzerklärung
+    markdown_editor:
+      collapse: Editor zuklappen
+      expand: Editor aufklappen
     navigation:
       rails_admin: Rails Admin
     session:

--- a/config/locales/en/views/application.yml
+++ b/config/locales/en/views/application.yml
@@ -11,6 +11,9 @@ en:
         header: More Information
         link: About CodeHarbor
       privacy_policy: Privacy Policy
+    markdown_editor:
+      collapse: Collapse editor
+      expand: Expand editor
     navigation:
       rails_admin: Rails admin
     session:

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -35,6 +35,16 @@ const envConfig = module.exports = {
                     filename: 'icons/[hash].svg'
                 },
             },
+            // Extract ToastUi's inline PNGs to actual resources, similar to Bootstrap's SVGs.
+            // This removes the requirement for `data:` URLs in our CSP
+            {
+                mimetype: 'image/png',
+                scheme: 'data',
+                type: 'asset/resource',
+                generator: {
+                    filename: 'icons/[hash].png'
+                },
+            },
             erb,
             {
                 // Exclude non-JS file from select2-i18n, otherwise breaking our dynamic language lookup.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@popperjs/core": "^2.11.8",
     "@sentry/browser": "^7.112.2",
     "@sentry/integrations": "^7.112.2",
+    "@toast-ui/editor": "^3.2.2",
     "@webpack-cli/serve": "^2.0.5",
     "ace-builds": "^1.33.1",
     "babel-loader": "9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,6 +1858,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@toast-ui/editor@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@toast-ui/editor@npm:3.2.2"
+  dependencies:
+    dompurify: "npm:^2.3.3"
+    prosemirror-commands: "npm:^1.1.9"
+    prosemirror-history: "npm:^1.1.3"
+    prosemirror-inputrules: "npm:^1.1.3"
+    prosemirror-keymap: "npm:^1.1.4"
+    prosemirror-model: "npm:^1.14.1"
+    prosemirror-state: "npm:^1.3.4"
+    prosemirror-view: "npm:^1.18.7"
+  checksum: 10c0/f7b2be4d49e85bd9f6ef08e6a66a73ddbfecd5d3a4ca9f441635fc90c621360b1c69966bac9d34cd315879f387e925a2a33da485f473b8820944c5f9fd2503af
+  languageName: node
+  linkType: hard
+
 "@trysound/sax@npm:0.2.0":
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
@@ -2947,6 +2963,7 @@ __metadata:
     "@popperjs/core": "npm:^2.11.8"
     "@sentry/browser": "npm:^7.112.2"
     "@sentry/integrations": "npm:^7.112.2"
+    "@toast-ui/editor": "npm:^3.2.2"
     "@webpack-cli/serve": "npm:^2.0.5"
     ace-builds: "npm:^1.33.1"
     babel-loader: "npm:9.1.3"
@@ -3486,6 +3503,13 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^2.3.3":
+  version: 2.5.0
+  resolution: "dompurify@npm:2.5.0"
+  checksum: 10c0/637dcf3430f3fedf66b58f84fd59ea9b3615a19a6db5efe444c635b2473a77a345b31d7328b56dbc80f692791915ffd6049d69041ff013e33692fdb8b0d84e48
   languageName: node
   linkType: hard
 
@@ -5272,6 +5296,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"orderedmap@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "orderedmap@npm:2.1.1"
+  checksum: 10c0/8d7d266659d1828937046e8b2a7b5f75914e0391db985da0ca75cd2246cccbf6d6f3a0886aa2034da15ee4923e8c45f95f8b588f575f535f0adecdefccc54634
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -5843,6 +5874,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prosemirror-commands@npm:^1.1.9":
+  version: 1.5.2
+  resolution: "prosemirror-commands@npm:1.5.2"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.0.0"
+  checksum: 10c0/9ff0b525d4bc654ecd41a27f11d8aff52f719ea9a7da2587d9632cfc00bcac46ecc3be628623d1a768e3aa7c7ed2fe291326bb7d63b0a5c0814e53b0a6af5b35
+  languageName: node
+  linkType: hard
+
+"prosemirror-history@npm:^1.1.3":
+  version: 1.4.0
+  resolution: "prosemirror-history@npm:1.4.0"
+  dependencies:
+    prosemirror-state: "npm:^1.2.2"
+    prosemirror-transform: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.31.0"
+    rope-sequence: "npm:^1.3.0"
+  checksum: 10c0/46299435ac963d5626e6faaca292369b1ae1d8746a5039b63df3aeed767c58d797e7bcfda3b4429b828798f6818e36476cc669f37cb2a40689cb8bf2635984ce
+  languageName: node
+  linkType: hard
+
+"prosemirror-inputrules@npm:^1.1.3":
+  version: 1.4.0
+  resolution: "prosemirror-inputrules@npm:1.4.0"
+  dependencies:
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.0.0"
+  checksum: 10c0/8ec72b6c2982bbd9fd378e51d67c6424119d081a4dcdeff430ab58055596cf67b691a890f46f135746f4de9bc6a6afb6ef1c0596df13bd633997e32ba0a25ddf
+  languageName: node
+  linkType: hard
+
+"prosemirror-keymap@npm:^1.1.4":
+  version: 1.2.2
+  resolution: "prosemirror-keymap@npm:1.2.2"
+  dependencies:
+    prosemirror-state: "npm:^1.0.0"
+    w3c-keyname: "npm:^2.2.0"
+  checksum: 10c0/7aa28c731e00962c90c91361a3c9f7000f960870a1300f7477da8afa8fd1b9cce0b3b7ca483aaa5832fd0bf88b5ff081defc184592997b08980b9ab67eeddcb7
+  languageName: node
+  linkType: hard
+
+"prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.14.1, prosemirror-model@npm:^1.20.0":
+  version: 1.20.0
+  resolution: "prosemirror-model@npm:1.20.0"
+  dependencies:
+    orderedmap: "npm:^2.0.0"
+  checksum: 10c0/18fa7a7da6d10f6212c351ea7291e2ea750681fd04a608aee54ef2775c113f4a76b4ba9969925a8615c5345d3e50bbab48bc4ac142abfeeaf92883ada503ee30
+  languageName: node
+  linkType: hard
+
+"prosemirror-state@npm:^1.0.0, prosemirror-state@npm:^1.2.2, prosemirror-state@npm:^1.3.4":
+  version: 1.4.3
+  resolution: "prosemirror-state@npm:1.4.3"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.27.0"
+  checksum: 10c0/e34dc9b1a6b23c23265569b2c246aaef4a61353a5fd33e933b62528917603382271d9f7d5212094e8928dee9bb4827e25a583104d43745e6ab3b8cbde12170f5
+  languageName: node
+  linkType: hard
+
+"prosemirror-transform@npm:^1.0.0, prosemirror-transform@npm:^1.1.0":
+  version: 1.8.0
+  resolution: "prosemirror-transform@npm:1.8.0"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+  checksum: 10c0/20861fcb304cc68718e49be6c41f22505689e969507f1e9754bbdfedf98fc4059254a79e1659b930c13ca52c547d3449f1814263a7601aeea1c1c4dfedc80ac1
+  languageName: node
+  linkType: hard
+
+"prosemirror-view@npm:^1.18.7, prosemirror-view@npm:^1.27.0, prosemirror-view@npm:^1.31.0":
+  version: 1.33.5
+  resolution: "prosemirror-view@npm:1.33.5"
+  dependencies:
+    prosemirror-model: "npm:^1.20.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.1.0"
+  checksum: 10c0/e334ea6bf776e78be6ece96d8fde9605667b6ab6bd171641aff00dd4c6ccf633f0f87aecc1cf994337440b6eefb49ef41fd3d99e8f2376a9207b95aae3e76c7b
+  languageName: node
+  linkType: hard
+
 "proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
@@ -6088,6 +6202,13 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 10c0/d50dbe724f33835decd88395b25ed35995077c60a50ae78ded06e0185418914e555817aad1b4243edbff2254548c2f6ad6f70cc850040bebb4da9e8cc016f586
+  languageName: node
+  linkType: hard
+
+"rope-sequence@npm:^1.3.0":
+  version: 1.3.4
+  resolution: "rope-sequence@npm:1.3.4"
+  checksum: 10c0/caa90be3d7a7cad155fb354a4679a1280dc9819c81bd319542a0d893a64e152284abb9cc1631d4351b328016a8d6c35a48c912234edfaf5173daef44b2e3609b
   languageName: node
   linkType: hard
 
@@ -6874,6 +6995,13 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f
+  languageName: node
+  linkType: hard
+
+"w3c-keyname@npm:^2.2.0":
+  version: 2.2.8
+  resolution: "w3c-keyname@npm:2.2.8"
+  checksum: 10c0/37cf335c90efff31672ebb345577d681e2177f7ff9006a9ad47c68c5a9d265ba4a7b39d6c2599ceea639ca9315584ce4bd9c9fbf7a7217bfb7a599e71943c4c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?

This PR integrates the ToastUi library and uses it in all forms where markdown editors are required (task descriptions and collection descriptions). Hence, this PR relates to #1114 and improves the editor experience for those attributes currently relying on Markdown. All code changes are based on the great work done by @JuliaCasamitjana with openHPI/codeocean#2242.

|light mode|
|--|
| <img width="1318" alt="Bildschirmfoto 2024-04-24 um 10 20 28" src="https://github.com/openHPI/codeharbor/assets/7300329/0c35e069-c6de-4f9b-8502-bb813fb77e37"> |

Note: There are three open bugs affecting the ToastUI preview:
- **WYSIWYG for HTML code blocks in lists**: https://github.com/nhn/tui.editor/issues/3240: Switching to WYSIWYG mode with a document that is written in HTML and uses a list with multi line code blocks renders an exception.
- **Referenced links**: https://github.com/nhn/tui.editor/issues/1635: Enabling the option `referenceDefinition` to support such links breaks the preview functionality. It has to be disabled.
- **Softbreak**: https://github.com/nhn/tui.editor/issues/485: A line break should be treated as a soft line break in the GFM specification. The ToastUi preview treats it like a hard break:

Current behaviour with such bugs:
|editor|real output|
|--|--|
| ![321616362-3ac4bc6f-d22d-4209-8b83-df3b34e1e598](https://github.com/openHPI/codeharbor/assets/7300329/06d3e50b-1e34-40f8-8530-173f37e356df) |<img width="449" alt="Bildschirmfoto 2024-04-24 um 10 24 49" src="https://github.com/openHPI/codeharbor/assets/7300329/4e07e8de-578a-4cd5-89e3-dccea896ad83">|

## Decisions / Choices we made

- In Xikolo we solve the issues caused by these bugs by dynamically parsing the user content using a different parser ([`markdown-it`](https://github.com/markdown-it/markdown-it)) and replacing the contents of the toastUi preview accordingly on the fly. We did not include this workaround, but implementing a similar solution here wouldn't require significant additional effort if we prefer to adopt this somewhat hacky approach.
- While integrating ToastUi in CodeOcean, we found some severe bug affecting the input of codeblocks with <code>```</code>. The last commit ef77c47c5442fb16a1c26bd75261889f182d5cc8 implements a workaround for this bug.
