### PR TITLE
Proforma: add support for files that referenced multiple times

### DIFF
--- a/app/services/proforma_service/convert_proforma_task_to_task.rb
+++ b/app/services/proforma_service/convert_proforma_task_to_task.rb
@@ -34,7 +34,7 @@ module ProformaService
 
         tests:,
         model_solutions:,
-        files: files.values # this line has to be last, because tests and model_solutions have to remove their respective files first
+        files:
       )
     end
 
@@ -47,9 +47,7 @@ module ProformaService
     end
 
     def files
-      @files ||= @proforma_task.all_files.reject {|file| file.id == 'ms-placeholder-file' }.to_h do |task_file|
-        [task_file.id, file_from_proforma_file(task_file)]
-      end
+      @proforma_task.files.map {|task_file| file_from_proforma_file(task_file) }
     end
 
     def file_from_proforma_file(proforma_task_file)
@@ -86,7 +84,7 @@ module ProformaService
           test_type: test.test_type,
           meta_data: test.meta_data,
           configuration: test.configuration,
-          files: object_files(test)
+          files: test.files.map {|task_file| file_from_proforma_file(task_file) }
         )
       end
     end
@@ -112,7 +110,7 @@ module ProformaService
           xml_id: model_solution.id,
           description: model_solution.description,
           internal_description: model_solution.internal_description,
-          files: object_files(model_solution)
+          files: model_solution.files.map {|task_file| file_from_proforma_file(task_file) }
         )
       end
     end

--- a/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
@@ -213,11 +213,25 @@ RSpec.describe ProformaService::ConvertProformaTaskToTask do
         end
       end
 
-      context 'when file is a model-solution-placeholder (needed by proforma until issue #5 is resolved)' do
-        let(:file) { ProformaXML::TaskFile.new(id: 'ms-placeholder-file') }
+      context 'when file is used by multiple tests' do
+        let(:file) do
+          ProformaXML::TaskFile.new(
+            id: 'id',
+            content: 'very generic content',
+            filename: 'multi_referenced_file.txt',
+            used_by_grader: false,
+            visible:,
+            usage_by_lms:,
+            binary:,
+            internal_description: 'internal_description',
+            mimetype:
+          )
+        end
 
-        it 'leaves files empty' do
-          expect(convert_to_task_service.files).to be_empty
+        let(:tests) { [ProformaXML::Test.new(files: [file]), ProformaXML::Test.new(files: [file])] }
+
+        it 'creates separate copies of referenced file with correct attributes' do
+          expect(convert_to_task_service.tests[0].files[0]).to have_attributes(convert_to_task_service.tests[1].files[0].attributes).and not_eql convert_to_task_service.tests[1].files[0]
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ require 'pundit/matchers'
 RSpec::Matchers.define_negated_matcher :avoid_change, :change
 RSpec::Matchers.define_negated_matcher :not_include, :include
 RSpec::Matchers.define_negated_matcher :not_have_attributes, :have_attributes
+RSpec::Matchers.define_negated_matcher :not_eql, :eql
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
File in ProformaXML can be referenced multiple times. The old implementation prevented importing tasks that made use of that feature.
This solution will create independent `TaskFile`s for every reference, since we current don't support multi-referenced files in codeharbor.
As discussed in #1249 