### PR TITLE
Explicitly remove file attachment if changed after validation failure

### DIFF
--- a/app/controllers/concerns/task_parameters.rb
+++ b/app/controllers/concerns/task_parameters.rb
@@ -20,7 +20,7 @@ module TaskParameters
   def task_params
     params.require(:task).permit(:title, :description, :internal_description, :parent_uuid, :language, :license_id,
       :programming_language_id, :access_level, files_attributes: file_params, tests_attributes: test_params,
-      model_solutions_attributes: model_solution_params, label_names: [])
+      model_solutions_attributes: model_solution_params, label_names: []).tap {|parameters| fix_nested_files_params(parameters) }
   end
 
   def group_tasks_params
@@ -29,5 +29,42 @@ module TaskParameters
 
   def import_confirm_params
     params.permit(:import_id, :subfile_id, :import_type)
+  end
+
+  def fix_nested_files_params(parameters)
+    # The task_params might contain incomplete attributes for files, which we must fix before using the parameters.
+    # Those file attributes can be attached directly to the task, to any of test or to any model solution.
+    # For each of the potential file attributes, we must check if the attachment attribute should present and re-add it if missing.
+    # This behavior is needed, since SimpleForm does not keep the (empty) attachment attribute if no file got attached by the user.
+    # Otherwise, an old file version would be linked to the task, test or model solution after a failed model validation.
+    # When this happens, the old file content is used alongside the name of the new file, which is confusing for the user.
+
+    # Fix file attributes directly linked to the task.
+    fix_attachment_params(parameters)
+
+    # Fix file attributes linked to tests. The tests are stored in a hash with the test number as the key.
+    parameters[:tests_attributes]&.each_value {|test_parameters| fix_attachment_params(test_parameters) }
+
+    # Fix file attributes linked to model solutions. The model solutions are stored in a hash with the model solution number as the key.
+    parameters[:model_solutions_attributes]&.each_value {|model_solution_parameters| fix_attachment_params(model_solution_parameters) }
+  end
+
+  def fix_attachment_params(parameters)
+    # Files are stored in a hash with the file number as the key.
+    parameters[:files_attributes]&.each_value do |file|
+      # Do not modify the given file attributes if an attachment key is already present.
+      # This is needed to keep the attachment if the user sent a file.
+      next unless file.key?(:attachment)
+      # Do not modify the given file attributes if the parent_blob_id is present.
+      # This ensures that an attachment is kept even if the user did not send a file.
+      # For example, a file has been stored previously and the user only wants to update unrelated attributes.
+      # As soon as the user chose a file manually and validations fail, the parent_blob_id is left empty.
+      # Then, on a second try, the (updated) file is no longer linked to the previous file version.
+      next if file[:parent_blob_id].blank?
+
+      # If none of the above conditions is met, the user did not send a file despite previously making changes.
+      # In this case, we must re-add the attachment attribute and set it to `nil` to indicate the missing file.
+      file[:attachment] = nil
+    end
   end
 end


### PR DESCRIPTION
We recently discovered an issue where an old attachment would be incorrectly linked to an updated file after validation errors occurred. Specifically, the reproduction scenario is as follows:

1. Create a new task with a native file attached that passes all validations.
2. Edit this task and introduce a validation error that is unrelated to the file. For example, remove the task's title or language.
3. Select another native file attachment for the already existing TaskFile.
4. Attempt to save the changes
5. As expected, a validation error regarding the change is shown (title, language). Furthermore, the upload field has been cleared, since the file attachment was changed and the newly selected file was not yet saved on the server.
6. Fix the validation error and (without re-selecting the file attachment) save the task again.
7. Now, the task was saved again, despite the "missing" file attachment. However, it was expected that another validation error regarding the missing file attachment is shown. Unfortunately, the existing TaskFile also gets updated with the name of the previously selected file name (new file name, old content).

During our investigation, we identified that the attachment param of TaskParameters#file_params was simply missing, despite `use_attached_file=true`. Consequentially, assigning the params as attributes to the task (and the task file respectively) did not modify the existing `attachment` relationship, so that the previously saved attachment was still "connected". With the commit at hand, we therefore set the `attachment` param to `nil` explicitly, when it is not yet present (indicating that no file was sent by the browser) and the `parent_blob_id` is not present either (indicating that the file attachment got touched in one of the previous attempts to save changes).


<hr>

I didn't add tests on my own, since @florian-str discovered the issue while working on tests for #1103, so that the changes will be covered there.

<hr>

Thanks @nenock for your valuable input on this issue! 