### PR TITLE
handle duplicated files on export

### DIFF
--- a/app/services/proforma_service/convert_task_to_proforma_task.rb
+++ b/app/services/proforma_service/convert_task_to_proforma_task.rb
@@ -6,6 +6,7 @@ module ProformaService
       super()
       @task = task
       @options = options
+      @all_files = []
     end
 
     def execute
@@ -78,6 +79,21 @@ module ProformaService
       end
     end
 
+    def task_files_equal?(task_file, other)
+      task_file.filename == other.filename &&
+        task_file.used_by_grader == other.used_by_grader &&
+        task_file.visible == other.visible &&
+        task_file.usage_by_lms == other.usage_by_lms &&
+        task_file.internal_description == other.internal_description &&
+        task_content_equal?(task_file, other)
+    end
+
+    def task_content_equal?(task_file, other)
+      task_file.content == other.content &&
+        task_file.binary == other.binary &&
+        task_file.mimetype == other.mimetype
+    end
+
     def task_file(file)
       task_file = ProformaXML::TaskFile.new(
         id: file.xml_id,
@@ -88,6 +104,11 @@ module ProformaService
         internal_description: file.internal_description
       )
       add_content_to_task_file(file, task_file)
+
+      original_file = @all_files.find {|f| task_files_equal?(f, task_file) }
+      return original_file if original_file
+
+      @all_files << task_file
       task_file
     end
 

--- a/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
+++ b/spec/services/proforma_service/convert_task_to_proforma_task_spec.rb
@@ -273,6 +273,25 @@ RSpec.describe ProformaService::ConvertTaskToProformaTask do
       it 'creates a task with two tests' do
         expect(proforma_task.tests).to have(2).items
       end
+
+      context 'with different files' do
+        let(:tests) do
+          [build(:test, files: build_list(:task_file, 1, content: 'file1')),
+           build(:test, files: build_list(:task_file, 1, content: 'file2'))]
+        end
+
+        it 'creates a task with two files' do
+          expect(proforma_task.all_files).to have(2).items
+        end
+      end
+
+      context 'with equal files used in both tests' do
+        let(:tests) { build_list(:test, 2, files: build_list(:task_file, 1)) }
+
+        it 'creates a task with one file' do
+          expect(proforma_task.all_files).to have(1).items
+        end
+      end
     end
 
     context 'when exercise has description formatted in markdown' do


### PR DESCRIPTION
handles duplicated files (primarily imported task with multi referenced file) during the export to avoid the duplication on export