### PR TITLE
Migrate RailsAdmin assets to Shakapacker

### DIFF
--- a/app/javascript/rails_admin.js
+++ b/app/javascript/rails_admin.js
@@ -1,0 +1,1 @@
+import "rails_admin/src/rails_admin/base";

--- a/app/javascript/rails_admin.scss
+++ b/app/javascript/rails_admin.scss
@@ -1,0 +1,1 @@
+@import "rails_admin/src/rails_admin/styles/base";

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RailsAdmin.config do |config|
-  config.asset_source = :sprockets
+  config.asset_source = :webpacker
   ### Popular gems integration
 
   ## == Devise ==

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jquery-ujs": "^1.2.3",
     "mini-css-extract-plugin": "^2.9.0",
     "rails-erb-loader": "usabilityhub/rails-erb-loader#master",
+    "rails_admin": "3.1.2",
     "sass": "^1.77.5",
     "sass-loader": "^14.2.1",
     "select2": "^4.1.0-rc.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,7 +1306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.24.7, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:7.24.7, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.8.4":
   version: 7.24.7
   resolution: "@babel/runtime@npm:7.24.7"
   dependencies:
@@ -1362,10 +1362,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-free@npm:^6.5.2":
+"@fortawesome/fontawesome-free@npm:>=5.15.0 <7.0.0, @fortawesome/fontawesome-free@npm:^6.5.2":
   version: 6.5.2
   resolution: "@fortawesome/fontawesome-free@npm:6.5.2"
   checksum: 10c0/932a8119376eab45da6c0702e955dcea55b916bbd7e118a365a8b3356a6322e725536f28f78e039bd47f4e1650b69bf9a85c2e40d0fdd69f9f0c138a5ef07e67
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo-rails@npm:^7.1.0":
+  version: 7.3.0
+  resolution: "@hotwired/turbo-rails@npm:7.3.0"
+  dependencies:
+    "@hotwired/turbo": "npm:^7.3.0"
+    "@rails/actioncable": "npm:^7.0"
+  checksum: 10c0/1b2a5bc8767f0366c91a80a6bac178b8b02ca607add5b14b637f128d9ff08629bf3761931cc892acd46175782649ebdffa76dd45fc7e23f44bff8c06ca452d0b
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@hotwired/turbo@npm:7.3.0"
+  checksum: 10c0/be7d273808d64e06682f413ea007b555ecc0077cfd846754fe3b1bca06ca1b9473184d95528f7de0f3002bbc7895d58a067845ba363c549229c3bc5870c981e2
   languageName: node
   linkType: hard
 
@@ -1526,10 +1543,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@popperjs/core@npm:^2.11.8":
+"@popperjs/core@npm:^2.11.0, @popperjs/core@npm:^2.11.8":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10c0/4681e682abc006d25eb380d0cf3efc7557043f53b6aea7a5057d0d1e7df849a00e281cd8ea79c902a35a414d7919621fc2ba293ecec05f413598e0b23d5a1e63
+  languageName: node
+  linkType: hard
+
+"@rails/actioncable@npm:^7.0":
+  version: 7.1.3
+  resolution: "@rails/actioncable@npm:7.1.3"
+  checksum: 10c0/6019097498387a9c0684df0be380182820a0480173e05a5c5a830cef6cf3e40c9ec75b834af0396b0f57b4e658891c820163e84b9f2bd1ac293c90f5a12ce488
+  languageName: node
+  linkType: hard
+
+"@rails/ujs@npm:^6.1.4-1":
+  version: 6.1.7
+  resolution: "@rails/ujs@npm:6.1.7"
+  checksum: 10c0/c1cfa3baa4b5ca2aec0fe1f5197a429cd46c3edee844dd749ee35f28002c130d8e49ec194c8de57333dd24d258d6a002a943de9ae1f7658eef166ebc1a09a8b8
   languageName: node
   linkType: hard
 
@@ -2407,7 +2438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap@npm:^5.3.3":
+"bootstrap@npm:^5.1.3, bootstrap@npm:^5.3.3":
   version: 5.3.3
   resolution: "bootstrap@npm:5.3.3"
   peerDependencies:
@@ -2635,6 +2666,7 @@ __metadata:
     jquery-ujs: "npm:^1.2.3"
     mini-css-extract-plugin: "npm:^2.9.0"
     rails-erb-loader: "usabilityhub/rails-erb-loader#master"
+    rails_admin: "npm:3.1.2"
     sass: "npm:^1.77.5"
     sass-loader: "npm:^14.2.1"
     select2: "npm:^4.1.0-rc.0"
@@ -3537,6 +3569,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flatpickr@npm:^4.6.9":
+  version: 4.6.13
+  resolution: "flatpickr@npm:4.6.13"
+  checksum: 10c0/0e027e72a2ce1716840a8c0bf9094f48d2665dc3f3024bf9604810c5bd7dd94aa830b133c5b5cfc0c330fc88939f33b54c8714515957f9d194c3a3bb7f75a1e2
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.0.0":
   version: 1.15.6
   resolution: "follow-redirects@npm:1.15.6"
@@ -4185,7 +4224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jquery-ui@npm:^1.13.3":
+"jquery-ui@npm:^1.12.1, jquery-ui@npm:^1.13.3":
   version: 1.13.3
   resolution: "jquery-ui@npm:1.13.3"
   dependencies:
@@ -4203,7 +4242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jquery@npm:>=1.8.0 <4.0.0, jquery@npm:^3.7.1":
+"jquery@npm:>=1.8.0 <4.0.0, jquery@npm:^3.6.0, jquery@npm:^3.7.1":
   version: 3.7.1
   resolution: "jquery@npm:3.7.1"
   checksum: 10c0/808cfbfb758438560224bf26e17fcd5afc7419170230c810dd11f5c1792e2263e2970cca8d659eb84fcd9acc301edb6d310096e450277d54be4f57071b0c82d9
@@ -5524,6 +5563,23 @@ __metadata:
   peerDependencies:
     webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
   checksum: 10c0/89b7765d427256e19a2b9cb3f93ed61dfc81bf1658c505316b0e8d3af6f9c155715c2c1cb891c3b7bdad4b02e6d440d878aefeebd51496b45e91123f88392215
+  languageName: node
+  linkType: hard
+
+"rails_admin@npm:3.1.2":
+  version: 3.1.2
+  resolution: "rails_admin@npm:3.1.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.16.7"
+    "@fortawesome/fontawesome-free": "npm:>=5.15.0 <7.0.0"
+    "@hotwired/turbo-rails": "npm:^7.1.0"
+    "@popperjs/core": "npm:^2.11.0"
+    "@rails/ujs": "npm:^6.1.4-1"
+    bootstrap: "npm:^5.1.3"
+    flatpickr: "npm:^4.6.9"
+    jquery: "npm:^3.6.0"
+    jquery-ui: "npm:^1.12.1"
+  checksum: 10c0/f0146b5fd5aeb054979e26b2fdf603606f7dbb94c44dc930fff293f429f9a70d9c89a6dd8400f3dc25bcc0efe1971ccf872291dd752ad373a1baccb9207417dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves an issue with a strict CSP disabling inline `data` images. With Shakapacker and our current webpack config, we extract inline `data` images to dedicated files, thus resolving the issue.

Fixes [CODEHARBOR-FRONTEND-G](https://codeocean.sentry.io/issues/5438246269/)