### PR TITLE
Migrate .js.erb files to .js

### DIFF
--- a/app/assets/javascripts/labels.coffee
+++ b/app/assets/javascripts/labels.coffee
@@ -1,9 +1,12 @@
-max_label_length = <%= Label::MAX_LENGTH %>
+get_max_label_length = ->
+  if (this._max_label_length == undefined)
+    this._max_label_length = $('#label-settings').data('max-length');
+  return this._max_label_length;
 
 verify_label_name = (label_name) ->
   if label_name == ''
     return I18n.t('labels.javascripts.cannot_be_empty');
-  if label_name.length > max_label_length
+  if label_name.length > get_max_label_length()
     return I18n.t('labels.javascripts.too_long');
   return I18n.t('labels.javascripts.ok');
 
@@ -20,7 +23,7 @@ ready = ->
     tags: true
     multiple: true
     maximumSelectionLength: 10
-    maximumInputLength: max_label_length
+    maximumInputLength: get_max_label_length()
     closeOnSelect: false
     tokenSeparators: [',']
 

--- a/app/views/labels/index.html.slim
+++ b/app/views/labels/index.html.slim
@@ -17,6 +17,7 @@
     .col-md-5
       div
         .input-group
+          #label-settings.d-none data-max-length=Label::MAX_LENGTH
           = button_tag t('.merge'), type: 'button', id: 'merge-labels-button', disabled: true, class: 'btn btn-primary'
           input.form-control#merge-labels-input type='text' placeholder=t('.new_name')
 

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -82,6 +82,7 @@
                       = group.name
 
           .field-element
+            #label-settings.d-none data-max-length=Label::MAX_LENGTH
             = f.label :labels, Label.model_name.human(count: :many), class: 'form-label'
             = f.select :label_names, options_for_select(@task.labels.map {|l| [l.name, l.name, {label_color: l.color, label_font_color: l.font_color}] }, @task.labels.map(&:name)), {}, {class: 'labels-select2-tag form-control', multiple: 'multiple'}
 


### PR DESCRIPTION
We want to get rid of `.js.erb` files, and hence migrate them to regular JavaScript files. Required attributes are passed through data-attributes in the HTML.