### PR TITLE
Ensure slim-lint annotations are always uploaded in the main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Upload slim-lint results as GitHub annotations
         uses: lcollins/checkstyle-github-action@v3.0.0
         # Only create GitHub annotations for the main repo (disable for forks):
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           name: Slim-Lint Report
           title: Analyze Slim templates for linting issues


### PR DESCRIPTION
In [this action run](https://github.com/openHPI/codeharbor/actions/runs/9321858461/job/25661891189), I learned that the current setup would not upload slim-lint results, since the slim-lint job previously failed. This PR fixes that erroneous behavior.

When applying this PR, the annotations work as expected:

<img width="1366" alt="Bildschirmfoto 2024-05-31 um 19 33 30" src="https://github.com/openHPI/codeharbor/assets/7300329/fd2e7598-ed28-438f-9e75-8d6e56ae1595">