### PR TITLE
chore: Enable Rubocop for migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ inherit_from:
 AllCops:
   UseCache: True
   NewCops: enable
+  MigratedSchemaVersion: 20240924144745
   Exclude:
     - 'bin/*'
     - 'db/*schema.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,17 +5,6 @@
 Layout/LineLength:
   Max: 140
 
-# We don't want to change previous migrations...
-#
-Rails/CreateTableWithTimestamps:
-  Enabled: false
-
-Rails/BulkChangeTable:
-  Enabled: false
-
-Rails/ThreeStateBooleanColumn:
-  Enabled: false
-
 # The models need to be fixed anyway
 #
 Rails/UniqueValidationWithoutIndex:


### PR DESCRIPTION
Rubocop gives valuable information about issues in migration. New migrations should be checked by the linter.