### PR TITLE
Fix incorrect indention for status group icon

### DIFF
--- a/app/views/application/_session.html.slim
+++ b/app/views/application/_session.html.slim
@@ -2,7 +2,7 @@
   li.nav-item.dropdown
     a.nav-link.px-3.dropdown-toggle#navbarDropdown href='#' role='button' data-bs-toggle='dropdown' aria-expanded='false'
       = render('shared/status_group_icon', user: current_user)
-      => current_user.email
+      =<> current_user.email
       - if current_user.unread_messages_count != '0'
         span.menu-number
           = current_user.unread_messages_count

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -34,7 +34,7 @@
           | :
         .col.row-value
           = render('/shared/status_group_icon', user: @user)
-          = t("users.status_group.#{@user.status_group}")
+          =< t("users.status_group.#{@user.status_group}")
 
 - if policy(@user).manage_accountlinks?
   .show-table


### PR DESCRIPTION
When viewing the page in development mode, the file names of views are annotated. Since the icon is extracted into an own partial, it is followed by such a comment. This caused a correct indention, which was missing in production.

The relevant setting is `config.action_view.annotate_rendered_view_with_filenames`.

| Before | After |
|--------|--------|
| <img width="220" alt="Bildschirmfoto 2024-06-12 um 17 44 40" src="https://github.com/openHPI/codeharbor/assets/7300329/5581960d-3086-461f-a7af-cc45d04f0552"> | <img width="228" alt="Bildschirmfoto 2024-06-12 um 17 44 45" src="https://github.com/openHPI/codeharbor/assets/7300329/51b9c968-f8f3-4f58-9689-200db10b8676"> | 
