### PR TITLE
Resolve warnings about unpermitted parameters during task#create and task#update

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -88,6 +88,10 @@
   color: #444444;
 }
 
+.not-allowed {
+  cursor: not-allowed;
+}
+
 a.no-border:link,
 a.no-border:active,
 a.no-border:hover,

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -288,7 +288,7 @@ class TasksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def group_tasks_params
-    params.permit(group_tasks: {group_ids: []})[:group_tasks]
+    params.require(:group_tasks).permit(group_ids: [])
   end
 
   def import_confirm_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,6 +72,10 @@ module ApplicationHelper
     end
   end
 
+  def uuid_pattern
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+  end
+
   def value_column(value)
     tag.div(class: 'col-md-9') do
       block_given? ? yield : symbol_for(value)

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -40,7 +40,7 @@
             = f.text_area :internal_description, class: 'form-control'
           .field-element
             = f.label :uuid, Task.human_attribute_name('uuid'), class: 'form-label'
-            = f.text_field :uuid, class: 'form-control'
+            = f.text_field :uuid, class: 'form-control not-allowed', disabled: true, title: t('.unchangeable_uuid'), 'data-bs-toggle': 'tooltip'
           .field-element
             = f.label :parent_uuid, Task.human_attribute_name('parent_uuid'), class: 'form-label'
             = f.text_field :parent_uuid, class: 'form-control'

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -7,7 +7,7 @@
 
 .row
   .col-md-12.my-4
-    = simple_form_for @task, html: {class: 'project exercise-validation', multipart: true}, builder: MarkdownFormBuilder do |f|
+    = simple_form_for @task, html: {multipart: true}, builder: MarkdownFormBuilder do |f|
       = render('shared/form_errors', object: @task)
       fieldset.form-group
         legend.toggle-next

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -40,10 +40,10 @@
             = f.text_area :internal_description, class: 'form-control'
           .field-element
             = f.label :uuid, Task.human_attribute_name('uuid'), class: 'form-label'
-            = f.text_field :uuid, class: 'form-control not-allowed', disabled: true, title: t('.unchangeable_uuid'), 'data-bs-toggle': 'tooltip'
+            = f.text_field :uuid, type: :uuid, class: 'form-control not-allowed', disabled: true, title: t('.unchangeable_uuid'), 'data-bs-toggle': 'tooltip', pattern: uuid_pattern
           .field-element
             = f.label :parent_uuid, Task.human_attribute_name('parent_uuid'), class: 'form-label'
-            = f.text_field :parent_uuid, class: 'form-control'
+            = f.text_field :parent_uuid, type: :uuid, class: 'form-control', pattern: uuid_pattern
           .field-element
             = f.label :language, Task.human_attribute_name('language'), class: 'form-label'
             = f.text_field :language, class: 'form-control'

--- a/config/locales/de/views/tasks.yml
+++ b/config/locales/de/views/tasks.yml
@@ -32,6 +32,7 @@ de:
         prog_lang_not_empty_while_public: darf nicht leer sein, wenn die Sichtbarkeit auf öffentlich eingestellt ist
       no_license: Keine Lizenz
       unchangeable_groups: Nicht änderbare Gruppen
+      unchangeable_uuid: Zur Zeit wird das manuelle Setzen der Aufgaben-UUID noch nicht unterstützt.
       visibility_warning: Diese Aufgabe befindet sich derzeit in einer Sammlung. Andere Benutzer:innen können Ihre Aufgabe nicht anzeigen oder bearbeiten. Der Titel bleibt jedoch für diese Benutzer:innen sichtbar.
     import_actions:
       button:

--- a/config/locales/en/views/tasks.yml
+++ b/config/locales/en/views/tasks.yml
@@ -32,6 +32,7 @@ en:
         prog_lang_not_empty_while_public: Can't be empty while visibility is set to public
       no_license: No License
       unchangeable_groups: Unchangeable groups
+      unchangeable_uuid: Manually setting a task's UUID is currently not yet supported.
       visibility_warning: This task is currently in a collection. Other users will not be able to view or modify your task. However, the title will remain visible to these users.
     import_actions:
       button:

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe TasksController do
     before { sign_in user }
 
     context 'with valid params' do
-      subject(:post_request) { post :create, params: {task: valid_params} }
+      subject(:post_request) { post :create, params: {task: valid_params, group_tasks: {group_ids: ['']}} }
 
       let(:valid_params) do
         {
@@ -304,7 +304,7 @@ RSpec.describe TasksController do
         end
 
         context 'when no groups are given' do
-          let(:group_tasks_params) { {group_ids: []} }
+          let(:group_tasks_params) { {group_ids: ['']} }
 
           it 'adds no groups to the Task' do
             post_request
@@ -336,7 +336,7 @@ RSpec.describe TasksController do
     end
 
     context 'with invalid params' do
-      subject(:post_request) { post :create, params: {task: invalid_attributes} }
+      subject(:post_request) { post :create, params: {task: invalid_attributes, group_tasks: {group_ids: ['']}} }
 
       it 'assigns a newly created but unsaved task as @task' do
         post_request
@@ -362,7 +362,7 @@ RSpec.describe TasksController do
   end
 
   describe 'PUT #update' do
-    subject(:put_update) { put :update, params: {id: task.to_param, task: changed_attributes} }
+    subject(:put_update) { put :update, params: {id: task.to_param, task: changed_attributes, group_tasks: {group_ids: ['']}} }
 
     before { sign_in user }
 
@@ -441,7 +441,7 @@ RSpec.describe TasksController do
 
       context 'when task has a test' do
         subject(:put_update) do
-          put :update, params: {id: task.to_param, task: changed_attributes.merge(tests_attributes:)}
+          put :update, params: {id: task.to_param, task: changed_attributes.merge(tests_attributes:), group_tasks: {group_ids: ['']}}
         end
 
         let(:test) { build(:test) }
@@ -475,7 +475,7 @@ RSpec.describe TasksController do
         end
 
         context 'when no groups are given' do
-          let(:group_tasks_params) { {group_ids: []} }
+          let(:group_tasks_params) { {group_ids: ['']} }
 
           it 'adds no groups to the Task' do
             put_update
@@ -538,7 +538,7 @@ RSpec.describe TasksController do
     end
 
     context 'with invalid params' do
-      subject(:put_update) { put :update, params: {id: task.to_param, task: invalid_attributes} }
+      subject(:put_update) { put :update, params: {id: task.to_param, task: invalid_attributes, group_tasks: {group_ids: ['']}} }
 
       it 'assigns the task as @task' do
         put_update

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Tasks' do
 
     describe 'POST /tasks' do
       it 'has http 302' do
-        post tasks_path, params: {task: valid_params}
+        post tasks_path, params: {task: valid_params, group_tasks: {group_ids: ['']}}
         expect(response).to have_http_status(:found)
       end
     end
@@ -66,14 +66,14 @@ RSpec.describe 'Tasks' do
 
     describe 'PATCH /task/:id' do
       it 'has http 302' do
-        patch task_path(task, task: update_params)
+        patch task_path(task, task: update_params, group_tasks: {group_ids: ['']})
         expect(response).to have_http_status(:found)
       end
     end
 
     describe 'PUT /task/:id' do
       it 'has http 302' do
-        put task_path(task, task: update_params)
+        put task_path(task, task: update_params, group_tasks: {group_ids: ['']})
         expect(response).to have_http_status(:found)
       end
     end


### PR DESCRIPTION
As noticed during #1103, the following warnings were present when saving a task:

```
Unpermitted parameter: :uuid.
Unpermitted parameters: :_method, :authenticity_token, :task, :button, :id. 
```

This PR fixes said behavior and includes two minor adjustments in the form builder for tasks, too.