### PR TITLE
Perform extended status group validation for NBP sign-up

### DIFF
--- a/app/controllers/users/nbp_wallet_controller.rb
+++ b/app/controllers/users/nbp_wallet_controller.rb
@@ -48,14 +48,7 @@ module Users
 
     private
 
-    def accept_and_create_user(relationship) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      if relationship.userdata[:status_group].blank?
-        abort_and_refresh(
-          relationship,
-          t('common.errors.model_not_created', model: User.model_name.human, errors: t('users.nbp_wallet.unrecognized_role'))
-        ) and return
-      end
-
+    def accept_and_create_user(relationship) # rubocop:disable Metrics/AbcSize
       user = User.new_from_omniauth(relationship.userdata, 'nbp', @provider_uid)
       user.identities << UserIdentity.new(omniauth_provider: 'enmeshed', provider_uid: relationship.peer)
       user.skip_confirmation_notification!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,11 @@ class User < ApplicationRecord
 
   # `Other` is a catch-all for any status that doesn't fit into the other categories and should be *last*.
   enum :status_group, {unknown: 0, learner: 2, educator: 3, other: 1}, default: :unknown, prefix: true
+  # When a user is created through the NBP wallet connection, we want to ensure a valid status group.
+  # We need to check with a string, because any symbol or integer otherwise used is automatically converted.
+  validates :status_group, inclusion: {in: %w[learner educator], message: :unrecognized_role}, on: :create, if: lambda {
+    identities.loaded? && identities.any? {|identity| identity.omniauth_provider == 'nbp' }
+  }
 
   # Called by Devise and overwritten for soft-deletion
   def destroy

--- a/config/locales/de/controllers/users.yml
+++ b/config/locales/de/controllers/users.yml
@@ -1,8 +1,6 @@
 ---
 de:
   users:
-    nbp_wallet:
-      unrecognized_role: Unbekannte Rolle. Bitte wählen Sie entweder "Lehrer:in" oder "Schüler:in" als Ihre Rolle.
     omniauth_callbacks:
       failure_deauthorize: 'Das Trennen von Ihrem %{kind}-Account war aufgrund des folgenden Grundes nicht möglich: "%{reason}".'
       failure_deauthorize_last_identity: Sie können sich nicht von Ihrem %{kind}-Account trennen, da dies Ihr letzter verbleibender Account ist. Bitte erstellen Sie ein Passwort, um sich in Zukunft anmelden zu können.

--- a/config/locales/de/models.yml
+++ b/config/locales/de/models.yml
@@ -129,6 +129,8 @@ de:
             avatar:
               not_an_image: muss ein Bild sein
               size_over_10_mb: Größe muss kleiner als 10MB sein
+            status_group:
+              unrecognized_role: ist unbekannt. Bitte wählen Sie entweder "Lehrer:in" oder "Schüler:in" als Ihre Rolle.
           invalid_api_key: Der API-Schlüssel in Ihrem Profil ist ungültig. Bitte fügen Sie den entsprechenden API-Schlüssel in Ihrem Profil hinzu, um die KI-Funktionen zu nutzen.
     models:
       account_link:

--- a/config/locales/en/controllers/users.yml
+++ b/config/locales/en/controllers/users.yml
@@ -1,8 +1,6 @@
 ---
 en:
   users:
-    nbp_wallet:
-      unrecognized_role: Unknown role. Please select either "Teacher" or "Student" as your role.
     omniauth_callbacks:
       failure_deauthorize: Could not remove authorization from %{kind} because "%{reason}".
       failure_deauthorize_last_identity: You cannot deauthorize your %{kind} account because it is your last remaining account. Please create a password to log in in the future.

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -129,6 +129,8 @@ en:
             avatar:
               not_an_image: needs to be an image
               size_over_10_mb: size needs to be less than 10MB
+            status_group:
+              unrecognized_role: is unknown. Please select either "Teacher" or "Student" as your role.
           invalid_api_key: The API key in your profile is invalid. Please add the appropriate API key in your profile to use the AI features.
     models:
       account_link:


### PR DESCRIPTION
For all users signing up through the NBP wallet, we want to validate their role. Only those registrations providing a specific role (learner / educator) should be allowed. Any other registrations should not be affected by this change.