### PR TITLE
Upgrade model from gpt3.5 to gpt4o-mini

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -15,4 +15,4 @@ oai_pmh:
   admin_mail: admin@example.org
 open_ai:
   access_token: ~ # Add a valid API key from https://platform.openai.com/api-keys
-  model: gpt-3.5-turbo
+  model: gpt-4o-mini

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -16,4 +16,4 @@ oai_pmh:
   admin_mail: admin@example.org
 open_ai:
   access_token: ~ # Add a valid API key from https://platform.openai.com/api-keys
-  model: gpt-3.5-turbo
+  model: gpt-4o-mini

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -22,4 +22,4 @@ oai_pmh:
   admin_mail: admin@example.org
 open_ai:
   access_token: ~ # Add a valid API key from https://platform.openai.com/api-keys
-  model: gpt-3.5-turbo
+  model: gpt-4o-mini


### PR DESCRIPTION
- openAI announced a new API model GPT4o-mini which is faster, cheaper and more efficient than GPT3.5-Turbo 
- openAI recommends the change from GPT3.5 to GPT4o-mini

more information can be found [here](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/)