### PR TITLE
Fix empty blocks for `button_tag`

### DIFF
--- a/app/views/tasks/_import_export_dialog.html.slim
+++ b/app/views/tasks/_import_export_dialog.html.slim
@@ -4,7 +4,8 @@
       .modal-header
         h4.modal-title
           = title
-        = button_tag class: 'btn-close', 'data-bs-dismiss': 'modal'
+        = button_tag class: 'btn-close', 'data-bs-dismiss': 'modal' do
+          span.visually-hidden = t('common.button.close')
       .modal-body#import-export-modal-body
       .modal-footer
         = button_tag class: 'btn btn-important', 'data-bs-dismiss': 'modal' do

--- a/app/views/users/shared/_notification_modal.html.slim
+++ b/app/views/users/shared/_notification_modal.html.slim
@@ -4,7 +4,8 @@
       .modal-header
         h4.modal-title
           = title
-        = button_tag class: 'btn-close', data: {'bs-dismiss': 'modal'}
+        = button_tag class: 'btn-close', data: {'bs-dismiss': 'modal'} do
+          span.visually-hidden = t('common.button.close')
       .modal-body#notification-modal-body
         = yield
       .modal-footer


### PR DESCRIPTION
Without this fix, the options passed to the `button_tag` would be displayed on the website.

Fixes a regression introduced in b6b634eb

| Before | After |
|--------|--------|
| <img width="588" alt="Bildschirmfoto 2024-05-13 um 13 36 33" src="https://github.com/openHPI/codeharbor/assets/7300329/7b23047c-999f-4e7b-871c-5059746df5a5"> | <img width="516" alt="Bildschirmfoto 2024-05-13 um 13 35 29" src="https://github.com/openHPI/codeharbor/assets/7300329/6e7371af-97be-4e11-8dc4-d57a31990713"> |
| <img width="594" alt="Bildschirmfoto 2024-05-13 um 13 36 22" src="https://github.com/openHPI/codeharbor/assets/7300329/e949cb87-7a6b-445d-a03e-6f79143db713"> | <img width="511" alt="Bildschirmfoto 2024-05-13 um 13 35 43" src="https://github.com/openHPI/codeharbor/assets/7300329/dff875ec-b5a7-4afe-898f-b52ea5564389"> | 
