### PR TITLE
Refactor Collection Share menu to avoid adblocking

### DIFF
--- a/app/assets/javascripts/collections.coffee
+++ b/app/assets/javascripts/collections.coffee
@@ -1,5 +1,5 @@
 ready = ->
-  $('#share-menu').on 'click', (e) ->
+  $('#share-collection-menu').on 'click', (e) ->
     e.stopPropagation()
     return
   $('#collection-tasks-sortable').sortable({

--- a/app/assets/stylesheets/collections.css.scss
+++ b/app/assets/stylesheets/collections.css.scss
@@ -12,7 +12,7 @@
   padding: 10px 15px;
 }
 
-#share-menu {
+#share-collection-menu {
   padding: 5px;
   min-width: 300px;
 }

--- a/app/views/collections/show.html.slim
+++ b/app/views/collections/show.html.slim
@@ -82,7 +82,7 @@
             = button_tag type: 'button', 'data-bs-toggle': 'dropdown', aria: {haspopup: 'true', expanded: 'false'}, class: 'btn btn-important nav-btn-exercise dropdown-toggle split' do
               => t('.button.share')
               span.caret
-            .dropdown-menu#share-menu
+            .dropdown-menu#share-collection-menu
               .dropdown-header.dropdown-title
                 = t('.type_hint')
                 | :


### PR DESCRIPTION
The ID `#share-menu` is listed on multiple adblockers, preventing the correct display in some browsers. By simply renaming, we avoid this bug.

<details>
<summary>Expected</summary>

![Bildschirmfoto 2024-07-02 um 14 37 22](https://github.com/openHPI/codeharbor/assets/7300329/9ddd6c8c-325f-4c15-80cd-ea54277193e8)

</details>

<details>
<summary>Current state with adblockers</summary>

![Bildschirmfoto 2024-07-02 um 14 37 32](https://github.com/openHPI/codeharbor/assets/7300329/dbc85e87-e1ba-4f09-87d4-662e0e01bcd4)

</details>


