### PR TITLE
Add status group to User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
     :validatable
 
   validates :email, presence: true, uniqueness: {case_sensitive: false}
-  validates :first_name, :last_name, presence: true
+  validates :first_name, :last_name, :status_group, presence: true
   validates :password_set, inclusion: [true, false]
 
   has_many :tasks, dependent: :nullify
@@ -44,6 +44,9 @@ class User < ApplicationRecord
   validate :avatar_format, if: -> { avatar.attached? }
 
   default_scope { where(deleted: [nil, false]) }
+
+  # `Other` is a catch-all for any status that doesn't fit into the other categories and should be *last*.
+  enum status_group: {unknown: 0, learner: 2, educator: 3, other: 1}, _default: :unknown, _prefix: true
 
   # Called by Devise and overwritten for soft-deletion
   def destroy

--- a/app/views/application/_session.html.slim
+++ b/app/views/application/_session.html.slim
@@ -1,6 +1,7 @@
 - if user_signed_in?
   li.nav-item.dropdown
     a.nav-link.px-3.dropdown-toggle#navbarDropdown href='#' role='button' data-bs-toggle='dropdown' aria-expanded='false'
+      = render('shared/status_group_icon', user: current_user)
       => current_user.email
       - if current_user.unread_messages_count != '0'
         span.menu-number

--- a/app/views/shared/_status_group_icon.html.slim
+++ b/app/views/shared/_status_group_icon.html.slim
@@ -1,0 +1,8 @@
+- if user.status_group_educator?
+  i.fa-solid.fa-chalkboard-teacher
+- elsif user.status_group_learner?
+  i.fa-solid.fa-user-graduate
+- elsif user.status_group_other?
+  i.fa-solid.fa-user-tie
+- else
+  i.fa-solid.fa-user

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -28,6 +28,13 @@
           | :
         .col.row-value
           = t("users.role.#{@user.role}")
+      .row
+        .col-auto.row-label
+          = User.human_attribute_name('status_group')
+          | :
+        .col.row-value
+          = render('/shared/status_group_icon', user: @user)
+          = t("users.status_group.#{@user.status_group}")
 
 - if policy(@user).manage_accountlinks?
   .show-table

--- a/config/locales/de/models.yml
+++ b/config/locales/de/models.yml
@@ -90,6 +90,7 @@ de:
         last_name: Nachname
         password_set: Passwort gesetzt
         role: Rolle
+        status_group: Statusgruppe
       user_identity:
         omniauth_provider: OmniAuth-Anbieter
         provider_uid: Anbieter-UID
@@ -191,3 +192,8 @@ de:
     role:
       admin: Administrator:in
       user: Benutzer:in
+    status_group:
+      educator: Lehrende:r
+      learner: Lernende:r
+      other: Andere
+      unknown: Keine Angabe

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -90,6 +90,7 @@ en:
         last_name: Last name
         password_set: Passwort set
         role: Role
+        status_group: Status group
       user_identity:
         omniauth_provider: OmniAuth provider
         provider_uid: Provider UID
@@ -191,3 +192,8 @@ en:
     role:
       admin: Admin
       user: User
+    status_group:
+      educator: Educator
+      learner: Learner
+      other: Other
+      unknown: Not specified

--- a/db/migrate/20240531160738_add_status_group_to_user.rb
+++ b/db/migrate/20240531160738_add_status_group_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusGroupToUser < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :status_group, :integer, null: false, limit: 1, default: 0, comment: 'Used as enum in Rails'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_131313) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_31_160738) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -325,6 +325,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_131313) do
     t.datetime "locked_at"
     t.string "preferred_locale"
     t.boolean "password_set", default: true, null: false
+    t.integer "status_group", limit: 1, default: 0, null: false, comment: "Used as enum in Rails"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
In the future, access to some information on CodeHarbor might be restricted due to the status group. For example, only teachers could get access to model solutions.

Further, we need this extension for #1326 and the NBP project.