### PR TITLE
Refactor deletion of dangling labels

### DIFF
--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -72,6 +72,10 @@ class Label < ApplicationRecord
     }.compact
   end
 
+  def to_s
+    name
+  end
+
   def self.ransackable_attributes(_auth_object = nil)
     %w[name]
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -27,7 +27,7 @@ class Task < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :groups, through: :group_tasks
 
   has_many :task_labels, dependent: :destroy
-  has_many :labels, through: :task_labels
+  has_many :labels, through: :task_labels, dependent: :destroy
 
   has_many :tests, dependent: :destroy, inverse_of: :task
   has_many :model_solutions, dependent: :destroy, inverse_of: :task
@@ -226,7 +226,7 @@ class Task < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def label_names=(label_names)
     self.labels = label_names.uniq.compact_blank.map {|name| Label.find_or_initialize_by(name:) }
-    Label.where.not(id: TaskLabel.select(:label_id)).destroy_all
+    # Labels without tasks will be deleted as part of `TaskLabel#remove_dangling_labels`.
   end
 
   def label_names

--- a/app/models/task_label.rb
+++ b/app/models/task_label.rb
@@ -3,4 +3,10 @@
 class TaskLabel < ApplicationRecord
   belongs_to :task
   belongs_to :label
+
+  after_destroy :remove_dangling_labels
+
+  def remove_dangling_labels
+    label.destroy if label.task_labels.empty?
+  end
 end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -384,8 +384,8 @@ RSpec.describe TasksController do
 
     before { sign_in user }
 
-    let!(:existing_label) { create(:label) }
-    let!(:new_label) { create(:label) }
+    let(:existing_label) { create(:label) }
+    let(:new_label) { create(:label) }
 
     let!(:task) { create(:task, valid_attributes) }
     let(:valid_attributes) do
@@ -428,14 +428,21 @@ RSpec.describe TasksController do
       end
 
       it 'does not create a new label' do
+        create(:task, title: 'An existing task with the new label', labels: [new_label])
         old_labels = Label.all.to_a
         put_update
         expect(Label.all.to_a.difference(old_labels)).to be_empty
       end
 
-      it 'does delete the unused label' do
+      it 'deletes unused labels' do
         put_update
         expect(Label.all).to not_include(existing_label)
+      end
+
+      it 'does not delete any used label' do
+        create(:task, title: 'An existing task with the existing label', labels: [existing_label])
+        put_update
+        expect(Label.all).to include(existing_label)
       end
 
       context 'when requesting a new label to be created' do

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -6,4 +6,13 @@ RSpec.describe Label do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
   end
+
+  describe '#to_s' do
+    let(:label_name) { 'Test Label' }
+    let(:label) { described_class.new(name: label_name) }
+
+    it 'returns the label name' do
+      expect(label.to_s).to eq label_name
+    end
+  end
 end


### PR DESCRIPTION
The previous mechanism required newly-assigned TaskLabels to be saved before aiming to destroy dangling labels. However, there is one edge-case previously used in the tests which caused erroneous behavior:

Imagine, there is a dangling label (with no matching TaskLabel). Then, a task is assigned that dangling label through the `label_names=` mechanism. This will cause the `Label.find_or_initialize_by(name:)` method to return the dangling label and assign that to the task. However, when this assignment is not saved it (and no `TaskLabel` record is created), the following call to destroy dangling labels also removed the one just assigned to a task.

This caused errors in tests, when switching from `labels` to `label_names` in the TaskController specs to remove the use of unpermitted parameters and transactional fixtures.

The new mechanism will still remove dangling labels, but only those associated with a TaskLabel just removed. Through the transactional setting of destroy hooks, this still ensures there aren't any leftovers.