### PR TITLE
Unify session access and always remove SAML information

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -28,7 +28,7 @@ module Users
         sign_in_and_redirect @user, event: :authentication
         # We use the configured OmniAuth camilization to include the user-facing name of the provider in the flash message
         set_flash_message(:notice, :success, kind: OmniAuth::Utils.camelize(provider)) if is_navigational_format?
-        session['omniauth_provider'] = provider
+        session[:omniauth_provider] = provider
       else
         if is_navigational_format? && @user.errors.any?
           # We show validation errors to the user, for example because required data from the IdP was missing
@@ -78,11 +78,11 @@ module Users
       # Prevent any further interaction with the given provider, as the user has deauthorized it.
       # This is necessary to avoid the user being redirected to the IdP after signing out.
       # In short: Once deauthorized, SLO is not enabled any longer for the provider..
-      return unless session['omniauth_provider'] == provider
+      return unless session[:omniauth_provider] == provider
 
-      session.delete('saml_uid')
-      session.delete('saml_session_index')
-      session.delete('omniauth_provider')
+      session.delete(:saml_uid)
+      session.delete(:saml_session_index)
+      session.delete(:omniauth_provider)
     end
 
     # More info at:

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -52,7 +52,10 @@ module Users
         return spslo_path_for(provider) if strategy_class.default_options.idp_slo_service_url
       end
 
-      # If SLO is not supported, we delegate the call to the parent
+      # If SLO is not supported, we first delete all information from the current session
+      # This is mainly done to remove the SAML information we stored before
+      session.clear
+      # Then, we delegate the call to the parent
       super
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -25,13 +25,13 @@ module Users
       #
       # Preserve the saml_uid, saml_session_index and omniauth_provider in the session
       # This is done by copying those and setting these after destroying the session (through `super`)
-      saml_uid = session['saml_uid']
-      saml_session_index = session['saml_session_index']
-      omniauth_provider = session['omniauth_provider']
+      saml_uid = session[:saml_uid]
+      saml_session_index = session[:saml_session_index]
+      omniauth_provider = session[:omniauth_provider]
       super do
-        session['saml_uid'] = saml_uid
-        session['saml_session_index'] = saml_session_index
-        session['omniauth_provider'] = omniauth_provider
+        session[:saml_uid] = saml_uid
+        session[:saml_session_index] = saml_session_index
+        session[:omniauth_provider] = omniauth_provider
       end
     end
 
@@ -43,8 +43,8 @@ module Users
     # end
 
     def after_sign_out_path_for(_)
-      provider = session['omniauth_provider']
-      if session['saml_uid'] && session['saml_session_index'] && provider
+      provider = session[:omniauth_provider]
+      if session[:saml_uid] && session[:saml_session_index] && provider
         provider_config = Devise.omniauth_configs[provider.to_sym]
         return super unless provider_config
 

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -113,22 +113,22 @@ RSpec.describe Users::OmniauthCallbacksController do
       let(:provider) { omniauth_provider }
 
       before do
-        session['omniauth_provider'] = provider
-        session['saml_uid'] = 'saml_uid'
-        session['saml_session_index'] = 'saml_session_index'
+        session[:omniauth_provider] = provider
+        session[:saml_uid] = 'saml_uid'
+        session[:saml_session_index] = 'saml_session_index'
         delete :deauthorize, params: {provider: omniauth_provider}
       end
 
       it 'does not remove the provider from the session' do
-        expect(session['omniauth_provider']).to eq provider
+        expect(session[:omniauth_provider]).to eq provider
       end
 
       it 'does not remove the saml_uid from the session' do
-        expect(session['saml_uid']).to eq 'saml_uid'
+        expect(session[:saml_uid]).to eq 'saml_uid'
       end
 
       it 'does not remove the saml_session_index from the session' do
-        expect(session['saml_session_index']).to eq 'saml_session_index'
+        expect(session[:saml_session_index]).to eq 'saml_session_index'
       end
     end
 
@@ -136,22 +136,22 @@ RSpec.describe Users::OmniauthCallbacksController do
       let(:provider) { 'another_provider' }
 
       before do
-        session['omniauth_provider'] = provider
-        session['saml_uid'] = 'saml_uid'
-        session['saml_session_index'] = 'saml_session_index'
+        session[:omniauth_provider] = provider
+        session[:saml_uid] = 'saml_uid'
+        session[:saml_session_index] = 'saml_session_index'
         delete :deauthorize, params: {provider: omniauth_provider}
       end
 
       it 'removes the provider from the session' do
-        expect(session['omniauth_provider']).to eq provider
+        expect(session[:omniauth_provider]).to eq provider
       end
 
       it 'removes the saml_uid from the session' do
-        expect(session['saml_uid']).to eq 'saml_uid'
+        expect(session[:saml_uid]).to eq 'saml_uid'
       end
 
       it 'removes the saml_session_index from the session' do
-        expect(session['saml_session_index']).to eq 'saml_session_index'
+        expect(session[:saml_session_index]).to eq 'saml_session_index'
       end
     end
 
@@ -161,15 +161,15 @@ RSpec.describe Users::OmniauthCallbacksController do
       end
 
       it 'does not add the provider to the session' do
-        expect(session['omniauth_provider']).to be_nil
+        expect(session[:omniauth_provider]).to be_nil
       end
 
       it 'does not add the saml_uid to the session' do
-        expect(session['saml_uid']).to be_nil
+        expect(session[:saml_uid]).to be_nil
       end
 
       it 'does not add the saml_session_index to the session' do
-        expect(session['saml_session_index']).to be_nil
+        expect(session[:saml_session_index]).to be_nil
       end
     end
 
@@ -203,22 +203,22 @@ RSpec.describe Users::OmniauthCallbacksController do
 
       context 'when session contains the provider' do
         before do
-          session['omniauth_provider'] = omniauth_provider
-          session['saml_uid'] = 'saml_uid'
-          session['saml_session_index'] = 'saml_session_index'
+          session[:omniauth_provider] = omniauth_provider
+          session[:saml_uid] = 'saml_uid'
+          session[:saml_session_index] = 'saml_session_index'
           delete :deauthorize, params: {provider: omniauth_provider}
         end
 
         it 'removes the provider from the session' do
-          expect(session['omniauth_provider']).to be_nil
+          expect(session[:omniauth_provider]).to be_nil
         end
 
         it 'removes the saml_uid from the session' do
-          expect(session['saml_uid']).to be_nil
+          expect(session[:saml_uid]).to be_nil
         end
 
         it 'removes the saml_session_index from the session' do
-          expect(session['saml_session_index']).to be_nil
+          expect(session[:saml_session_index]).to be_nil
         end
       end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::SessionsController do
+  render_views
+
+  describe '#destroy' do
+    context 'with SAML login' do
+      let(:omniauth_provider) { User.omniauth_providers.first.to_s }
+      let(:saml_uid) { 'saml_uid' }
+      let(:saml_session_index) { 'saml_session_index' }
+
+      before do
+        OmniAuth.config.test_mode = true
+        request.env['devise.mapping'] = Devise.mappings[:user]
+
+        # Add a new provider to the omniauth config and reload routes
+        Devise.omniauth :sso_callback, strategy_class: OmniAuth::Strategies::AbstractSaml
+        Rails.application.reload_routes!
+
+        session[:saml_uid] = saml_uid
+        session[:saml_session_index] = saml_session_index
+        session[:omniauth_provider] = omniauth_provider
+      end
+
+      after do
+        # Remove the provider from the omniauth config and reload routes
+        Devise.class_variable_set(:@@omniauth_configs, {}) # rubocop:disable Style/ClassVars
+        Rails.application.reload_routes!
+      end
+
+      context 'when SLO is supported' do
+        before do
+          options = OmniAuth::Strategy::Options.new(idp_slo_service_url: 'https://idp.example.com/slo')
+          allow(OmniAuth::Strategies::AbstractSaml).to receive(:default_options).and_return(options)
+        end
+
+        it 'redirects to the IdP SLO path' do
+          delete :destroy
+          expect(response).to redirect_to(controller.send(:spslo_path_for, omniauth_provider))
+        end
+
+        it 'preserves the SAML information in the session' do
+          delete :destroy
+          expect(session[:saml_uid]).to eq(saml_uid)
+          expect(session[:saml_session_index]).to eq(saml_session_index)
+          expect(session[:omniauth_provider]).to eq(omniauth_provider)
+        end
+      end
+
+      context 'when SLO is not supported' do
+        it 'redirects to the root path' do
+          delete :destroy
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'clears the session' do
+          delete :destroy
+          expect(session[:saml_uid]).to be_nil
+          expect(session[:saml_session_index]).to be_nil
+          expect(session[:omniauth_provider]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR:
- unifies the usage of the session keys to always use symbols
- removes the SAML information even if Single Log-Out is not supported by the provider

Reviewing commit-by-commit is recommended.

<hr>

The bug fixed with this PR is an error in our handling when Single Log-Out (SLO) is not supported. With CodeHarbor, SLO works as follows:
1. The user session is terminated first, i.e., logging the user out of their account. This is handled by devise and usually clears the session completely.
2. Then, the SAML SLO workflow is initialized, which redirects the user to the identity provider used during login. As a user can have multiple identity providers, we need to know which one (and some further SAML data). This is the data stored as `saml_uid`, `saml_session_index` and `omniauth_provider`.
3. The Identity Provider handles the logout request and _should_ redirect the user either to the next service or back to CodeHarbor.
4. Back on CodeHarbor, the SAML session is cleared, too, effectively finishing the logout request.

As you see, clearing the session first is not the smartest way to do regarding the SLO workflow, since some data is required in the second step. Hence, it would be enough to do clear the session in the forth steps. However, if the provider does not redirect back (which some won't) or something goes wrong, a user wouldn't have cleared their CodeHarbor session.

Therefore, we decided to "keep" the SAML session to the CodeHarbor session during the first step, allowing the remaining workflow to work. This data was removed during the forth step. At the time of implementation, every provider (including the SAML test IdP we used for development at that time) supported SLO, so that this worked. Now, the SAML Mock provider currently used doesn't support SLO, which effectively cut the process short and just "terminated" after the first step. This PR resolves said issue and ensures that a logout will clear the SAML session even if SLO is not supported.