### PR TITLE
Fix source map generation with Webpack

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -102,6 +102,12 @@ if (webpackConfig.mode === 'development') {
     envConfig.devtool = 'source-map';
 }
 
+// Enable source map for SASS / SCSS files, including the original sources in the source map.
+webpackConfig.module.rules
+  .flatMap(rule => Array.isArray(rule.use) ? rule.use : [])
+  .filter(loaderConfig => loaderConfig.options?.sassOptions)
+  .forEach(loaderConfig => loaderConfig.options.sassOptions.sourceMapIncludeSources = true);
+
 // Use the following lines below to remove original plugins and replace them with our custom config.
 // This is especially needed for the `WebpackAssetsManifest` plugin, which would otherwise run twice.
 const customPlugins = envConfig.plugins.map((plugin) => plugin.constructor.name);

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -97,6 +97,11 @@ const envConfig = module.exports = {
     stats: 'minimal',
 }
 
+// Enable working source maps in development mode, overwriting the default 'cheap-module-source-map'.
+if (webpackConfig.mode === 'development') {
+    envConfig.devtool = 'source-map';
+}
+
 // Use the following lines below to remove original plugins and replace them with our custom config.
 // This is especially needed for the `WebpackAssetsManifest` plugin, which would otherwise run twice.
 const customPlugins = envConfig.plugins.map((plugin) => plugin.constructor.name);


### PR DESCRIPTION
There were two distinct issues with source maps generated by WebPakc that prevented them to be useful. Sprocket-generated source maps were not affected.

| Bug | Before | After |
|--------|--------|--------|
| JavaScript source maps were only available in production | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 21 50 35" src="https://github.com/user-attachments/assets/15c92170-ddb0-4f68-bacc-31e86d1b9f20"> | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 21 51 54" src="https://github.com/user-attachments/assets/b24918d9-9214-4222-9016-ae710d963f74"> |
| SASS / SCSS did not have proper source files at all | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 21 48 35" src="https://github.com/user-attachments/assets/a886442c-43a5-420b-843e-b7d84d319cc3"> | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 21 48 39" src="https://github.com/user-attachments/assets/97d73091-dceb-4fd1-82c9-4422ccb86707"> |