### PR TITLE
Add Solid Cable adapter for ActionCable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'sassc-rails'
 gem 'shakapacker', '8.0.2'
 gem 'simple_form'
 gem 'slim-rails'
+gem 'solid_cable'
 gem 'solid_queue'
 gem 'sprockets-rails'
 gem 'terser', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,6 +528,8 @@ GEM
       rexml (~> 3.2)
       rubocop (>= 1.0, < 2.0)
       slim (>= 3.0, < 6.0)
+    solid_cable (2.0.2)
+      rails (>= 7.2)
     solid_queue (0.9.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
@@ -668,6 +670,7 @@ DEPENDENCIES
   simplecov
   slim-rails
   slim_lint
+  solid_cable
   solid_queue
   sprockets-rails
   stackprof

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,11 +1,24 @@
+default: &default
+  adapter: solid_cable # OR postgresql OR redis
+
+  ### Config options for `solid_cable`
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
+  autotrim: true
+  silence_polling: true
+
+  ### Config options for `redis`
+  # url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  # channel_prefix: codeharbor_production
+
 development:
-  adapter: postgresql
+  <<: *default
 
 test:
   adapter: test
 
 production:
-  adapter: postgresql # redis
-  # all other options below are only used for redis
-  # url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  # channel_prefix: codeharbor_production
+  <<: *default

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -32,6 +32,10 @@ development:
   primary: &primary_development
     <<: *default
     database: codeharbor_development
+  cable:
+    <<: *primary_development
+    database: codeharbor_development_cable
+    migrations_paths: db/cable_migrate
   queue:
     <<: *primary_development
     database: codeharbor_development_queue
@@ -64,6 +68,10 @@ production:
   primary: &primary_production
     <<: *default
     database: codeharbor_production
+  cable:
+    <<: *primary_production
+    database: codeharbor_production_cable
+    migrations_paths: db/cable_migrate
   queue:
     <<: *primary_production
     database: codeharbor_production_queue

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.text "channel"
+    t.text "payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end


### PR DESCRIPTION
ActionCable got introduced with Rails 7.2 for CodeHarbor. Switching the adapter is not expected to make any noticeable difference and is in line with CodeOcean. The new Solid Cable adapter is also shipping with Rails 8 by default.