### PR TITLE
Disable footnote backlinks in Markdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,8 @@ module ApplicationHelper
       markdown,
       input: 'GFM',
       hard_wrap: false,
-      smart_quotes: 'apos,apos,quot,quot'
+      smart_quotes: 'apos,apos,quot,quot',
+      footnote_backlink: nil
     ).to_html.strip
   end
 


### PR DESCRIPTION
These backlinks don't work reliably and are thus more harmful than useful.