### PR TITLE
Migrate mailers to use parametrized attributes

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -63,7 +63,7 @@ class GroupsController < ApplicationController
     @group.admins.each do |admin|
       send_message(admin, :group_request)
 
-      AccessRequestMailer.send_access_request(current_user, admin, @group).deliver_later
+      AccessRequestMailer.with(user: current_user, admin:, group: @group).send_access_request.deliver_later
     end
     @group.add(current_user, role: :applicant)
     redirect_to Group

--- a/app/controllers/task_contributions_controller.rb
+++ b/app/controllers/task_contributions_controller.rb
@@ -8,7 +8,7 @@ class TaskContributionsController < ApplicationController
 
   def approve_changes
     if @task.apply_contribution(@task_contribution)
-      TaskContributionMailer.send_approval_info(@task_contribution).deliver_later
+      TaskContributionMailer.with(task_contrib: @task_contribution).send_approval_info.deliver_later
       redirect_to @task, notice: t('.success')
     else
       redirect_to [@task, @task_contribution], alert: t('.error')
@@ -27,7 +27,7 @@ class TaskContributionsController < ApplicationController
   def reject_changes
     duplicate = @task_contribution.decouple
     if duplicate
-      TaskContributionMailer.send_rejection_info(@task_contribution, duplicate).deliver_later
+      TaskContributionMailer.with(task_contrib: @task_contribution, duplicate:).send_rejection_info.deliver_later
       redirect_to @task, notice: t('.success')
     else
       redirect_to [@task, @task_contribution], alert: t('.error')
@@ -78,7 +78,7 @@ class TaskContributionsController < ApplicationController
     authorize @task_contribution
 
     if @task_contribution.save(context: :force_validations)
-      TaskContributionMailer.send_contribution_request(@task_contribution).deliver_later
+      TaskContributionMailer.with(task_contrib: @task_contribution).send_contribution_request.deliver_later
       redirect_to [@task, @task_contribution], notice: t('common.notices.object_created', model: TaskContribution.model_name.human)
     else
       @task = @task_contribution.suggestion

--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class AccessRequestMailer < ApplicationMailer
-  def send_access_request(user, admin, group)
-    @user = user
-    @admin = admin
-    @group = group
+  def send_access_request
+    @user = params.fetch(:user)
+    @admin = params.fetch(:admin)
+    @group = params.fetch(:group)
+
     I18n.with_locale(@admin.preferred_locale || I18n.default_locale) do
       mail(to: @admin.email, subject: t('groups.access_request_mailer.subject', user: @user.name, group: @group.name))
     end

--- a/app/mailers/task_contribution_mailer.rb
+++ b/app/mailers/task_contribution_mailer.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class TaskContributionMailer < ApplicationMailer
-  def send_contribution_request(task_contrib)
-    @task_author = task_contrib.base.user
-    @task_contrib = task_contrib
-    @contrib_author = task_contrib.suggestion.user
+  def send_contribution_request
+    @task_contrib = params.fetch(:task_contrib)
+    @task_author = @task_contrib.base.user
+    @contrib_author = @task_contrib.suggestion.user
+
     I18n.with_locale(@task_author.preferred_locale || I18n.default_locale) do
       mail(to: @task_author.email,
         subject: t('task_contributions.mailer.contribution_request.subject_message', contrib_author: @contrib_author,
@@ -12,19 +13,21 @@ class TaskContributionMailer < ApplicationMailer
     end
   end
 
-  def send_approval_info(task_contrib)
-    @task_contrib = task_contrib
-    @contrib_author = task_contrib.suggestion.user
+  def send_approval_info
+    @task_contrib = params.fetch(:task_contrib)
+    @contrib_author = @task_contrib.suggestion.user
+
     I18n.with_locale(@contrib_author.preferred_locale || I18n.default_locale) do
       mail(to: @contrib_author.email,
         subject: t('task_contributions.mailer.approval_info.subject_message', task: @task_contrib.base.title))
     end
   end
 
-  def send_rejection_info(task_contrib, duplicate)
-    @task_contrib = task_contrib
-    @contrib_author = task_contrib.suggestion.user
-    @duplicate = duplicate
+  def send_rejection_info
+    @task_contrib = params.fetch(:task_contrib)
+    @contrib_author = @task_contrib.suggestion.user
+    @duplicate = params.fetch(:duplicate)
+
     I18n.with_locale(@contrib_author.preferred_locale || I18n.default_locale) do
       mail(to: @contrib_author.email,
         subject: t('task_contributions.mailer.rejection_info.subject_message', task: @task_contrib.base.title))

--- a/spec/mailers/previews/access_request_mailer_preview.rb
+++ b/spec/mailers/previews/access_request_mailer_preview.rb
@@ -7,6 +7,6 @@ class AccessRequestMailerPreview < ActionMailer::Preview
     group = FactoryBot.build(:group, id: 1)
     admin = group.group_memberships.find(&:role_admin?).user
     user = FactoryBot.build(:user)
-    AccessRequestMailer.send_access_request(user, admin, group)
+    AccessRequestMailer.with(user:, admin:, group:).send_access_request
   end
 end

--- a/spec/mailers/previews/task_contribution_mailer_preview.rb
+++ b/spec/mailers/previews/task_contribution_mailer_preview.rb
@@ -6,19 +6,19 @@ class TaskContributionMailerPreview < ActionMailer::Preview
   def send_contribution_request
     base = FactoryBot.build(:task, id: 1)
     task_contribution = FactoryBot.build(:task_contribution, base:, id: 2)
-    TaskContributionMailer.send_contribution_request(task_contribution)
+    TaskContributionMailer.with(task_contrib: task_contribution).send_contribution_request
   end
 
   def send_approval_info
     base = FactoryBot.build(:task, id: 1)
     task_contribution = FactoryBot.build(:task_contribution, base:, id: 2)
-    TaskContributionMailer.send_approval_info(task_contribution)
+    TaskContributionMailer.wtih(task_contrib: task_contribution).send_approval_info
   end
 
   def send_rejection_info
     base = FactoryBot.build(:task, id: 1)
     duplicate = FactoryBot.build(:task, parent: base, id: 3)
     task_contribution = FactoryBot.build(:task_contribution, base:, id: 2)
-    TaskContributionMailer.send_rejection_info(task_contribution, duplicate)
+    TaskContributionMailer.with(task_contrib: task_contribution, duplicate:).send_rejection_info
   end
 end

--- a/spec/mailers/task_contribution_mailer_spec.rb
+++ b/spec/mailers/task_contribution_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TaskContributionMailer do
   let(:task_contrib) { create(:task_contribution) }
 
   describe '#contribution_request' do
-    subject(:contribution_request) { described_class.send_contribution_request(task_contrib) }
+    subject(:contribution_request) { described_class.with(task_contrib:).send_contribution_request }
 
     it 'sends an email' do
       expect(contribution_request.to).to include(task_contrib.base.user.email)
@@ -23,7 +23,7 @@ RSpec.describe TaskContributionMailer do
   end
 
   describe '#approval_info' do
-    subject(:approval_info) { described_class.send_approval_info(task_contrib) }
+    subject(:approval_info) { described_class.with(task_contrib:).send_approval_info }
 
     it 'sends an email' do
       expect(approval_info.to).to include(task_contrib.suggestion.user.email)
@@ -37,7 +37,7 @@ RSpec.describe TaskContributionMailer do
   end
 
   describe '#rejection_info' do
-    subject(:rejection_info) { described_class.send_rejection_info(task_contrib, duplicate_task) }
+    subject(:rejection_info) { described_class.with(task_contrib:, duplicate: duplicate_task).send_rejection_info }
 
     let(:duplicate_task) { create(:task) }
 


### PR DESCRIPTION
Related to [CodeOcean #2959](https://github.com/openHPI/codeocean/issues/2959), we migrate all mailers to use parameterized attributes, since this should work better with testing.