### PR TITLE
Add noreferrer policy for external links

### DIFF
--- a/app/views/tasks/_import_actions.html.slim
+++ b/app/views/tasks/_import_actions.html.slim
@@ -1,5 +1,5 @@
 - if imported
-  = link_to t('.button.show_task'), task, class: 'btn btn-light btn-sm float-end show-action import-export-button', target: '_blank', rel: 'noopener'
+  = link_to t('.button.show_task'), task, class: 'btn btn-light btn-sm float-end show-action import-export-button', target: '_blank', rel: 'noopener noreferrer'
 - elsif exists && updatable
   = button_tag type: 'button', class: 'btn btn-light btn-sm float-end import-action import-export-button', data: {'import-type' => 'import'} do
     i.fa-solid.fa-check.confirm-icon.export-button-icon

--- a/app/views/tasks/_import_dialog_content.html.slim
+++ b/app/views/tasks/_import_dialog_content.html.slim
@@ -1,7 +1,7 @@
 - data.each do |subfile_id, task|
   .import-export-task data-task-uuid=task[:task_uuid] data-import-subfile-id=subfile_id data-import-id=task[:import_id] data-task-path=task[:path]
     .import-export-message
-      = link_to_if(task[:exists], t('.task_with_uuid', task_uuid: task[:task_uuid]), Task.find_by(uuid: task[:task_uuid]), {target: '_blank', rel: 'noopener'})
+      = link_to_if(task[:exists], t('.task_with_uuid', task_uuid: task[:task_uuid]), Task.find_by(uuid: task[:task_uuid]), {target: '_blank', rel: 'noopener noreferrer'})
       br
       = t('.path', path: task[:path])
     .import-export-task-actions

--- a/config/locales/de/views/users.yml
+++ b/config/locales/de/views/users.yml
@@ -9,13 +9,13 @@ de:
         cancel_registration: Registrierung abbrechen
         header: Wallet verbinden
         info_html: |
-          Um Ihre Registrierung abzuschließen, scannen Sie bitte den QR Code mit Ihrer 'Mein Bildungsraum: Wallet' App. Die 'Mein Bildungsraum: Wallet' App gibt es im <a href='%{app_store_link}' target='_blank' rel='noopener'>App Store</a> und <a href='%{play_store_link}' target='_blank' rel='noopener'>Play Store</a>.
+          Um Ihre Registrierung abzuschließen, scannen Sie bitte den QR Code mit Ihrer 'Mein Bildungsraum: Wallet' App. Die 'Mein Bildungsraum: Wallet' App gibt es im <a href='%{app_store_link}' target='_blank' rel='noopener noreferrer'>App Store</a> und <a href='%{play_store_link}' target='_blank' rel='noopener noreferrer'>Play Store</a>.
           <br>
           Wenn Sie die App auf dem Gerät installiert haben, mit dem Sie diese Seite ansehen, können Sie stattdessen auch <a href='%{alternative_link}'>hier klicken</a>.
           <br><br>
           Bitte geben Sie in der App entweder "Lehrer:in" oder "Schüler:in" als Ihre Rolle ein.
         privacy_disclaimer:
-          html: CodeHarbor bietet Lehrenden eine dedizierte Möglichkeit, sich gemeinsam über automatisch-bewertbare Programmieraufgaben auszutauschen, diese in Sammlungen zu organisieren oder über Gruppen in einem Team kollaborativ zu bearbeiten. Die Plattform basiert dabei grundsätzlich auf dem Prinzip der Datensparsamkeit bei der Erhebung und Verarbeitung personenbezogener Daten. Für die Nutzung unserer Plattform sind daher nur wenige Daten zwingend erforderlich (z.B. Name und E-Mail-Adresse), während andere Daten freiwillig von Ihnen ergänzt werden können (z.B. ein Profilbild). Diese Daten werden gemäß unserer <a href='%{privacy_policy_link}' target='_blank' rel='noopener'>Datenschutzerklärung</a> dauerhaft auf Servern in Deutschland gespeichert, um Ihnen die Nutzung von CodeHarbor zu ermöglichen.
+          html: CodeHarbor bietet Lehrenden eine dedizierte Möglichkeit, sich gemeinsam über automatisch-bewertbare Programmieraufgaben auszutauschen, diese in Sammlungen zu organisieren oder über Gruppen in einem Team kollaborativ zu bearbeiten. Die Plattform basiert dabei grundsätzlich auf dem Prinzip der Datensparsamkeit bei der Erhebung und Verarbeitung personenbezogener Daten. Für die Nutzung unserer Plattform sind daher nur wenige Daten zwingend erforderlich (z.B. Name und E-Mail-Adresse), während andere Daten freiwillig von Ihnen ergänzt werden können (z.B. ein Profilbild). Diese Daten werden gemäß unserer <a href='%{privacy_policy_link}' target='_blank' rel='noopener noreferrer'>Datenschutzerklärung</a> dauerhaft auf Servern in Deutschland gespeichert, um Ihnen die Nutzung von CodeHarbor zu ermöglichen.
           title: Datenschutz
         qr_code_alt_text: 'QR Code, der mit der ''Mein Bildungsraum: Wallet'' App gescannt werden kann'
         regenerate_code: Code erneuern

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -9,13 +9,13 @@ en:
         cancel_registration: Cancel registration
         header: Connect Wallet
         info_html: |
-          To complete your registration, please scan the QR code with your 'Mein Bildungsraum: Wallet' app. The 'Mein Bildungsraum: Wallet' app is available in the <a href='%{app_store_link}' target='_blank' rel='noopener'>App Store</a> and <a href='%{play_store_link}' target='_blank' rel='noopener'>Play Store</a>.
+          To complete your registration, please scan the QR code with your 'Mein Bildungsraum: Wallet' app. The 'Mein Bildungsraum: Wallet' app is available in the <a href='%{app_store_link}' target='_blank' rel='noopener noreferrer'>App Store</a> and <a href='%{play_store_link}' target='_blank' rel='noopener noreferrer'>Play Store</a>.
           <br>
           If you have the app installed on the device you are viewing this page with, you can alternatively <a href='%{alternative_link}'>click here</a>.
           <br><br>
           Within the app, please enter either "Teacher" or "Student" as your role.
         privacy_disclaimer:
-          html: CodeHarbor provides educators with a dedicated tool for sharing auto-gradable programming tasks, organizing them in collections or working on them collaboratively via groups. The platform is fundamentally based on the principle of data minimization when collecting and processing personal data. Only a small amount of data is therefore mandatory for the use of our platform (e.g., name and email address), while other data can be added voluntarily (e.g., a profile picture). This data is stored permanently on servers in Germany in accordance with our <a href='%{privacy_policy_link}' target='_blank' rel='noopener'>privacy policy</a> to provide you with access to CodeHarbor.
+          html: CodeHarbor provides educators with a dedicated tool for sharing auto-gradable programming tasks, organizing them in collections or working on them collaboratively via groups. The platform is fundamentally based on the principle of data minimization when collecting and processing personal data. Only a small amount of data is therefore mandatory for the use of our platform (e.g., name and email address), while other data can be added voluntarily (e.g., a profile picture). This data is stored permanently on servers in Germany in accordance with our <a href='%{privacy_policy_link}' target='_blank' rel='noopener noreferrer'>privacy policy</a> to provide you with access to CodeHarbor.
           title: Privacy Policy
         qr_code_alt_text: 'QR Code to be scanned with the ''Mein Bildungsraum: Wallet'' app'
         regenerate_code: Refresh Code


### PR DESCRIPTION
We recently noticed that our links to external pages only contained the `noopener` directive (instructing browsers to use a dedicated context for the new target) but not the `noreferrer` (which hides the source page's address from the new page). This PR fixes said behavior.

//cc @Melhaya for the boy scouting rule