### PR TITLE
Encourage users to respond to group requests

### DIFF
--- a/app/views/access_request_mailer/send_access_request.html.erb
+++ b/app/views/access_request_mailer/send_access_request.html.erb
@@ -10,7 +10,7 @@
   <%= t('groups.access_request_mailer.message_line2') %> <br/>
   <%= t('groups.access_request_mailer.message_line3') %> <br/>
   <br/>
-  <%= link_to t('groups.access_request_mailer.confirm_request'), group_url(@group)%>
+  <%= link_to t('groups.access_request_mailer.respond_to_request'), group_url(@group)%>
 </p>
 </body>
 </html>

--- a/config/locales/de/views/groups.yml
+++ b/config/locales/de/views/groups.yml
@@ -2,11 +2,11 @@
 de:
   groups:
     access_request_mailer:
-      confirm_request: Anfrage annehmen
       greeting: Hallo %{user}
       message_line1: '%{user} möchte Ihrer Gruppe "%{group}" beitreten.'
-      message_line2: Sie können sie/ihn beitreten lassen, indem Sie auf den Link unten klicken.
-      message_line3: Ansonsten können Sie diese E-Mail ignorieren.
+      message_line2: Sie können die Beitrittsanfrage über CodeHarbor annehmen oder ablehnen.
+      message_line3: Bitte klicken Sie dazu auf den unten stehenden Link.
+      respond_to_request: Anfrage beantworten
       subject: '%{user} möchte Ihrer Grupper "%{group}" beitreten'
     form:
       button:

--- a/config/locales/en/views/groups.yml
+++ b/config/locales/en/views/groups.yml
@@ -2,11 +2,11 @@
 en:
   groups:
     access_request_mailer:
-      confirm_request: Confirm Request
       greeting: Hello %{user}
       message_line1: '%{user} asked to join your group "%{group}".'
-      message_line2: If you want to give your permission click on the link below.
-      message_line3: Otherwise ignore this Email.
+      message_line2: You can accept or reject the membership request via CodeHarbor.
+      message_line3: Please click on the link below to do so.
+      respond_to_request: Respond to Request
       subject: '%{user} wants to access your Group "%{group}"'
     form:
       button:


### PR DESCRIPTION
While working on #1230, we noticed that group invites are not clear about the link target. Therefore, we rephrase the message slightly.