### PR TITLE
Fix errors in migrations and schema

### DIFF
--- a/db/migrate/20230110212941_populate_task_file_xml_ids.rb
+++ b/db/migrate/20230110212941_populate_task_file_xml_ids.rb
@@ -1,6 +1,29 @@
 # frozen_string_literal: true
 
 class PopulateTaskFileXmlIds < ActiveRecord::Migration[6.1]
+  class Task < ApplicationRecord
+    has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy
+    has_many :tests, dependent: :destroy
+    has_many :model_solutions, dependent: :destroy
+
+    def all_files
+      (files + tests.map(&:files) + model_solutions.map(&:files)).flatten
+    end
+  end
+
+  class TaskFile < ApplicationRecord
+    belongs_to :fileable, polymorphic: true
+    validates :xml_id, presence: true
+  end
+
+  class Test < ApplicationRecord
+    has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy
+  end
+
+  class ModelSolution < ApplicationRecord
+    has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def up
     Task.find_each do |task|

--- a/db/migrate/20230116201724_refactor_group_membership.rb
+++ b/db/migrate/20230116201724_refactor_group_membership.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class RefactorGroupMembership < ActiveRecord::Migration[6.1]
+  class GroupMembershipOld < ApplicationRecord
+    self.table_name = 'group_memberships_old'
+  end
+
+  class GroupMembership < ApplicationRecord
+  end
+
   def up
     rename_table :group_memberships, :group_memberships_old
 
@@ -22,8 +29,4 @@ class RefactorGroupMembership < ActiveRecord::Migration[6.1]
 
     drop_table :group_memberships_old
   end
-end
-
-class GroupMembershipOld < ApplicationRecord
-  self.table_name = 'group_memberships_old'
 end

--- a/db/migrate/20231002220433_migrate_meta_data_to_dachsfisch.rb
+++ b/db/migrate/20231002220433_migrate_meta_data_to_dachsfisch.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class MigrateMetaDataToDachsfisch < ActiveRecord::Migration[7.0]
+  class Task < ApplicationRecord
+  end
+
+  class Test < ApplicationRecord
+  end
+
   def change
     Task.where.not(meta_data: nil).in_batches&.each {|tasks| update_meta_data tasks }
     Test.where.not(meta_data: nil).in_batches&.each {|tests| update_meta_data tests }
@@ -43,10 +49,4 @@ class MigrateMetaDataToDachsfisch < ActiveRecord::Migration[7.0]
       end
     end
   end
-end
-
-class Task < ApplicationRecord
-end
-
-class Test < ApplicationRecord
 end

--- a/db/migrate/20240312165451_rename_group_param_type.rb
+++ b/db/migrate/20240312165451_rename_group_param_type.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class RenameGroupParamType < ActiveRecord::Migration[7.1]
+  class Message < ApplicationRecord
+  end
+
   def change
     reversible do |dir|
       dir.up do

--- a/db/migrate/20240312201146_migrate_task_descriptions_fix_kramdown_quotes.rb
+++ b/db/migrate/20240312201146_migrate_task_descriptions_fix_kramdown_quotes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class MigrateTaskDescriptionsFixKramdownQuotes < ActiveRecord::Migration[7.1]
+  class Task < ApplicationRecord
+  end
+
   def up
     Task.find_each do |task|
       task.description = fix_kramdown_descriptions(task.description)
@@ -12,7 +15,4 @@ class MigrateTaskDescriptionsFixKramdownQuotes < ActiveRecord::Migration[7.1]
     # removes double escapes of symbols and unnecessary newlines
     Kramdown::Document.new(string, line_width: -1).to_kramdown.gsub(/\\([\\*_`\[\]\{"'|])/, '\1').strip
   end
-end
-
-class Task < ApplicationRecord
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,7 +326,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_160738) do
     t.datetime "locked_at"
     t.string "preferred_locale"
     t.boolean "password_set", default: true, null: false
-    t.integer "status_group", limit: 1, default: 0, null: false, comment: "Used as enum in Rails"
+    t.integer "status_group", limit: 2, default: 0, null: false, comment: "Used as enum in Rails"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
This PR fixes two issues with the migration and schema.

- The first commit ensures we can run `db:migrate:reset` on an empty database by ensuring the model classes are specified correctly.
- The second commit ensures the schema actually matches PostgreSQL capabilities.

_PS: While the migrations can now run successfully, I have not validated or touched them. Probably, some could have been designed better._