### PR TITLE
Allow moving ProFormA files between fileables

### DIFF
--- a/app/models/concerns/file_concern.rb
+++ b/app/models/concerns/file_concern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module FileConcern
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy, autosave: true, inverse_of: :fileable
+    accepts_nested_attributes_for :files, allow_destroy: true
+  end
+
+  def files
+    # We need to overwrite the `files` association method to allow moving files between the polymorphic associations.
+    # In the default case, a moved file would still be associated with the old record until saved (despite a correct inverse relationship).
+    # Therefore, we need to filter the files by the fileable type and only return those are belong to the current record.
+    # To minimize the impact and still allow method chaining, we filter only files if the association is already loaded.
+    # See https://github.com/openHPI/codeharbor/pull/1606 for more details.
+    return super unless association(:files).loaded?
+
+    association(:files).reader.records.filter {|file| file.fileable == self }
+  end
+end

--- a/app/models/model_solution.rb
+++ b/app/models/model_solution.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class ModelSolution < ApplicationRecord
-  belongs_to :task
-  has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy
-  accepts_nested_attributes_for :files, allow_destroy: true
+  include FileConcern
+  belongs_to :task, autosave: true, inverse_of: :model_solutions
   validates :xml_id, presence: true
   validates :xml_id, uniqueness: {scope: :task_id}
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@
 require 'nokogiri'
 require 'zip'
 class Task < ApplicationRecord
+  include FileConcern
   acts_as_taggable_on :state
 
   before_validation :lowercase_language
@@ -15,16 +16,14 @@ class Task < ApplicationRecord
   validates :language, format: {with: /\A[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*\z/, message: :not_de_or_us}
   validate :primary_language_tag_in_iso639?
 
-  has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy
-
   has_many :group_tasks, dependent: :destroy
   has_many :groups, through: :group_tasks
 
   has_many :task_labels, dependent: :destroy
   has_many :labels, through: :task_labels
 
-  has_many :tests, dependent: :destroy
-  has_many :model_solutions, dependent: :destroy
+  has_many :tests, dependent: :destroy, inverse_of: :task
+  has_many :model_solutions, dependent: :destroy, inverse_of: :task
 
   has_many :collection_tasks, dependent: :destroy
   has_many :collections, through: :collection_tasks
@@ -36,7 +35,6 @@ class Task < ApplicationRecord
   belongs_to :programming_language, optional: true
   belongs_to :license, optional: true
 
-  accepts_nested_attributes_for :files, allow_destroy: true
   accepts_nested_attributes_for :tests, allow_destroy: true
   accepts_nested_attributes_for :model_solutions, allow_destroy: true
   accepts_nested_attributes_for :group_tasks, allow_destroy: true

--- a/app/models/task_file.rb
+++ b/app/models/task_file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TaskFile < ApplicationRecord
-  belongs_to :fileable, polymorphic: true
+  belongs_to :fileable, polymorphic: true, autosave: true, inverse_of: :files
 
   has_one_attached :attachment
   validates :name, presence: true

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class Test < ApplicationRecord
-  belongs_to :task
+  include FileConcern
+  belongs_to :task, autosave: true, inverse_of: :tests
   belongs_to :testing_framework, optional: true
-  has_many :files, as: :fileable, class_name: 'TaskFile', dependent: :destroy
-  accepts_nested_attributes_for :files, allow_destroy: true
   validates :title, presence: true
   validates :xml_id, presence: true
   validates :xml_id, uniqueness: {scope: :task_id}

--- a/app/views/tasks/_nested_file_form.html.slim
+++ b/app/views/tasks/_nested_file_form.html.slim
@@ -1,5 +1,5 @@
 .field-element
-  = f.nested_fields_for :files do |file|
+  = f.nested_fields_for :files, class_name: TaskFile do |file|
     .show-table.exercise-show
       - if file.object.new_record?
         - display_container_class = '' # rubocop:disable Lint/UselessAssignment

--- a/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_proforma_task_to_task_spec.rb
@@ -605,6 +605,50 @@ RSpec.describe ProformaService::ConvertProformaTaskToTask do
         )
       end
 
+      context 'when files have been deleted' do
+        context 'when task files have been deleted' do
+          before { task.files = [] }
+
+          it 'imports task files correctly' do
+            expect(convert_to_task_service.files).to be_empty
+          end
+
+          it 'saves the task correctly' do
+            convert_to_task_service.save
+            task.reload
+            expect(task.files).to be_empty
+          end
+        end
+
+        context 'when test files have been deleted' do
+          before { task.tests.first.files = [] }
+
+          it 'imports test files correctly' do
+            expect(convert_to_task_service.tests.first.files).to be_empty
+          end
+
+          it 'saves the task correctly' do
+            convert_to_task_service.save
+            task.reload
+            expect(task.tests.first.files).to be_empty
+          end
+        end
+
+        context 'when model solution files have been deleted' do
+          before { task.model_solutions.first.files = [] }
+
+          it 'imports model solution files correctly' do
+            expect(convert_to_task_service.model_solutions.first.files).to be_empty
+          end
+
+          it 'saves the task correctly' do
+            convert_to_task_service.save
+            task.reload
+            expect(task.model_solutions.first.files).to be_empty
+          end
+        end
+      end
+
       context 'when files have been move around' do
         before do
           task_file = proforma_task.files.first


### PR DESCRIPTION
We recently discovered an edge case where a moved file was not updated correctly. At first, it got removed and recreated, and later on only removed. While these changes look pretty difficult, they are the best and only working approach I could find to fix the problem ;). For now, I'd suggest to go with this solution. See #1606 for more details.