### PR TITLE
Fix account_link security issue

### DIFF
--- a/app/policies/account_link_policy.rb
+++ b/app/policies/account_link_policy.rb
@@ -13,7 +13,7 @@ class AccountLinkPolicy < ApplicationPolicy
     define_method(action) { admin? || record_owner? }
   end
 
-  %i[show? remove_shared_user?].each do |action|
+  %i[show? remove_shared_user? use?].each do |action|
     define_method(action) { admin? || record_owner? || account_link.shared_users.include?(@user) }
   end
 end

--- a/app/services/proforma_service/handle_export_confirm.rb
+++ b/app/services/proforma_service/handle_export_confirm.rb
@@ -2,12 +2,12 @@
 
 module ProformaService
   class HandleExportConfirm < ServiceBase
-    def initialize(user:, task:, push_type:, account_link_id:)
+    def initialize(user:, task:, push_type:, account_link:)
       super()
       @user = user
       @task = task
       @push_type = push_type
-      @account_link_id = account_link_id
+      @account_link = account_link
     end
 
     def execute
@@ -17,9 +17,8 @@ module ProformaService
         @task.reload
       end
 
-      account_link = AccountLink.find(@account_link_id)
       zip_stream = ProformaService::ExportTask.call(task: @task, options: {description_format: 'md'})
-      error = TaskService::PushExternal.call(zip: zip_stream, account_link:)
+      error = TaskService::PushExternal.call(zip: zip_stream, account_link: @account_link)
 
       [@task, error]
     end

--- a/spec/policies/account_link_policy_spec.rb
+++ b/spec/policies/account_link_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AccountLinkPolicy do
     context 'when user is listed as shared_user' do
       let(:shared_users) { [user] }
 
-      it { is_expected.to permit_only_actions(%i[new show remove_shared_user]) }
+      it { is_expected.to permit_only_actions(%i[new show remove_shared_user use]) }
     end
 
     context 'when user is admin' do

--- a/spec/services/proforma_service/handle_export_confirm_spec.rb
+++ b/spec/services/proforma_service/handle_export_confirm_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 RSpec.describe ProformaService::HandleExportConfirm do
   describe '.new' do
     subject(:handle_export_confirm) do
-      described_class.new(user:, task:, push_type:, account_link_id:)
+      described_class.new(user:, task:, push_type:, account_link:)
     end
 
     let(:user) { build(:user) }
     let(:task) { build(:task, user:) }
     let(:push_type) { 'export' }
-    let(:account_link_id) { create(:account_link, user:).id }
+    let(:account_link) { create(:account_link, user:) }
 
     it 'assigns user' do
       expect(handle_export_confirm.instance_variable_get(:@user)).to be user
@@ -26,13 +26,13 @@ RSpec.describe ProformaService::HandleExportConfirm do
     end
 
     it 'assigns account_link_id' do
-      expect(handle_export_confirm.instance_variable_get(:@account_link_id)).to be account_link_id
+      expect(handle_export_confirm.instance_variable_get(:@account_link)).to be account_link
     end
   end
 
   describe '#execute' do
     subject(:handle_export_confirm) do
-      described_class.call(user:, task:, push_type:, account_link_id: account_link.id)
+      described_class.call(user:, task:, push_type:, account_link:)
     end
 
     let(:user) { create(:user) }


### PR DESCRIPTION
Fixes a security issue enabling access to any account_link given the id. I only fixed the occurrences in the `task_controller` since the `collections_controller` would need a spec as well and is not in use at the moment. The collection-export should be fixed and tested in another PR.

fixes: #1566 

