### PR TITLE
Reorder includes for `spec_helper` and `rails_helper`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,10 +4,14 @@
 ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../config/environment', __dir__)
+
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'rspec/rails'
+require 'pundit/matchers'
+require 'webmock/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,9 +24,6 @@ unless ENV.fetch('RUBYMINE_SIMPLECOV_COVERAGE_PATH', nil)
   SimpleCov.start('rails')
 end
 
-require 'webmock/rspec'
-require 'pundit/matchers'
-
 RSpec::Matchers.define_negated_matcher :avoid_change, :change
 RSpec::Matchers.define_negated_matcher :not_include, :include
 RSpec::Matchers.define_negated_matcher :not_have_attributes, :have_attributes


### PR DESCRIPTION
While working on #1463, I noticed some differences between CodeOcean and CodeHarbor. This PR aligns both code bases again with each other.