### PR TITLE
Add missing SolidQueue migration and prevent further occurrences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,15 @@ jobs:
         env:
           RAILS_ENV: test
         run: bundler exec rake db:schema:load
+      - name: Temporarily create pending SolidQueue migrations
+        # Dependabot might update the SolidQueue gem, which might include new migrations.
+        # However, Dependabot won't add the migrations nor run SolidQueue at all.
+        # Consequently, all tests would still pass and the dependency update would be merged.
+        # To prevent this, we temporarily create the pending migrations *after* the schema has been loaded.
+        # If a new migration was added, a `PendingMigrationError` will be raised and the CI will fail.
+        env:
+          RAILS_ENV: test
+        run: bundler exec rails solid_queue:install:migrations
       - name: Precompile assets
         env:
           RAILS_ENV: test

--- a/db/migrate/20240815132406_create_recurring_tasks.solid_queue.rb
+++ b/db/migrate/20240815132406_create_recurring_tasks.solid_queue.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This migration comes from solid_queue (originally 20240719134516)
+class CreateRecurringTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false, index: {unique: true}
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+
+      t.string :queue_name
+      t.integer :priority, default: 0
+
+      t.boolean :static, default: true, index: true
+
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_03_221801) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_15_132406) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -280,6 +280,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_221801) do
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
     t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|


### PR DESCRIPTION
With #1584, Dependabot bumped SolidQueue from 0.4.1 to 0.5.0. The new version of SolidQueue, however, requires a database migration that wasn't applied.

Therefore, this PR adds two commits:

1. We fix the underlying issue and let the CI fail if SolidQueue ships with a migration not yet applied (db9739e6).
2. We add the missing migration and the updated schema (cddd453b).

As you can see from the GitHub CI status, the first commit (db9739e6) is working as expected and recognizing a potential issue: [Pipeline failure due to a `PendingMigrationError`](https://github.com/openHPI/codeharbor/actions/runs/10404633188/job/28813512322). With these changes, I would assume the same bug doesn't occur another time.