### PR TITLE
LOM: Return description in HTML rather than Markdown

### DIFF
--- a/app/services/lom_service/export_lom.rb
+++ b/app/services/lom_service/export_lom.rb
@@ -38,7 +38,7 @@ module LomService
         end
         xml.language @task.iso639_lang
         xml.description do
-          xml.string @task.description, language: @task.iso639_lang
+          xml.string ApplicationController.helpers.render_markdown(@task.description), language: @task.iso639_lang
         end
         if @task.programming_language&.language.present?
           xml.keyword do

--- a/spec/controllers/bridges/lom/tasks_controller_spec.rb
+++ b/spec/controllers/bridges/lom/tasks_controller_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Bridges::Lom::TasksController do
       end
     end
 
+    context 'with a description in Markdown' do
+      let(:description_markdown) { '# Description' }
+      let(:description_html) { CGI.escapeHTML '<h1>Description</h1>' }
+
+      before { task.update(description: description_markdown) }
+
+      it 'returns the description in HTML' do
+        get_request
+        expect(response.body).to include description_html
+      end
+    end
+
     context 'with additional details' do
       context 'when no license is specified' do
         let(:license) { nil }


### PR DESCRIPTION
Some IEEE LOM clients, such as "Mein Bildungsraum" expect the description to contain valid HTML. Without parsing the description, we would return the raw Markdown, which is not necessarily correct HTML.