### PR TITLE
Policy: Use no_one rather than false

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -12,8 +12,8 @@ class ApplicationPolicy
 
   def method_missing(method_name, *_args)
     if RESOURCE_ACTIONS.include?(method_name)
-      Rails.logger.debug { "Pundit policy does not have method #{method_name}. Returning false as default." }
-      return false
+      Rails.logger.debug { "Pundit policy does not have method #{method_name}. Returning no_one as default." }
+      return no_one
     end
 
     super
@@ -44,6 +44,10 @@ class ApplicationPolicy
   def everyone
     # `everyone` here means `every user logged in`
     @user.present?
+  end
+
+  def no_one
+    false
   end
 
   class Scope

--- a/app/policies/task_policy.rb
+++ b/app/policies/task_policy.rb
@@ -29,14 +29,14 @@ class TaskPolicy < ApplicationPolicy
 
   %i[add_to_collection? duplicate? export_external_start? export_external_check? export_external_confirm?].each do |action|
     define_method(action) do
-      return false if @user.blank?
+      return no_one if @user.blank?
 
       record_owner? || task.access_level_public? || task_in_group_with?(@user) || admin?
     end
   end
 
   def update?
-    return false if @user.blank?
+    return no_one if @user.blank?
 
     record_owner? || task_in_group_with?(@user) || admin?
   end


### PR DESCRIPTION
In CodeOcean, we have a `no_one` policy that denies access to some actions. In CodeHarbor, we didn't add the policy when introducing Pundit, since it wasn't yet used. However, with #1230, we'll do so (and already did implicitly). Hence, we are adding the method here already and use it where appropriate

//cc @Melhaya for the boy scouting rule