### PR TITLE
Remove obsolete string concatenation in headline

### DIFF
--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,5 +3,5 @@
     .col-md-12.pb-2.border-bottom
       .std-heading
         i.fa-regular.fa-file-lines
-        =< + t('.new_task')
+        =< t('.new_task')
 = render 'form'


### PR DESCRIPTION
The formerly used `+` has no effect and thus is removed.