### PR TITLE
Use `deliver_later` to send emails

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -63,7 +63,7 @@ class GroupsController < ApplicationController
     @group.admins.each do |admin|
       send_message(admin, :group_request)
 
-      AccessRequestMailer.send_access_request(current_user, admin, @group).deliver_now
+      AccessRequestMailer.send_access_request(current_user, admin, @group).deliver_later
     end
     @group.add(current_user, role: :applicant)
     redirect_to groups_path

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe GroupsController do
+  include ActiveJob::TestHelper
   render_views
 
   let(:user) { create(:user, preferred_locale: user_locale) }
@@ -172,7 +173,7 @@ RSpec.describe GroupsController do
     end
 
     it 'sends mail in correct language for recipient' do
-      post_request
+      perform_enqueued_jobs { post_request }
       expect(ActionMailer::Base.deliveries.last.body.parts.first.body).to include(I18n.t('groups.access_request_mailer.message_line2', locale: admin_locale))
     end
   end


### PR DESCRIPTION
Now, we are only using `deliver_now` for login-based emails, such as password reset or confirmation emails.