### PR TITLE
task import: handle errors during import better

### DIFF
--- a/app/assets/javascripts/flash_message.coffee
+++ b/app/assets/javascripts/flash_message.coffee
@@ -1,7 +1,7 @@
 show_ajax_message = (msg, type) ->
   cls = 'alert-success' if type == 'notice'
   cls = 'alert-danger' if type == 'alert'
-  $("#flash-message").html "<div id='flash-#{type}' class='alert #{cls}'>#{msg}</div>"
+  $("#flash-message").html "<div id='flash-#{type}' class='alert flash #{cls} my-2 alert-dismissible fade show'><p class='mb-0' id='flash-notice'>#{decodeURIComponent(msg)}</p><button aria-label='Close' class='btn-close' data-bs-dismiss='alert' type='button'></button></div>"
   $("#flash-#{type}").delay(6000).slideUp 'medium'
 
 $(document).ajaxComplete (event, request) ->
@@ -11,6 +11,5 @@ $(document).ajaxComplete (event, request) ->
 
 ready = ->
   $('#flash-message').children().first().delay(5000).slideUp 'medium'
-
 
 $(document).on('turbolinks:load', ready)

--- a/app/assets/javascripts/tasks_import.coffee
+++ b/app/assets/javascripts/tasks_import.coffee
@@ -34,9 +34,6 @@ importStart = () ->
     data: formData,
     processData: false,
     contentType: false,
-    success: (response) ->
-      if response.status == 'failure'
-        alert(response.message)
     error: (_xhr, _textStatus, message) ->
       alert("#{I18n.t('common.javascripts.error')}: #{message}")
   })

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -101,7 +101,7 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
       format.js { render layout: false }
     end
   rescue ProformaXML::ProformaError => e
-    messages = JSON.parse(e.message).map {|message| t("proforma_errors.#{message}") }.join(', ')
+    messages = prettify_import_errors(e)
     flash[:alert] = messages
     render json: {
       status: 'failure',
@@ -220,6 +220,13 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   private
+
+  def prettify_import_errors(error)
+    message = "#{t('proforma_errors.import')}<br>"
+    message + JSON.parse(error.message).map do |msg|
+                t("proforma_errors.#{msg}", default: t('proforma_errors.import_default', error: msg))
+              end.join('<br>')
+  end
 
   def load_and_authorize_task
     @task = Task.find(params[:id])

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -224,7 +224,7 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
   def prettify_import_errors(error)
     message = "#{t('proforma_errors.import')}<br>"
     message + JSON.parse(error.message).map do |msg|
-                t("proforma_errors.#{msg}", default: t('proforma_errors.import_default', error: msg))
+                t("proforma_errors.#{msg}", default: msg)
               end.join('<br>')
   end
 

--- a/config/locales/de/controllers/tasks.yml
+++ b/config/locales/de/controllers/tasks.yml
@@ -10,7 +10,7 @@ de:
       error: 'Der Export der Aufgabe (%{title}) ist fehlgeschlagen. <br> Fehler: %{error}'
       success: Aufgabe (%{title}) erfolgreich exportiert.
     import:
-      internal_error: Bei der Importierung der Aufgabe ist ein interner Fehler aufgetreten.
+      internal_error: Beim Import dieser Aufgabe ist auf CodeHarbor ein interner Fehler aufgetreten.
     import_confirm:
       error: 'Der Import der Aufgabe (%{title}) ist fehlgeschlagen. <br> Fehler: %{error}'
       success: Aufgabe (%{title}) erfolgreich importiert.

--- a/config/locales/de/controllers/tasks.yml
+++ b/config/locales/de/controllers/tasks.yml
@@ -9,15 +9,17 @@ de:
     export_external_confirm:
       error: 'Der Export der Aufgabe (%{title}) ist fehlgeschlagen. <br> Fehler: %{error}'
       success: Aufgabe (%{title}) erfolgreich exportiert.
+    import:
+      internal_error: Bei der Importierung der Aufgabe ist ein interner Fehler aufgetreten.
     import_confirm:
       error: 'Der Import der Aufgabe (%{title}) ist fehlgeschlagen. <br> Fehler: %{error}'
       success: Aufgabe (%{title}) erfolgreich importiert.
     import_external:
-      internal_error: Bei der Importierung der Aufgabe ist ein interner Fehler aufgetreten.
       invalid: Ungültige Aufgabe
       success: Erfolg
     import_start:
       choose_file_error: Sie müssen eine Datei auswählen.
+      error: 'Der Import konnte nicht gestartet werden. <br> Fehler: %{error}'
     proforma_service:
       convert_zip_to_proforma_tasks:
         nested_too_deep: Die ZIP-Datei ist zu tief verschachtelt.

--- a/config/locales/de/proforma_errors.yml
+++ b/config/locales/de/proforma_errors.yml
@@ -1,0 +1,4 @@
+---
+de:
+  proforma_errors:
+    version not supported: Die Version dieses ProformaXML Dokuments wird nicht unterstützt

--- a/config/locales/de/proforma_errors.yml
+++ b/config/locales/de/proforma_errors.yml
@@ -1,4 +1,7 @@
 ---
 de:
   proforma_errors:
-    version not supported: Die Version dieses ProformaXML Dokuments wird nicht unterstützt
+    import: Es ist ein Fehler beim Importieren der ProformaXML ZIP-Datei aufgetreten.
+    import_default: "%{error}"
+    no task_xml found: Es konnte keine task.xml in der ZIP-Datei gefunden werden.
+    version not supported: Die Version dieses ProformaXML Dokuments wird nicht unterstützt.

--- a/config/locales/de/proforma_errors.yml
+++ b/config/locales/de/proforma_errors.yml
@@ -2,6 +2,5 @@
 de:
   proforma_errors:
     import: Es ist ein Fehler beim Importieren der ProformaXML ZIP-Datei aufgetreten.
-    import_default: "%{error}"
     no task_xml found: Es konnte keine task.xml in der ZIP-Datei gefunden werden.
     version not supported: Die Version dieses ProformaXML Dokuments wird nicht unterstützt.

--- a/config/locales/en/controllers/tasks.yml
+++ b/config/locales/en/controllers/tasks.yml
@@ -9,15 +9,17 @@ en:
     export_external_confirm:
       error: 'Export of task (%{title}) failed. <br> Error: %{error}'
       success: Task (%{title}) successfully exported.
+    import:
+      internal_error: An internal error occurred on CodeHarbor while importing the exercise.
     import_confirm:
       error: 'Import of task (%{title}) failed. <br> Error: %{error}'
       success: Task (%{title}) successfully imported.
     import_external:
-      internal_error: An internal error occurred on CodeHarbor while importing the exercise.
       invalid: Invalid exercise
       success: success
     import_start:
       choose_file_error: You need to choose a file.
+      error: 'Import of task could not be started. <br> Error: %{error}'
     proforma_service:
       convert_zip_to_proforma_tasks:
         nested_too_deep: ZIP is nested too deep.

--- a/config/locales/en/proforma_errors.yml
+++ b/config/locales/en/proforma_errors.yml
@@ -1,4 +1,7 @@
 ---
 en:
   proforma_errors:
-    version not supported: The version of this ProformaXML document is not supported
+    import: An error occurred while importing your ProformaXML ZIP file.
+    import_default: "%{error}"
+    no task_xml found: No task.xml could be found in the supplied ZIP file.
+    version not supported: The version of this ProformaXML document is not supported.

--- a/config/locales/en/proforma_errors.yml
+++ b/config/locales/en/proforma_errors.yml
@@ -2,6 +2,5 @@
 en:
   proforma_errors:
     import: An error occurred while importing your ProformaXML ZIP file.
-    import_default: "%{error}"
     no task_xml found: No task.xml could be found in the supplied ZIP file.
     version not supported: The version of this ProformaXML document is not supported.

--- a/config/locales/en/proforma_errors.yml
+++ b/config/locales/en/proforma_errors.yml
@@ -1,0 +1,4 @@
+---
+en:
+  proforma_errors:
+    version not supported: The version of this ProformaXML document is not supported

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -722,7 +722,7 @@ RSpec.describe TasksController do
     context 'when zip_file is submitted' do
       let(:zip_file) {}
 
-      it 'renders correct json' do
+      it 'renders correct JSON' do
         post_request
         expect(JSON.parse(response.body, symbolize_names: true)).to eql({status: 'failure', message: 'You need to choose a file.'})
       end
@@ -731,7 +731,7 @@ RSpec.describe TasksController do
     context "when zip_file is 'undefined'" do
       let(:zip_file) { 'undefined' }
 
-      it 'renders correct json' do
+      it 'renders correct JSON' do
         post_request
         expect(JSON.parse(response.body, symbolize_names: true)).to eql({status: 'failure', message: 'You need to choose a file.'})
       end
@@ -742,7 +742,7 @@ RSpec.describe TasksController do
         allow(ProformaService::CacheImportFile).to receive(:call).and_raise(ProformaXML::ProformaError.new(['version not supported']))
       end
 
-      it 'renders correct json' do
+      it 'renders correct JSON' do
         post_request
         expect(JSON.parse(response.body, symbolize_names: true)).to eql({status: 'failure', message: 'Import of task could not be started. <br> Error: An error occurred while importing your ProformaXML ZIP file.<br>The version of this ProformaXML document is not supported.', actions: ''})
       end
@@ -753,7 +753,7 @@ RSpec.describe TasksController do
         allow(ProformaService::CacheImportFile).to receive(:call).and_raise(StandardError)
       end
 
-      it 'renders correct json' do
+      it 'renders correct JSON' do
         post_request
         expect(JSON.parse(response.body, symbolize_names: true)).to eql({status: 'failure', message: 'An internal error occurred on CodeHarbor while importing the exercise.', actions: ''})
       end
@@ -779,7 +779,7 @@ RSpec.describe TasksController do
         expect { post_request }.to change(Task, :count).by(1)
       end
 
-      it 'renders correct json' do
+      it 'renders correct JSON' do
         post_request
         expect(response.body).to include('successfully imported').and(include(I18n.t('tasks.import_actions.button.show_task')).and(include('Hide')))
       end
@@ -787,7 +787,7 @@ RSpec.describe TasksController do
       context 'when import raises a validation error' do
         before { allow(ProformaService::ImportTask).to receive(:call).and_raise(ActiveRecord::RecordInvalid) }
 
-        it 'renders correct json' do
+        it 'renders correct JSON' do
           post_request
           expect(response.body).to include('failed').and(include('Record invalid').and(include('"actions":""')))
         end
@@ -798,7 +798,7 @@ RSpec.describe TasksController do
           allow(ProformaService::ImportTask).to receive(:call).and_raise(StandardError)
         end
 
-        it 'renders correct json' do
+        it 'renders correct JSON' do
           post_request
           expect(JSON.parse(response.body, symbolize_names: true)).to eql({status: 'failure', message: 'An internal error occurred on CodeHarbor while importing the exercise.', actions: ''})
         end
@@ -943,7 +943,7 @@ RSpec.describe TasksController do
     let(:uuid_found) { true }
     let(:error) { nil }
 
-    it 'renders the correct contents as json' do
+    it 'renders the correct contents as JSON' do
       post_request
       expect(response.parsed_body.symbolize_keys[:message]).to eq('message')
       expect(response.parsed_body.symbolize_keys[:actions]).to(
@@ -957,7 +957,7 @@ RSpec.describe TasksController do
     context 'when there is an error' do
       let(:error) { 'error' }
 
-      it 'renders the correct contents as json' do
+      it 'renders the correct contents as JSON' do
         post_request
         expect(response.parsed_body.symbolize_keys[:message]).to eq('message')
         expect(response.parsed_body.symbolize_keys[:actions]).to(
@@ -972,7 +972,7 @@ RSpec.describe TasksController do
     context 'when uuid_found is false' do
       let(:uuid_found) { false }
 
-      it 'renders the correct contents as json' do
+      it 'renders the correct contents as JSON' do
         post_request
         expect(response.parsed_body.symbolize_keys[:message]).to eq('message')
         expect(response.parsed_body.symbolize_keys[:actions]).to(

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe TasksController do
 
       it 'renders correct json' do
         post_request
-        expect(JSON.parse(response.body, symbolize_names: true)).to eql({status: 'failure', message: 'Import of task could not be started. <br> Error: The version of this ProformaXML document is not supported', actions: ''})
+        expect(JSON.parse(response.body, symbolize_names: true)).to eql({status: 'failure', message: 'Import of task could not be started. <br> Error: An error occurred while importing your ProformaXML ZIP file.<br>The version of this ProformaXML document is not supported.', actions: ''})
       end
     end
 


### PR DESCRIPTION
fixes #1091

removed unnecessary alerts and added more rescues