### PR TITLE
Use Bulk Enqueueing for ActiveJob

### DIFF
--- a/app/jobs/nbp_sync_all_job.rb
+++ b/app/jobs/nbp_sync_all_job.rb
@@ -15,8 +15,7 @@ class NbpSyncAllJob < ApplicationJob
     Task.select(:id, :uuid).find_each {|task| uuids.add(task.uuid) }
 
     # Finally, schedule a full sync for each UUID identified.
-    uuids.each do |uuid|
-      NbpSyncJob.perform_later uuid
-    end
+    sync_jobs = uuids.map {|uuid| NbpSyncJob.new(uuid) }
+    ActiveJob.perform_all_later(sync_jobs)
   end
 end


### PR DESCRIPTION
With this new approach, only one operation with the ActiveJob backend is required to schedule all jobs.

See the ActiveJob Guide for more details on [Bulk Enqueuing](https://edgeguides.rubyonrails.org/active_job_basics.html#bulk-enqueuing).
