### PR TITLE
Remove any unpermitted parameters and raise if it reoccurs

### DIFF
--- a/app/assets/javascripts/labels_index.coffee
+++ b/app/assets/javascripts/labels_index.coffee
@@ -174,7 +174,7 @@ class LabelsTable
           $.ajax({
             url: "/labels/#{id}",
             type: "PATCH",
-            data: {color: new_color}
+            data: {label: {color: new_color}}
           })
         );
       $.when.apply($, requests).then(@reload_table);

--- a/app/controllers/concerns/task_parameters.rb
+++ b/app/controllers/concerns/task_parameters.rb
@@ -24,7 +24,7 @@ module TaskParameters
   end
 
   def group_tasks_params
-    params.permit(group_tasks: {group_ids: []})[:group_tasks]
+    params.require(:group_tasks).permit(group_ids: [])
   end
 
   def import_confirm_params

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -7,7 +7,7 @@ class LabelsController < ApplicationController
   def index; end
 
   def update
-    if @label.update(params.permit(:color))
+    if @label.update(label_params)
       render json: @label.to_h
     else
       flash.now[:alert] = @label.errors.full_messages
@@ -48,6 +48,10 @@ class LabelsController < ApplicationController
   end
 
   private
+
+  def label_params
+    params.require(:label).permit(:color)
+  end
 
   def load_and_authorize_label
     @label = Label.find(params[:id])

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -25,15 +25,11 @@ class MessagesController < ApplicationController
     authorize @message
   end
 
-  # rubocop:disable Metrics/AbcSize
   def create
+    recipient = params.require(:message).delete(:recipient)
     @message = Message.new(message_params)
     @message.sender = current_user
-    @message.recipient = if params[:message][:recipient]
-                           User.find_by(email: params[:message][:recipient])
-                         else
-                           User.find(params[:message][:recipient_hidden])
-                         end
+    @message.recipient = User.find_by(email: recipient) if recipient.present?
     authorize @message
 
     if @message.save
@@ -42,7 +38,6 @@ class MessagesController < ApplicationController
       render :new
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def destroy
     @message.mark_as_deleted(current_user)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -24,8 +24,9 @@ module Users
 
     # PUT /resource
     def update
+      avatar_present = params.require(:user).delete(:avatar_present)
       super do |resource|
-        resource.avatar.purge if params[:user][:avatar].nil? && params[:user][:avatar_present] == 'false'
+        resource.avatar.purge if params[:user][:avatar].nil? && avatar_present == 'false'
         if resource.password_set_changed?
           # If a user tried to set a password but failed, we need to reset the password_set flag.
           # Further, we need to remove the current_password error, since the user didn't enter their current password.

--- a/app/views/messages/_form.html.slim
+++ b/app/views/messages/_form.html.slim
@@ -3,7 +3,7 @@
     = render('shared/form_errors', object: @message)
 
     - if @recipient
-      = f.hidden_field :recipient_hidden, value: @recipient.id
+      = f.hidden_field :recipient_id, value: @recipient.id
     - else
       .field-element
         = f.label :recipient, Message.human_attribute_name('recipient'), class: 'form-label'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -91,6 +91,9 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  # Raises error for unpermitted parameters (default is `:log`).
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -71,6 +71,9 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  # Raises error for unpermitted parameters (default is `:log`).
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/spec/controllers/account_links_controller_spec.rb
+++ b/spec/controllers/account_links_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AccountLinksController do
   let(:account_link) { create(:account_link, user:) }
   let(:account_link_from_another_user) { create(:account_link, user: another_user) }
 
-  let(:valid_attributes) { attributes_for(:account_link).merge(user:) }
+  let(:valid_attributes) { attributes_for(:account_link) }
   let(:invalid_attributes) do
     {api_key: ''}
   end
@@ -65,14 +65,14 @@ RSpec.describe AccountLinksController do
 
       context 'with valid attributes' do
         it 'updates the requested account_link' do
-          account_link = AccountLink.create! valid_attributes
+          account_link = AccountLink.create! valid_attributes.merge(user:)
           put :update, params: empty_params.merge(id: account_link.to_param, account_link: new_attributes)
           account_link.reload
           expect(account_link.api_key).to eq(new_attributes[:api_key])
         end
 
         it 'redirects to the user' do
-          account_link = AccountLink.create! valid_attributes
+          account_link = AccountLink.create! valid_attributes.merge(user:)
           put :update, params: empty_params.merge(id: account_link.to_param, account_link: valid_attributes)
           expect(response).to redirect_to(user)
         end
@@ -82,7 +82,7 @@ RSpec.describe AccountLinksController do
     describe 'DELETE #destroy' do
       include_examples 'destroy examples', klass: AccountLink, resource: :account_link
       it 'with valid attributes redirects to the user' do
-        account_link = AccountLink.create! valid_attributes
+        account_link = AccountLink.create! valid_attributes.merge(user:)
         delete :destroy, params: empty_params.merge(id: account_link.to_param)
         expect(response).to redirect_to(user)
       end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CollectionsController do
   render_views
 
   let(:valid_attributes) do
-    attributes_for(:collection)
+    build(:collection).attributes.except('id', 'created_at', 'updated_at')
   end
 
   let(:invalid_attributes) do
@@ -274,6 +274,11 @@ RSpec.describe CollectionsController do
 
     context 'with valid params' do
       let(:collection_params) { valid_attributes }
+      let(:collection_tasks_attributes) do
+        collection.collection_tasks.map do |collection_task|
+          collection_task.attributes.symbolize_keys.except(:collection_id, :created_at, :task_id, :updated_at)
+        end
+      end
 
       it 'assigns the requested collection as @collection' do
         put_update
@@ -296,8 +301,8 @@ RSpec.describe CollectionsController do
       context 'with new task order' do
         let(:collection_params) do
           {collection_tasks_attributes: {
-            '0': collection.collection_tasks.first.attributes.merge(rank: 0),
-            '1': collection.collection_tasks.second.attributes.merge(rank: 1),
+            '0': collection_tasks_attributes.first.merge(rank: 0),
+            '1': collection_tasks_attributes.second.merge(rank: 1),
           }}
         end
 
@@ -309,8 +314,8 @@ RSpec.describe CollectionsController do
       context 'when removing a task' do
         let(:collection_params) do
           {collection_tasks_attributes: {
-            '0': collection.collection_tasks.first.attributes.merge(rank: 0),
-            '1': collection.collection_tasks.second.attributes.merge(_destroy: 1),
+            '0': collection_tasks_attributes.first.merge(rank: 0),
+            '1': collection_tasks_attributes.second.merge(_destroy: 1),
           }}
         end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GroupsController do
   let(:admin_locale) { :de }
 
   let(:valid_post_attributes) do
-    attributes_for(:group, users: [user])
+    build(:group, users: [user]).attributes.except('id', 'created_at', 'updated_at')
   end
 
   let(:invalid_attributes) do

--- a/spec/controllers/task_contributions_controller_spec.rb
+++ b/spec/controllers/task_contributions_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe TaskContributionsController do
   describe 'POST #create' do
     subject(:post_request) { post :create, params: {task_id: task.id, task: task_params} }
 
-    let(:task_params) { attributes_for(:task) }
+    let(:task_params) { attributes_for(:task).except(:uuid) }
     let(:suggestion) { assigns(:task_contribution).suggestion }
 
     context 'with valid params' do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe TasksController do
       let(:valid_params) do
         {
           title: 'title',
-          descriptions_attributes: {'0' => {text: 'description', primary: true}},
+          description: 'description',
           programming_language_id: create(:programming_language, :ruby).id,
           license_id: create(:license),
           language: 'de',
@@ -387,13 +387,12 @@ RSpec.describe TasksController do
     let(:existing_label) { create(:label) }
     let(:new_label) { create(:label) }
 
-    let!(:task) { create(:task, valid_attributes) }
+    let!(:task) { create(:task, valid_attributes.merge(user:)) }
     let(:valid_attributes) do
       {
-        user:,
         title: 'title',
-        license: create(:license, name: 'old_license'),
-        labels: [existing_label],
+        license_id: create(:license, name: 'old_license').id,
+        label_names: [existing_label.name],
       }
     end
     let(:changed_attributes) do
@@ -471,9 +470,13 @@ RSpec.describe TasksController do
 
         let(:test) { build(:test) }
         let(:new_testing_framework) { create(:testing_framework) }
-        let!(:task) { create(:task, valid_attributes.merge(tests: [test])) }
+        let!(:task) { create(:task, valid_attributes.merge(tests: [test], user:)) }
 
-        let(:tests_attributes) { {'0': test.attributes.symbolize_keys.merge(title: 'new_test_title', testing_framework_id: new_testing_framework.id)} }
+        let(:tests_attributes) do
+          {'0': test.attributes.symbolize_keys
+            .except(:configuration, :created_at, :meta_data, :task_id, :updated_at)
+            .merge(title: 'new_test_title', testing_framework_id: new_testing_framework.id)}
+        end
 
         it 'updates the requested task' do
           expect { put_update }.to change { task.reload.title }.to('new_title')

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -3,6 +3,8 @@
 FactoryBot.define do
   factory :collection do
     title { 'Some Collection' }
+    description { 'Some Description' }
+    visibility_level { :private }
     users { build_list(:user, 1) }
     tasks { build_list(:task, 2) }
   end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Collections' do
     let(:user) { create(:user) }
     let(:task) { create(:task) }
     let(:collection) { create(:collection, title: 'Some Collection', users: [user], tasks: [task]) }
-    let(:collection_params) { attributes_for(:collection) }
+    let(:collection_params) { build(:collection).attributes.except('id', 'created_at', 'updated_at') }
 
     before do
       sign_in user

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Groups' do
   context 'when logged in' do
     let(:user) { create(:user) }
     let(:group) { create(:group) }
-    let(:group_params) { attributes_for(:group) }
+    let(:group_params) { build(:group).attributes.except('id', 'created_at', 'updated_at') }
 
     before do
       group.add(user, role: :admin)

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Tasks' do
     let(:valid_params) do
       {
         title: 'title',
-        descriptions_attributes: {'0' => {text: 'description', primary: true}},
-        programming_language: create(:programming_language, :ruby).id,
+        description: 'description',
+        programming_language_id: create(:programming_language, :ruby).id,
         license_id: create(:license).id,
         language: 'de',
       }
@@ -19,8 +19,8 @@ RSpec.describe 'Tasks' do
     let(:update_params) do
       {
         title: 'new_title',
-        descriptions_attributes: {'0' => {text: 'description'}},
-        programming_language: create(:programming_language, :ruby).id,
+        description: 'description',
+        programming_language_id: create(:programming_language, :ruby).id,
         license_id: create(:license).id,
       }
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Users' do
   end
 
   context 'when logged in' do
-    let(:user_params) { attributes_for(:user, current_password: user.password) }
+    let(:user_params) { attributes_for(:user, current_password: user.password).except(:confirmed_at) }
 
     before do
       sign_in user

--- a/spec/support/shared_examples/standard_examples.rb
+++ b/spec/support/shared_examples/standard_examples.rb
@@ -20,7 +20,7 @@ end
 
 RSpec.shared_examples 'edit examples' do |klass:, resource:|
   it "assigns the requested #{resource} as @#{resource}" do
-    object = klass.create! valid_attributes
+    object = klass.create! valid_attributes.merge(user:)
     get :edit, params: empty_params.merge(id: object.to_param)
     expect(assigns(resource)).to eq(object)
   end
@@ -70,7 +70,7 @@ end
 RSpec.shared_examples 'update examples' do |klass:, resource:|
   context 'with valid params' do
     it "assigns the requested #{resource} as @#{resource}" do
-      object = klass.create! valid_attributes
+      object = klass.create! valid_attributes.merge(user:)
       put :update, params: empty_params.merge(:id => object.to_param, resource => valid_attributes)
       expect(assigns(resource)).to eq(object)
     end
@@ -78,13 +78,13 @@ RSpec.shared_examples 'update examples' do |klass:, resource:|
 
   context 'with invalid params' do
     it "assigns the #{resource} as @#{resource}" do
-      object = klass.create! valid_attributes
+      object = klass.create! valid_attributes.merge(user:)
       put :update, params: empty_params.merge(:id => object.to_param, resource => invalid_attributes)
       expect(assigns(resource)).to eq(object)
     end
 
     it "re-renders the 'edit' template" do
-      object = klass.create! valid_attributes
+      object = klass.create! valid_attributes.merge(user:)
       put :update, params: empty_params.merge(:id => object.to_param, resource => invalid_attributes)
       expect(response).to render_template('edit')
     end
@@ -93,7 +93,7 @@ end
 
 RSpec.shared_examples 'destroy examples' do |klass:, resource:|
   it "destroys the requested #{resource}" do
-    object = klass.create! valid_attributes
+    object = klass.create! valid_attributes.merge(user:)
     expect do
       delete :destroy, params: empty_params.merge(id: object.to_param)
     end.to change(klass, :count).by(-1)


### PR DESCRIPTION
So far, we had a few tests (and production-used code) that would log unpermitted parameters. This PR therefore addresses this issue by ensuring we are not sending unpermitted parameters during regular use. Furthermore, it raises if any unpermitted parameter is detected in development or test to make everyone aware.

This PR depends on the following two PRs to be merged first:
- #1555
- #1606 

Only when those two PRs are merged, the tests in this branch will pass. Nevertheless, reviewing is already possible, @Dome-GER 😉